### PR TITLE
release-binaries: drop un-runnable darwin-x64 job; honest Intel-Mac path (cou-42)

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -60,11 +60,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # No darwin-x64 (Intel Mac) entry: the only x64 macOS runner GitHub
+        # offered here was macos-13, which it has retired — that job queued
+        # forever and never produced an asset. Cross-compiling on macos-14
+        # (arm64) is not an option either: the binary itself could be built
+        # with `--target=bun-darwin-x64`, but the matching browsers tarball
+        # can't — Playwright downloads Chromium per host arch, so an arm64
+        # runner yields an arm64 Chromium, and there is no reliable cross-arch
+        # download. Intel Macs build from source instead (`bun run build`);
+        # see the README platform matrix and browse/bin/find-browse.
         include:
           - os: macos-14
             artifact: counsel-browse-darwin-arm64
-          - os: macos-13
-            artifact: counsel-browse-darwin-x64
           - os: ubuntu-latest
             artifact: counsel-browse-linux-x64
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ If that still doesn't work, fall back to the local clone below. Same content, sa
 **Optional dependencies** (Claude Code; the setup skill auto-detects what you have):
 - **pandoc**, for extracting tracked changes from Word documents
 - **[QMD](https://github.com/tobi/qmd)**, a content-index MCP server for entity discovery across your whole vault. Install separately as its own Claude plugin (works in Claude Code and Cowork). Without it, entity files live under `{legal_root}/entities/` and are found via filesystem search.
-- **[Bun](https://bun.sh/)** plus Playwright Chromium (`bunx playwright install chromium`), only if you want to build the `/counsel-os:browse` skill from source. Without them, browse downloads a prebuilt binary and matching browser builds from the GitHub release automatically on first use (set `COUNSEL_OS_NO_DOWNLOAD=1` to disable).
+- **[Bun](https://bun.sh/)** plus Playwright Chromium (`bunx playwright install chromium`), only if you want to build the `/counsel-os:browse` skill from source. Without them, browse downloads a prebuilt binary and matching browser builds from the GitHub release automatically on first use (set `COUNSEL_OS_NO_DOWNLOAD=1` to disable). Prebuilt browse binaries are published for **Apple-Silicon macOS** and **Linux-x64**; on **Intel Macs** browse builds from source, so those users need Bun installed. (Everything else in Counsel OS — the full methodology, all 26 law areas, your vault — runs on Intel Macs with no extra tooling.)
 
 ### Claude Desktop / Cowork (no terminal required)
 

--- a/browse/bin/find-browse
+++ b/browse/bin/find-browse
@@ -27,9 +27,13 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 REPO_URL="https://github.com/eigenlegal/counsel-os"
 VERSION="$(cat "$PLUGIN_ROOT/VERSION" 2>/dev/null | tr -d '[:space:]' || true)"
 
+# Prebuilt binaries ship for Apple-Silicon macOS and Linux-x64 only. Intel
+# Macs (Darwin-x86_64) have no prebuilt: the release workflow can't produce a
+# working darwin-x64 asset (see release-binaries.yml). Leaving ASSET empty
+# routes them to the honest "build from source" message rather than a doomed
+# download of a nonexistent asset.
 case "$(uname -s)-$(uname -m)" in
   Darwin-arm64)             ASSET="counsel-browse-darwin-arm64" ;;
-  Darwin-x86_64)            ASSET="counsel-browse-darwin-x64" ;;
   Linux-x86_64|Linux-amd64) ASSET="counsel-browse-linux-x64" ;;
   *)                        ASSET="" ;;
 esac


### PR DESCRIPTION
## What
The `release-binaries.yml` build matrix carried a `darwin-x64` (Intel Mac) entry running on `macos-13`, a runner GitHub has retired. That job sat queued indefinitely and never produced an asset — so **no release has ever shipped darwin-x64 binaries** (v0.9.29 and v0.9.30 asset sets are identical: arm64 + linux-x64 + runtime only). This makes every future release run complete cleanly and makes the Intel-Mac install story honest.

## Why option (a), not cross-compile
Cross-compiling on `macos-14` (arm64) does **not** fully work: `bun build --compile --target=bun-darwin-x64` can produce the binary, but the matching browsers tarball can't be built on an arm64 runner — Playwright downloads Chromium per host arch and there's no reliable cross-arch download, so it would ship a broken half-artifact. Per the task AC ("do NOT ship a half/broken x64 artifact"), dropping the prebuilt + pointing Intel Macs at the working source build is the cheapest path that fully works. The core plugin (methodology, 26 law areas, vault) already runs on Intel Macs with no extra tooling — only the optional prebuilt `browse` binary is affected, and it never shipped anyway (no regression).

## Changes
- **`.github/workflows/release-binaries.yml`** — remove the `macos-13`/`counsel-browse-darwin-x64` matrix entry; add a comment explaining why. Runtime-upload gate (`linux-x64`) and the two remaining builds (arm64, linux-x64) are unaffected.
- **`browse/bin/find-browse`** — leave `ASSET` empty for `Darwin-x86_64` so Intel Macs get the honest "no prebuilt browse binary … Build with: bun run build" message instead of attempting (and failing) to download a nonexistent asset.
- **`README.md`** — state prebuilt coverage honestly: Apple-Silicon macOS + Linux-x64; Intel Macs build browse from source (need Bun); everything else runs with no tooling.

## Verification
Full CI run locally (green): `bun run typecheck`, `bun test` (36 pass), `bun run evals:self-test`, `bun run law:frontmatter` (0 warnings), `python3 scripts/lint_knowledge.py --check-versions` (0 problems), `bash -n` on find-browse + all scripts, and `python3 -c` YAML parse confirming the matrix now has exactly `[macos-14/arm64, ubuntu-latest/linux-x64]`.

Note for founder: the README wording is a public claim (platform support) — flagged for founder pass.

cou-42