### PR TITLE
backup/restore: atomic backup staging + symlink dereference (cou-29)

### DIFF
--- a/backup
+++ b/backup
@@ -19,12 +19,25 @@ BACKUP_DIR="$HOME/.counsel-os/backups"
 LEGACY_BACKUP_DIR="$COUNSEL_DIR/backups"
 TIMESTAMP="$(date +%Y-%m-%d-%H%M%S)"
 BACKUP_PATH="$BACKUP_DIR/$TIMESTAMP"
-if [ -e "$BACKUP_PATH" ]; then
+if [ -e "$BACKUP_PATH" ] || [ -e "$BACKUP_PATH.partial" ]; then
   n=2
-  while [ -e "$BACKUP_PATH-$n" ]; do n=$((n + 1)); done
+  while [ -e "$BACKUP_PATH-$n" ] || [ -e "$BACKUP_PATH-$n.partial" ]; do n=$((n + 1)); done
   BACKUP_PATH="$BACKUP_PATH-$n"
 fi
-PAYLOAD_PATH="$BACKUP_PATH/root"
+
+# The backup is staged under a .partial name and renamed to its final name
+# only after every file AND the manifest are written. An interrupted run
+# (disk full, iCloud placeholder that can't be materialized, ctrl-C) must
+# never leave a directory that ./restore could pick as the newest backup.
+STAGE_BACKUP_PATH="$BACKUP_PATH.partial"
+PAYLOAD_PATH="$STAGE_BACKUP_PATH/root"
+
+cleanup_stage() {
+  if [ -d "$STAGE_BACKUP_PATH" ]; then
+    rm -rf "$STAGE_BACKUP_PATH"
+  fi
+}
+trap cleanup_stage EXIT
 
 LEGAL_ROOT="$(bash "$COUNSEL_DIR/scripts/resolve_legal_root.sh" || true)"
 
@@ -62,8 +75,9 @@ if [ -d "$LEGACY_BACKUP_DIR" ]; then
 fi
 
 # Anything beyond config.md worth backing up? (Skip .git and leftover
-# restore work directories.)
-content_probe="$(cd "$LEGAL_ROOT" && find . -name .git -prune -o -name '.counsel-os-restore.*' -prune -o -type f ! -name '.gitkeep' -print 2>/dev/null | grep -v '^\./config\.md$' | head -1 || true)"
+# restore work directories.) -L so content that lives behind a symlinked
+# subdirectory counts — it gets dereferenced into the backup below.
+content_probe="$(cd "$LEGAL_ROOT" && find -L . -name .git -prune -o -name '.counsel-os-restore.*' -prune -o -type f ! -name '.gitkeep' -print 2>/dev/null | grep -v '^\./config\.md$' | head -1 || true)"
 
 if [ -z "$content_probe" ]; then
   echo "Nothing to back up. Run /counsel-os:setup first."
@@ -76,6 +90,9 @@ mkdir -p "$PAYLOAD_PATH"
 # path overrides (matters_path, entities_path) and any other vault content
 # are captured, not just a hardcoded list of default subdirectories.
 # Excluded: .git (use git's own tooling for that) and restore work dirs.
+# Symlinks are dereferenced (cp -RL): a vault entry like
+# matters -> /Volumes/Shared/matters must back up the CONTENT, not a link
+# that dangles when restored on another machine.
 shopt -s dotglob
 for entry in "$LEGAL_ROOT"/*; do
   [ -e "$entry" ] || [ -L "$entry" ] || continue
@@ -83,20 +100,26 @@ for entry in "$LEGAL_ROOT"/*; do
   case "$name" in
     .git|.counsel-os-restore.*) continue ;;
   esac
-  cp -R "$entry" "$PAYLOAD_PATH/$name"
+  if [ -L "$entry" ]; then
+    if [ ! -e "$entry" ]; then
+      echo "Warning: skipping dangling symlink: $name -> $(readlink "$entry")" >&2
+      continue
+    fi
+    echo "  note: $name is a symlink to $(readlink "$entry"); backing up its contents"
+  fi
+  cp -RL "$entry" "$PAYLOAD_PATH/$name"
 done
 shopt -u dotglob
 
 if [ ! -f "$PAYLOAD_PATH/config.md" ]; then
   echo "Backup payload is missing config.md; aborting." >&2
-  rm -rf "$BACKUP_PATH"
   exit 1
 fi
 
 VERSION="$(cat "$COUNSEL_DIR/VERSION" 2>/dev/null || echo "unknown")"
 FILE_COUNT="$(find "$PAYLOAD_PATH" -type f ! -name '.gitkeep' | wc -l | tr -d ' ')"
 
-python3 - "$BACKUP_PATH/manifest.json" "$TIMESTAMP" "$VERSION" "$LEGAL_ROOT" "$FILE_COUNT" <<'PY'
+python3 - "$STAGE_BACKUP_PATH/manifest.json" "$TIMESTAMP" "$VERSION" "$LEGAL_ROOT" "$FILE_COUNT" <<'PY'
 import json
 import sys
 
@@ -113,6 +136,11 @@ with open(manifest_path, "w", encoding="utf-8") as f:
     json.dump(manifest, f, indent=2)
     f.write("\n")
 PY
+
+# Commit point: everything (payload + manifest) is on disk — take the final
+# name. Until this rename the directory is *.partial, which restore ignores.
+mv "$STAGE_BACKUP_PATH" "$BACKUP_PATH"
+PAYLOAD_PATH="$BACKUP_PATH/root"
 
 echo "Backup created: $BACKUP_PATH"
 echo "  source: $LEGAL_ROOT"

--- a/browse/src/backup-restore.test.ts
+++ b/browse/src/backup-restore.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const repoRoot = path.resolve(import.meta.dir, '../..');
+const backupScript = path.join(repoRoot, 'backup');
+const restoreScript = path.join(repoRoot, 'restore');
+
+const cleanups: Array<() => void> = [];
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()!();
+  }
+});
+
+function makeTempDir(prefix: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  cleanups.push(() => fs.rmSync(dir, { recursive: true, force: true }));
+  return dir;
+}
+
+function makeVault(dir: string): void {
+  fs.writeFileSync(
+    path.join(dir, 'config.md'),
+    `counsel-os-config: true\nlegal_root: ${dir}\n`,
+  );
+}
+
+function runScript(
+  script: string,
+  args: string[],
+  home: string,
+  vault: string,
+  stdin = '',
+) {
+  return spawnSync('bash', [script, ...args], {
+    cwd: home,
+    encoding: 'utf8',
+    input: stdin,
+    env: { ...process.env, HOME: home, COUNSEL_OS_LEGAL_ROOT: vault },
+  });
+}
+
+function backupsDir(home: string): string {
+  return path.join(home, '.counsel-os', 'backups');
+}
+
+function listBackups(home: string): string[] {
+  const dir = backupsDir(home);
+  if (!fs.existsSync(dir)) return [];
+  return fs.readdirSync(dir).sort();
+}
+
+function writeManifest(backupPath: string, files: number): void {
+  fs.writeFileSync(
+    path.join(backupPath, 'manifest.json'),
+    JSON.stringify(
+      {
+        format: 'full-root',
+        timestamp: path.basename(backupPath),
+        version: 'test',
+        source: '/tmp/somewhere',
+        files,
+      },
+      null,
+      2,
+    ) + '\n',
+  );
+}
+
+function makeHandBuiltBackup(
+  home: string,
+  name: string,
+  payloadFiles: Record<string, string>,
+  manifestFiles: number | null,
+): string {
+  const backupPath = path.join(backupsDir(home), name);
+  for (const [rel, content] of Object.entries(payloadFiles)) {
+    const target = path.join(backupPath, 'root', rel);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  if (manifestFiles !== null) {
+    writeManifest(backupPath, manifestFiles);
+  }
+  return backupPath;
+}
+
+const markedConfig = 'counsel-os-config: true\nlegal_root: /tmp/original\n';
+
+describe('backup', () => {
+  test('completes atomically: final dir has a manifest and no .partial is left', () => {
+    const home = makeTempDir('counsel-backup-home-');
+    const vault = makeTempDir('counsel-backup-vault-');
+    makeVault(vault);
+    fs.mkdirSync(path.join(vault, 'matters'));
+    fs.writeFileSync(path.join(vault, 'matters', 'a.md'), 'matter a\n');
+
+    const result = runScript(backupScript, [], home, vault);
+    expect(result.status).toBe(0);
+
+    const backups = listBackups(home);
+    expect(backups.length).toBe(1);
+    const name = backups[0]!;
+    expect(name).not.toEndWith('.partial');
+
+    const backupPath = path.join(backupsDir(home), name);
+    expect(fs.existsSync(path.join(backupPath, 'manifest.json'))).toBe(true);
+    expect(fs.existsSync(path.join(backupPath, 'root', 'config.md'))).toBe(true);
+    expect(
+      fs.readFileSync(path.join(backupPath, 'root', 'matters', 'a.md'), 'utf8'),
+    ).toBe('matter a\n');
+  });
+
+  test('dereferences symlinked vault dirs instead of saving bare links', () => {
+    const home = makeTempDir('counsel-backup-home-');
+    const vault = makeTempDir('counsel-backup-vault-');
+    const shared = makeTempDir('counsel-backup-shared-');
+    makeVault(vault);
+    fs.writeFileSync(path.join(shared, 'nda.md'), 'shared matter content\n');
+    fs.symlinkSync(shared, path.join(vault, 'matters'));
+
+    const result = runScript(backupScript, [], home, vault);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('matters is a symlink');
+
+    const backups = listBackups(home);
+    expect(backups.length).toBe(1);
+    const copied = path.join(backupsDir(home), backups[0]!, 'root', 'matters');
+    expect(fs.lstatSync(copied).isSymbolicLink()).toBe(false);
+    expect(fs.lstatSync(copied).isDirectory()).toBe(true);
+    expect(fs.readFileSync(path.join(copied, 'nda.md'), 'utf8')).toBe(
+      'shared matter content\n',
+    );
+  });
+
+  test('a failed copy leaves NO directory that restore could pick up', () => {
+    const home = makeTempDir('counsel-backup-home-');
+    const vault = makeTempDir('counsel-backup-vault-');
+    makeVault(vault);
+    fs.mkdirSync(path.join(vault, 'matters'));
+    fs.writeFileSync(path.join(vault, 'matters', 'a.md'), 'matter a\n');
+    // An unreadable directory sorted last in the glob makes cp fail AFTER
+    // config.md and matters/ were already copied — the exact shape of a
+    // partial backup that used to pass restore's config.md-only check.
+    const locked = path.join(vault, 'zz-locked');
+    fs.mkdirSync(locked);
+    fs.writeFileSync(path.join(locked, 'secret.md'), 'x\n');
+    fs.chmodSync(locked, 0o000);
+    cleanups.push(() => fs.chmodSync(locked, 0o755));
+
+    const result = runScript(backupScript, [], home, vault);
+    expect(result.status).not.toBe(0);
+
+    // The staged .partial dir must be cleaned up: nothing in the backups
+    // dir means nothing for restore's newest-backup pick to find.
+    expect(listBackups(home)).toEqual([]);
+
+    const restore = runScript(restoreScript, [], home, vault);
+    expect(restore.status).not.toBe(0);
+    expect(restore.stdout + restore.stderr).toContain('No backups found');
+  });
+});
+
+describe('restore backup selection', () => {
+  test('prefers the newest COMPLETE backup over a newer manifest-less one', () => {
+    const home = makeTempDir('counsel-restore-home-');
+    const vault = makeTempDir('counsel-restore-vault-');
+    makeVault(vault);
+
+    // Older, complete backup: manifest present, count matches (2 files).
+    makeHandBuiltBackup(
+      home,
+      '2026-01-01-000000',
+      { 'config.md': markedConfig, 'matters/good.md': 'from complete backup\n' },
+      2,
+    );
+    // Newer directory that looks like an interrupted backup: config.md
+    // made it, matters/ did not, no manifest. Before the fix this was the
+    // auto-picked restore candidate.
+    const partial = makeHandBuiltBackup(
+      home,
+      '2026-01-02-000000',
+      { 'config.md': markedConfig },
+      null,
+    );
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(partial, future, future);
+
+    const result = runScript(restoreScript, [], home, vault);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('2026-01-01-000000');
+    expect(
+      fs.readFileSync(path.join(vault, 'matters', 'good.md'), 'utf8'),
+    ).toBe('from complete backup\n');
+  });
+
+  test('never auto-picks a .partial staging directory', () => {
+    const home = makeTempDir('counsel-restore-home-');
+    const vault = makeTempDir('counsel-restore-vault-');
+    makeVault(vault);
+
+    makeHandBuiltBackup(
+      home,
+      '2026-01-03-000000.partial',
+      { 'config.md': markedConfig, 'matters/bad.md': 'from partial\n' },
+      2,
+    );
+
+    const result = runScript(restoreScript, [], home, vault);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout + result.stderr).toContain('No backups found');
+  });
+
+  test('refuses a truncated backup (manifest count mismatch) unless confirmed', () => {
+    const home = makeTempDir('counsel-restore-home-');
+    const vault = makeTempDir('counsel-restore-vault-');
+    makeVault(vault);
+    fs.mkdirSync(path.join(vault, 'matters'));
+    fs.writeFileSync(path.join(vault, 'matters', 'live.md'), 'live content\n');
+
+    // Manifest says 5 files; only config.md is actually there.
+    makeHandBuiltBackup(
+      home,
+      '2026-01-01-000000',
+      { 'config.md': markedConfig },
+      5,
+    );
+
+    const result = runScript(
+      restoreScript,
+      ['2026-01-01-000000'],
+      home,
+      vault,
+      'n\n',
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('INCOMPLETE');
+    expect(result.stdout).toContain('Restore cancelled');
+    expect(
+      fs.readFileSync(path.join(vault, 'matters', 'live.md'), 'utf8'),
+    ).toBe('live content\n');
+  });
+
+  test('warns on an explicitly named manifest-less full-root backup', () => {
+    const home = makeTempDir('counsel-restore-home-');
+    const vault = makeTempDir('counsel-restore-vault-');
+    makeVault(vault);
+    fs.mkdirSync(path.join(vault, 'matters'));
+    fs.writeFileSync(path.join(vault, 'matters', 'live.md'), 'live content\n');
+
+    makeHandBuiltBackup(
+      home,
+      '2026-01-01-000000',
+      { 'config.md': markedConfig },
+      null,
+    );
+
+    const result = runScript(
+      restoreScript,
+      ['2026-01-01-000000'],
+      home,
+      vault,
+      'n\n',
+    );
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('no manifest.json');
+    expect(result.stdout).toContain('Restore cancelled');
+    expect(
+      fs.readFileSync(path.join(vault, 'matters', 'live.md'), 'utf8'),
+    ).toBe('live content\n');
+  });
+});

--- a/restore
+++ b/restore
@@ -106,6 +106,12 @@ is_backup_dir() {
   [ -f "$1/root/config.md" ] || [ -f "$1/config.md" ]
 }
 
+# Pick the newest COMPLETE backup. ./backup writes the manifest last (and
+# stages under *.partial before the final rename), so a full-root directory
+# without manifest.json is an interrupted copy — auto-picking it would
+# silently restore a truncated vault over live content. Legacy-layout
+# backups (config.md at top level) predate manifests and stay eligible as
+# a fallback when no manifest-bearing backup exists.
 newest_backup_in() {
   local base="$1"
   local candidate
@@ -114,7 +120,17 @@ newest_backup_in() {
 
   while IFS= read -r candidate; do
     candidate="${candidate%/}"
-    if is_backup_dir "$candidate"; then
+    case "$candidate" in *.partial) continue ;; esac
+    if [ -f "$candidate/manifest.json" ] && is_backup_dir "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done < <(ls -dt "$base"/*/ 2>/dev/null)
+
+  while IFS= read -r candidate; do
+    candidate="${candidate%/}"
+    case "$candidate" in *.partial) continue ;; esac
+    if [ ! -d "$candidate/root" ] && [ -f "$candidate/config.md" ]; then
       printf '%s\n' "$candidate"
       return 0
     fi
@@ -185,6 +201,31 @@ echo "Restoring to:   $LEGAL_ROOT"
 if [ -f "$BACKUP_PATH/manifest.json" ]; then
   echo "  backed up at version: $(grep -o '"version": "[^"]*"' "$BACKUP_PATH/manifest.json" | cut -d'"' -f4)"
   echo "  current version:      $(cat "$COUNSEL_DIR/VERSION" 2>/dev/null || echo "unknown")"
+fi
+
+# Sanity-check completeness BEFORE touching the legal root: an interrupted
+# copy can hold a valid config.md but a truncated payload. Explicitly-named
+# backups may still be restored after a confirmation (salvage), but never
+# silently.
+confirm_incomplete_backup() {
+  echo ""
+  echo "WARNING: $1"
+  echo "Restoring it would replace live content with an incomplete copy."
+  read -r -p "Restore it anyway? (y/N) " confirm
+  if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+    echo "Restore cancelled."
+    exit 0
+  fi
+}
+
+if [ -f "$BACKUP_PATH/manifest.json" ]; then
+  manifest_files="$(grep -o '"files":[[:space:]]*[0-9]*' "$BACKUP_PATH/manifest.json" | grep -o '[0-9]*$' || true)"
+  actual_files="$(find "$PAYLOAD_PATH" -type f ! -name '.gitkeep' ! -path "$BACKUP_PATH/manifest.json" | wc -l | tr -d ' ')"
+  if [ -n "$manifest_files" ] && [ "$manifest_files" != "$actual_files" ]; then
+    confirm_incomplete_backup "This backup looks INCOMPLETE: its manifest records $manifest_files files but $actual_files are present."
+  fi
+elif [ "$BACKUP_FORMAT" = "full-root" ]; then
+  confirm_incomplete_backup "This backup has no manifest.json — it is likely an interrupted (incomplete) backup."
 fi
 
 # Build the list of top-level items to restore. Never restore .git or


### PR DESCRIPTION
## What

Fixes two data-loss paths in the top-level `backup`/`restore` scripts (founder code review 2026-07-11, task cou-29).

### 1. Partial backup could become the newest restore candidate (CRITICAL)
`backup` built the directory under its final timestamped name with no failure handling: a mid-copy `cp` failure (disk full, unreadable iCloud placeholder, ctrl-C) left a directory with a valid `config.md` but truncated content. `restore` with no argument picks the newest directory whose `config.md` exists — exactly that one — then replaces the live vault and discards the rollback dir.

**Fix (atomic staging):**
- `backup` stages into `<name>.partial`, writes the manifest as the last step, then renames to the final name. An `EXIT` trap removes the stage dir on any failure.
- `restore`'s auto-pick skips `*.partial` dirs and requires `manifest.json` for full-root backups (manifest is written last, so its presence proves completeness). Legacy-layout backups (pre-manifest) stay eligible as a fallback.
- Restoring a backup whose manifest `files` count mismatches the actual payload — or an explicitly named manifest-less full-root backup — now requires an explicit y/N confirmation (salvage stays possible, silent data loss doesn't).

### 2. Symlinked vault subdirs were backed up as bare links
macOS `cp -R` doesn't follow symlinks: a vault entry like `matters -> /Volumes/Shared/matters` backed up only the link; the file count didn't flag it; restoring elsewhere yielded dangling links. Now `cp -RL` dereferences symlinks (with a note in the output), the anything-to-back-up probe uses `find -L`, and dangling symlinks are skipped with a loud warning.

`restore`'s existing stage → rollback → trap design is untouched, as the review asked.

## Testing

- New `browse/src/backup-restore.test.ts` (7 tests, runs in CI): atomic completion, symlink dereference, failed-copy-leaves-nothing, auto-pick prefers complete over newer manifest-less, `.partial` never picked, truncated-manifest confirmation, manifest-less explicit-restore confirmation.
- Full suite: 35 pass / 0 fail; typecheck clean; `bash -n` clean on both scripts.
- Manual end-to-end on stock macOS `/bin/bash` 3.2 (the scripts' floor): symlinked vault backs up real content, induced mid-copy failure leaves an empty backups dir, restore auto-picks the complete backup and restores correctly.

## What to verify (QA)

1. `bun test browse/src/backup-restore.test.ts` green on your machine.
2. Interrupted backup leaves no `*.partial` and no bogus newest candidate (test 3 covers it; reproducible manually with a `chmod 000` subdir).
3. A vault with a symlinked subdir round-trips: backup → restore yields real files.
4. Legacy backups (config.md at top level, no manifest) still restore — covered by the existing-format fallback; no fixture change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)