### PR TITLE
Harden docx XML parsing against XXE + entity expansion (cou-43)

### DIFF
--- a/browse/src/docx-xxe.test.ts
+++ b/browse/src/docx-xxe.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'child_process';
+import * as path from 'path';
+
+// The redline pipeline ingests .docx authored by a hostile counterparty, so
+// its raw XML parts are untrusted. These tests prove scripts/xml_safety.py
+// neutralises XXE (external-entity file read) and billion-laughs entity
+// expansion at every stdlib/lxml parse site — see cou-43.
+function hasPythonDocx(): boolean {
+  try {
+    execFileSync('python3', ['-c', 'import docx, lxml'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const xxeTest = hasPythonDocx() ? test : test.skip;
+const repoRoot = path.resolve(import.meta.dir, '../..');
+
+describe('xml_safety guards untrusted docx XML', () => {
+  xxeTest('rejects DTDs and refuses entity expansion at both parser sites', () => {
+    const script = String.raw`
+import sys
+from pathlib import Path
+
+repo = Path(sys.argv[1])
+sys.path.insert(0, str(repo / "scripts"))
+
+from xml_safety import safe_fromstring, safe_lxml_fromstring, UnsafeXmlError
+
+BILLION_LAUGHS = b"""<?xml version="1.0"?>
+<!DOCTYPE lolz [
+ <!ENTITY lol "lol">
+ <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+ <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+]>
+<root>&lol3;</root>"""
+
+# billion-laughs must be refused before any expansion (no hang, no crash).
+for parse in (safe_fromstring, safe_lxml_fromstring):
+    try:
+        parse(BILLION_LAUGHS)
+        raise SystemExit("FAIL: %s expanded a DTD payload" % parse.__name__)
+    except UnsafeXmlError:
+        pass
+
+# external-entity XXE (local file read) is likewise refused up front.
+XXE = b"""<?xml version="1.0"?>
+<!DOCTYPE r [ <!ENTITY x SYSTEM "file:///etc/hostname"> ]>
+<root>&x;</root>"""
+for parse in (safe_fromstring, safe_lxml_fromstring):
+    try:
+        parse(XXE)
+        raise SystemExit("FAIL: %s parsed an XXE payload" % parse.__name__)
+    except UnsafeXmlError:
+        pass
+
+# a benign OOXML part still parses cleanly through both hardened paths.
+BENIGN = b'<?xml version="1.0"?><w:p xmlns:w="urn:x"><w:t>hi</w:t></w:p>'
+assert safe_fromstring(BENIGN).tag.endswith("}p")
+assert safe_lxml_fromstring(BENIGN).tag.endswith("}p")
+print("OK")
+`;
+    const out = execFileSync('python3', ['-c', script, repoRoot], {
+      encoding: 'utf8',
+      timeout: 15000,
+    });
+    expect(out.trim().endsWith('OK')).toBe(true);
+  });
+
+  xxeTest('apply_redlines skips a hostile header part without crashing or leaking', () => {
+    const script = String.raw`
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+from docx import Document
+
+repo = Path(sys.argv[1])
+apply_redlines = repo / "scripts" / "apply_redlines.py"
+work = Path(tempfile.mkdtemp(prefix="counsel-xxe-test-"))
+
+secret = work / "secret.txt"
+secret.write_text("TOPSECRET_XXE_CANARY")
+
+original = work / "original.docx"
+doc = Document()
+doc.add_paragraph("The confidential terms apply.")
+doc.save(original)
+
+# Inject a hostile word/header1.xml (raw part; apply_redlines scans it by name)
+# that declares an external entity pointing at our secret file.
+hostile = (
+    '<?xml version="1.0"?>'
+    '<!DOCTYPE hdr [ <!ENTITY leak SYSTEM "file://' + str(secret) + '"> ]>'
+    '<w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">'
+    '<w:p><w:r><w:t>confidential terms &leak;</w:t></w:r></w:p></w:hdr>'
+)
+with zipfile.ZipFile(original, "a") as z:
+    z.writestr("word/header1.xml", hostile)
+
+redlines = work / "redlines.json"
+redlines.write_text(
+    '[{"current": "confidential terms", "proposed": "public terms", '
+    '"comment": null, "author": "Tester"}]'
+)
+out_docx = work / "out.docx"
+
+proc = subprocess.run(
+    ["python3", str(apply_redlines), str(original), str(redlines), str(out_docx)],
+    text=True,
+    capture_output=True,
+    timeout=30,
+)
+
+combined = proc.stdout + proc.stderr
+assert "TOPSECRET_XXE_CANARY" not in combined, "XXE leaked secret file contents!"
+assert "Traceback" not in proc.stderr, "crashed with a stacktrace:\n" + proc.stderr
+assert "skipping word/header1.xml" in proc.stderr, "did not skip hostile header:\n" + proc.stderr
+# body edit still applied normally (exit 0), the hostile part merely skipped.
+assert proc.returncode == 0, "unexpected exit %d:\n%s" % (proc.returncode, combined)
+assert Document(out_docx).paragraphs[0].text == "The public terms apply."
+print("OK")
+`;
+    const out = execFileSync('python3', ['-c', script, repoRoot], {
+      encoding: 'utf8',
+      timeout: 40000,
+    });
+    expect(out.trim().endsWith('OK')).toBe(true);
+  });
+});

--- a/scripts/apply_redlines.py
+++ b/scripts/apply_redlines.py
@@ -42,6 +42,8 @@ from xml.etree import ElementTree as ET
 from docx import Document
 from docx.text.run import Run
 
+from xml_safety import UnsafeXmlError, safe_fromstring
+
 W_NS = "{http://schemas.openxmlformats.org/wordprocessingml/2006/main}"
 UNSUPPORTED_PARTS = (
     ("word/footnotes.xml", "footnote", "footnote"),
@@ -263,7 +265,11 @@ def collect_unsupported_matches(docx_path, current, occurrence):
                 if part_name not in names:
                     continue
 
-                root = ET.fromstring(package.read(part_name))
+                try:
+                    root = safe_fromstring(package.read(part_name))
+                except UnsafeXmlError as exc:
+                    print(f"warning: skipping {part_name}: {exc}", file=sys.stderr)
+                    continue
                 paragraph_index = 0
                 for paragraph in root.iter(f"{W_NS}p"):
                     full_text = paragraph_text_from_xml(paragraph)

--- a/scripts/extract_redlines.py
+++ b/scripts/extract_redlines.py
@@ -163,8 +163,8 @@ def extract(path, full_text=False):
             if part.partname.endswith("/word/comments.xml"):
                 root = part.element if hasattr(part, "element") else None
                 if root is None:
-                    import lxml.etree as etree
-                    root = etree.fromstring(part.blob)
+                    from xml_safety import safe_lxml_fromstring
+                    root = safe_lxml_fromstring(part.blob)
                 for c in root.iter(qn("w:comment")):
                     cid = c.get(qn("w:id"))
                     text = " ".join(

--- a/scripts/xml_safety.py
+++ b/scripts/xml_safety.py
@@ -1,0 +1,68 @@
+"""Hardened XML parsing for untrusted OOXML (.docx) parts.
+
+A ``.docx`` is a zip authored by an arbitrary counterparty, and the redline
+pipeline ingests opposing-counsel markup by design — so its raw XML parts are
+untrusted input. Stdlib ``xml.etree`` is vulnerable to entity-expansion
+("billion laughs") and ``lxml`` resolves external entities and loads external
+DTDs by default (classic XXE: local file read / SSRF).
+
+OOXML forbids DTDs in its parts, so a legitimate ``.docx`` never declares one.
+We therefore reject any part carrying a ``DOCTYPE`` outright and, as
+defense-in-depth, parse with entity resolution and network access disabled.
+This closes both XXE and billion-laughs without adding a third-party
+dependency (the project ships no requirements manifest; ``lxml`` is already
+present transitively via python-docx).
+"""
+
+from xml.etree import ElementTree as ET
+
+# ``<!DOCTYPE`` is only valid in the XML prolog; anywhere else the literal
+# bytes would have to be escaped, so a whole-document scan cannot miss a real
+# declaration and a stray match only causes a fail-closed rejection. The XML
+# spec requires the keyword uppercase; we also reject a lowercased spelling so
+# a malformed-but-hostile part fails closed rather than reaching the parser.
+_DOCTYPE_MARKERS = (b"<!DOCTYPE", b"<!doctype")
+
+
+class UnsafeXmlError(ValueError):
+    """An OOXML part declares a DTD — never legitimate, treated as hostile."""
+
+
+def _as_bytes(blob):
+    if isinstance(blob, str):
+        return blob.encode("utf-8")
+    return bytes(blob)
+
+
+def _reject_dtd(raw):
+    if any(marker in raw for marker in _DOCTYPE_MARKERS):
+        raise UnsafeXmlError(
+            "refusing to parse OOXML part declaring a DOCTYPE/DTD "
+            "(possible XXE or entity-expansion attack)"
+        )
+
+
+def safe_fromstring(blob):
+    """Parse an untrusted OOXML part with the stdlib ElementTree.
+
+    Rejects any DTD before parsing so no internal entity is ever expanded.
+    """
+    raw = _as_bytes(blob)
+    _reject_dtd(raw)
+    return ET.fromstring(raw)
+
+
+def safe_lxml_fromstring(blob):
+    """Parse an untrusted OOXML part with lxml, entities and network disabled."""
+    import lxml.etree as etree
+
+    raw = _as_bytes(blob)
+    _reject_dtd(raw)
+    parser = etree.XMLParser(
+        resolve_entities=False,
+        no_network=True,
+        load_dtd=False,
+        dtd_validation=False,
+        huge_tree=False,
+    )
+    return etree.fromstring(raw, parser=parser)


### PR DESCRIPTION
## What
Hardens every direct XML parse of untrusted `.docx` parts in the redline pipeline against **XXE** (external-entity file read / SSRF) and **billion-laughs** entity expansion. Closes cou-43.

The redline pipeline ingests `.docx` authored by a hostile counterparty by design, so its raw XML parts are untrusted input. Two direct parse sites were exposed:
- `extract_redlines.py` — lxml fallback on `word/comments.xml` (lxml resolves external entities and loads external DTDs **by default**).
- `apply_redlines.py` — stdlib `ElementTree` scan of header/footer/unsupported parts (vulnerable to entity expansion).

## How
New `scripts/xml_safety.py` with `safe_fromstring` (stdlib) and `safe_lxml_fromstring` (lxml). OOXML forbids DTDs in its parts, so both **reject any part carrying a `DOCTYPE` before parsing** — this alone fully closes XXE and billion-laughs (both require a DTD). The lxml path additionally disables entity resolution, external-DTD loading, and network access as defense-in-depth.

- `apply_redlines` skips a hostile part with a stderr warning and continues (the header/footer scan is best-effort, informational); body edits still apply normally.
- `extract_redlines`' existing best-effort handler records the rejection and continues.

### Approach note (for the reviewer)
The lead AC offered **"defusedxml OR reject any part declaring a DOCTYPE"**. I took the **DOCTYPE-reject** option because the project ships **no requirements manifest** — adding an undeclared `defusedxml` pip dep would `ImportError` at runtime on a fresh machine that has python-docx but not defusedxml, a real regression risk on the hero redline path right before the virgin-hardware-QA launch gate. `defusedxml` also doesn't cover the lxml site. The DOCTYPE-reject + hardened lxml parser gives the same `forbid_dtd` guarantee uniformly, dependency-free (lxml is already present transitively via python-docx).

## Test
`browse/src/docx-xxe.test.ts` (gated on python-docx/lxml, like the existing redline tests):
1. Both parsers **refuse** a billion-laughs payload and an external-entity XXE payload (`UnsafeXmlError`), and a benign OOXML part still parses cleanly.
2. `apply_redlines` against a docx with a hostile `word/header1.xml` (external entity → secret canary file): asserts the secret is **not leaked**, no stacktrace, the part is skipped with a warning, exit 0, and the body edit still lands.

## Verification (local, CI-equivalent)
- `bun run typecheck` — clean
- `bun test` — 38 pass / 0 fail (incl. 2 new)
- `bun run evals:self-test` — exit 0
- `python3 scripts/lint_knowledge.py --check-versions` — OK, 0 problems
- browse command-reference drift — none
- `python3 -m py_compile scripts/*.py` + `bash -n` on all shell scripts — OK