### PR TITLE
apply_redlines: occurrence numbers resolve against the original document (cou-26)

### DIFF
--- a/browse/src/apply-redlines.test.ts
+++ b/browse/src/apply-redlines.test.ts
@@ -87,3 +87,95 @@ finally:
     expect(output).toBe('');
   });
 });
+
+describe('apply_redlines.py occurrence snapshot semantics', () => {
+  redlineTest('occurrence numbers always refer to the original document', () => {
+    const repoRoot = path.resolve(import.meta.dir, '../..');
+    const script = String.raw`
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from docx import Document
+
+repo = Path(sys.argv[1])
+apply_redlines = repo / "scripts" / "apply_redlines.py"
+work = Path(tempfile.mkdtemp(prefix="counsel-redline-occ-test-"))
+
+def run_edits(original, edits, out):
+    edits_json = out.with_suffix(".json")
+    edits_json.write_text(json.dumps(edits))
+    return subprocess.run(
+        ["python3", str(apply_redlines), str(original), str(edits_json), str(out)],
+        text=True,
+        capture_output=True,
+    )
+
+try:
+    # A string repeated 3x across paragraphs, edited at occurrences 0/1/2.
+    # Before the snapshot fix, applying occurrence 0 renumbered the
+    # survivors, so occurrence 1 landed on what was originally occurrence 2.
+    original = work / "original.docx"
+    doc = Document()
+    doc.add_paragraph("Payment is due within 30 days of invoice.")
+    doc.add_paragraph("Cure period shall be 30 days from notice.")
+    doc.add_paragraph("Termination requires 30 days advance notice.")
+    doc.save(original)
+
+    run = run_edits(original, [
+        {"current": "30 days", "proposed": "45 days", "comment": None, "author": "Tester", "match": {"occurrence": 0}},
+        {"current": "30 days", "proposed": "60 days", "comment": None, "author": "Tester", "match": {"occurrence": 1}},
+        {"current": "30 days", "proposed": "90 days", "comment": None, "author": "Tester", "match": {"occurrence": 2}},
+    ], work / "across.docx")
+    assert run.returncode == 0, run.stderr + run.stdout
+    payload = json.loads(run.stdout)
+    assert [a["occurrence"] for a in payload["applied"]] == [0, 1, 2]
+    result = Document(work / "across.docx")
+    assert result.paragraphs[0].text == "Payment is due within 45 days of invoice."
+    assert result.paragraphs[1].text == "Cure period shall be 60 days from notice."
+    assert result.paragraphs[2].text == "Termination requires 90 days advance notice."
+
+    # All 3 occurrences in ONE paragraph with different-length replacements:
+    # exercises back-to-front application (earlier offsets stay valid).
+    original2 = work / "original2.docx"
+    doc2 = Document()
+    doc2.add_paragraph("Pay in 30 days, cure in 30 days, terminate on 30 days notice.")
+    doc2.save(original2)
+
+    run2 = run_edits(original2, [
+        {"current": "30 days", "proposed": "ten (10) days", "comment": None, "author": "Tester", "match": {"occurrence": 0}},
+        {"current": "30 days", "proposed": "sixty (60) days", "comment": None, "author": "Tester", "match": {"occurrence": 1}},
+        {"current": "30 days", "proposed": "ninety (90) days", "comment": None, "author": "Tester", "match": {"occurrence": 2}},
+    ], work / "within.docx")
+    assert run2.returncode == 0, run2.stderr + run2.stdout
+    result2 = Document(work / "within.docx")
+    assert result2.paragraphs[0].text == (
+        "Pay in ten (10) days, cure in sixty (60) days, terminate on ninety (90) days notice."
+    )
+
+    # Two items resolving to the SAME occurrence: the first wins, the second
+    # is skipped explicitly — never silently re-targeted to a survivor.
+    run3 = run_edits(original, [
+        {"current": "30 days", "proposed": "45 days", "comment": None, "author": "Tester", "match": {"occurrence": 0}},
+        {"current": "30 days", "proposed": "60 days", "comment": None, "author": "Tester", "match": {"occurrence": 0}},
+    ], work / "overlap.docx")
+    assert run3.returncode == 2, run3.stderr + run3.stdout
+    payload3 = json.loads(run3.stdout)
+    assert [a["index"] for a in payload3["applied"]] == [0]
+    assert payload3["skipped"][0]["index"] == 1
+    assert "overlaps" in payload3["skipped"][0]["reason"]
+    result3 = Document(work / "overlap.docx")
+    assert result3.paragraphs[0].text == "Payment is due within 45 days of invoice."
+    assert result3.paragraphs[1].text == "Cure period shall be 30 days from notice."
+    assert result3.paragraphs[2].text == "Termination requires 30 days advance notice."
+finally:
+    shutil.rmtree(work)
+`;
+
+    const output = execFileSync('python3', ['-c', script, repoRoot], { encoding: 'utf8' });
+    expect(output).toBe('');
+  });
+});

--- a/scripts/apply_redlines.py
+++ b/scripts/apply_redlines.py
@@ -22,6 +22,13 @@ The redlines.json file should contain an array of objects:
 If `current` appears more than once, the script refuses to apply that item
 unless `match` selects exactly one occurrence. Supported match selectors:
 `location`, `paragraph_index`, `occurrence`, `before`, `after`, and `context`.
+
+Every item is resolved against the ORIGINAL document, not the partially
+edited one: all targets are located before any replacement is made, so
+`occurrence` numbers and other selectors always mean what they meant in the
+document the redlines were drafted from. Consequently an item cannot target
+text introduced by an earlier item, and two items whose targets overlap
+result in the later item being skipped, never a silently misplaced edit.
 """
 
 import json
@@ -406,11 +413,12 @@ def main():
 
     results = {"applied": [], "skipped": [], "warnings": []}
 
+    # Phase 1: resolve every item against the pristine document, before any
+    # replacement mutates it. Occurrence numbers and offsets therefore always
+    # refer to the original text the redlines were drafted from.
+    resolved = []
     for i, item in enumerate(redlines):
         current = item["current"]
-        proposed = item["proposed"]
-        comment_text = item.get("comment")
-        author = item.get("author", "Unknown")
         match_spec = item.get("match")
 
         if not current:
@@ -468,6 +476,21 @@ def main():
             )
             continue
 
+        resolved.append((i, item, selected_match))
+
+    # Phase 2: apply back-to-front (descending start offset) so an applied
+    # edit can never shift the offset of one still to come. Edits in
+    # different paragraphs don't interact, so one global sort suffices;
+    # the sort is stable, so of two items with the same target the earlier
+    # one wins and the later is skipped by the pre-replace text check.
+    for i, item, selected_match in sorted(
+        resolved, key=lambda entry: -entry[2].start
+    ):
+        current = item["current"]
+        proposed = item["proposed"]
+        comment_text = item.get("comment")
+        author = item.get("author", "Unknown")
+
         replaced = replace_in_paragraph(
             selected_match.paragraph, current, proposed, selected_match.start
         )
@@ -500,9 +523,15 @@ def main():
             {
                 "index": i,
                 "current": truncate(current),
-                "reason": "Replacement failed despite text being found",
+                "reason": (
+                    "Text at the resolved location changed before this edit "
+                    "was applied (an earlier item's replacement overlaps it)"
+                ),
             }
         )
+
+    for entries in results.values():
+        entries.sort(key=lambda entry: entry["index"])
 
     doc.save(str(output_path))
 


### PR DESCRIPTION
## Problem (CRITICAL — founder code review 2026-07-11)

`collect_matches()` ran against the LIVE document per item. After item 0 replaced occurrence 0 of a repeated string (e.g. "30 days" ×3), the survivors renumbered to 0,1 — so an item spec'd `occurrence: 1` against the ORIGINAL document silently landed on what was originally occurrence 2. Wrong replacement in a client contract, exit 0, recorded as "applied".

## Fix
Two-phase apply in `scripts/apply_redlines.py`:
1. **Resolve** every item's target against the pristine document (no mutation), so occurrence numbers and selectors always mean what they meant in the document the redlines were drafted from.
2. **Apply back-to-front** by start offset (single stable global sort — cross-paragraph edits don't interact; within a paragraph, descending offset keeps earlier offsets valid). The existing pre-replace text check in `replace_in_paragraph` turns any overlapping/duplicate target into an explicit skip ("an earlier item's replacement overlaps it") — never a silent mis-edit.

Docstring documents the snapshot contract; results arrays are sorted by item index for stable output.

## Verification (per task AC)
- New test in `browse/src/apply-redlines.test.ts`: 3×-repeated string with edits targeting occurrences 0/1/2 — asserts each lands on the right one, (a) across paragraphs, (b) all three inside ONE paragraph with different-length replacements (exercises back-to-front), (c) two items resolving to the same occurrence → first wins, second skipped explicitly, exit 2.
- Confirmed the new test FAILS against main's script (reproduces the bug) and passes with the fix.
- Full suite: `bun test` 29 pass / 0 fail; `bun run evals:self-test` aggregate_score 1.0.

## Behavior change (intentional)
An item can no longer target text INTRODUCED by an earlier item, and a repeated string no longer auto-disambiguates just because earlier items consumed the other occurrences — both now require targeting the original text. That is the correct contract: redlines.json is drafted from reading the original document.

Task: cou-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)