### PR TITLE
doctor: fix Step 11 matters-path $-expansion (silent no-op) + browse-binary guidance (cou-30)

### DIFF
--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -131,7 +131,7 @@ One table row per dependency. What each one unlocks, and its install one-liner a
 |------------|---------|------------------|
 | pandoc | Tracked-change extraction from .docx | `brew install pandoc` (macOS) / `apt-get install pandoc` (Linux) |
 | python3 + python-docx | Redline pipeline (apply_redlines, clean_format, extract_redlines) | `python3 -m pip install python-docx` |
-| bun | Building/running the browse binary | `curl -fsSL https://bun.sh/install \| bash` |
+| bun | Building browse from source (optional — the prebuilt binary auto-downloads on first use) | `curl -fsSL https://bun.sh/install \| bash` |
 | Playwright Chromium | The browse skill's headless browser | `cd "${CLAUDE_PLUGIN_ROOT}" && bunx playwright install chromium` |
 | qmd CLI | Vault index maintenance (`qmd update`; `qmd embed` is opt-in) | see https://github.com/tobi/qmd (optional — filesystem search is the fallback) |
 
@@ -160,7 +160,7 @@ done
 
 - Binary present, no state file → ✅, detail "built; daemon not running (starts on demand)".
 - Binary present, daemon responds `"status": "healthy"` → ✅, include uptime/tabs in the detail.
-- Binary missing → ⚠️, fix: `cd "${CLAUDE_PLUGIN_ROOT}" && bun install && bun run build` (requires bun — cross-reference check 5).
+- Binary missing → ⚠️, fix: run any `/counsel-os:browse` command — `find-browse` auto-downloads the prebuilt binary, runtime, and Chromium on first use (no bun needed). To build from source instead: `cd "${CLAUDE_PLUGIN_ROOT}" && bun install && bun run build` (requires bun — cross-reference check 5).
 - State file present but the port doesn't respond, or `/health` reports unhealthy → ⚠️, fix: `kill {pid} 2>/dev/null; rm <state file>` — the next browse command starts a fresh daemon.
 - State file found under `/tmp` → ⚠️, a daemon from an earlier release is still running; fix: `kill {pid} 2>/dev/null; rm /tmp/browse-server*.json` — the next browse command starts a fresh daemon that keeps its state under `~/.counsel-os/browse/`.
 
@@ -231,7 +231,8 @@ The eval suite tests that the *plugin* respects precedence; this check tests tha
 Open matters carry a `Law areas:` field; law files carry `last-reviewed`. When law moved *after* the lawyer last touched a matter, the matter may be running on a stale understanding.
 
 ```bash
-grep -l -E '^stage: (intake|working)' "$LEGAL_ROOT"/{matters_path:-matters}/*.md
+MATTERS_PATH=$(grep -m1 '^matters_path:' "$LEGAL_ROOT/config.md" | sed 's/^matters_path:[[:space:]]*//')
+grep -l -E '^stage: (intake|working)' "$LEGAL_ROOT/${MATTERS_PATH:-matters}"/*.md
 ```
 
 For each open matter: read its `Law areas` and `updated:` frontmatter. For each named area, find the newest `last-reviewed` across `law/{area}/*.md`. If the area was reviewed **after** the matter's `updated:` date, the matter predates the law refresh.


### PR DESCRIPTION
## What

Two fixes to `skills/doctor/SKILL.md` from the 2026-07-11 founder code review (cou-30):

1. **Step 11 (matter-aware law impact) was a silent no-op.** The grep used `{matters_path:-matters}` with no `$` — bash treats that as a literal brace token, the glob matches nothing, and the flagship check (half of `--consistency`, the 'cheap pre-deal spot-check' the README sells) reported a false ✅ on every run. The snippet now derives `MATTERS_PATH` from `config.md` exactly like Step 2 and expands it properly: `"$LEGAL_ROOT/${MATTERS_PATH:-matters}"/*.md`. The derivation is repeated in Step 11's block so the snippet is self-contained (each step runs in its own shell). Side benefit: the check now honors `matters_path:` overrides, which the old literal never did.

2. **Browse-binary guidance predated the 0.9.23 auto-download.** Step 6 told a bun-less user to `bun install && bun run build` when the binary is missing; `browse/bin/find-browse` has auto-downloaded the prebuilt binary + runtime + Chromium on first use since 0.9.23 (verified against `skills/browse/SKILL.md`). The missing-binary fix now leads with 'run any /counsel-os:browse command', keeping build-from-source as the secondary path, and the Step 5 bun row is reworded to 'building browse from source (optional)'.

## What to verify (AC)

- [ ] Step 11 snippet: run it against a vault with an open (`stage: working`/`intake`) matter — it must list the matter file (previously always empty). Tested here for both the default `matters/` and a `matters_path:` override case.
- [ ] No residual `{matters_path:-` pattern anywhere in the repo (grepped — clean).
- [ ] Step 5/6 wording matches actual find-browse behavior in `skills/browse/SKILL.md` lines 21+34–39.
- [ ] `bun test` 36/36 pass, `lint_knowledge.py` OK (markdown-only change; suite unaffected).

## Sequencing note

cou-31 (qmd embed) also edits this file (Step 9) — per the task notes this PR goes first.