### PR TITLE
docs: consistency sweep + eval CI honesty (cou-34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ If that still doesn't work, fall back to the local clone below. Same content, sa
 
 **Optional dependencies** (Claude Code; the setup skill auto-detects what you have):
 - **pandoc**, for extracting tracked changes from Word documents
+- **python-docx**, for the native Word redline pipeline — applies tracked-change edits and ingests counterparty `.docx` markup (`apply_redlines`, `extract_redlines`, `diff_rounds`). Without it, redlines come back as markdown.
 - **[QMD](https://github.com/tobi/qmd)**, a content-index MCP server for entity discovery across your whole vault. Install separately as its own Claude plugin (works in Claude Code and Cowork). Without it, entity files live under `{legal_root}/entities/` and are found via filesystem search.
 - **[Bun](https://bun.sh/)** plus Playwright Chromium (`bunx playwright install chromium`), only if you want to build the `/counsel-os:browse` skill from source. Without them, browse downloads a prebuilt binary and matching browser builds from the GitHub release automatically on first use (set `COUNSEL_OS_NO_DOWNLOAD=1` to disable).
 
@@ -225,7 +226,7 @@ Analyzes your matter history and produces insights, calibrated to the shape of y
 - **High-volume practices** (many similar contracts against the same positions) get the full statistical pass: most-negotiated clauses, acceptance and exception rates, counterparties that push back hardest, standards that keep getting overridden (maybe the standard is wrong?), and trends compared to previous retros. Per-clause statistics only run where there are roughly 10+ comparable matters; below that, deviations are reported as case notes, not percentages.
 - **Low-volume, heterogeneous practices** (most solo and in-house work) skip the statistics and center on **harvesting promotable knowledge**: sweeping matter and entity files for deal-archetype playbooks, regulatory-posture notes, and proven clause language that has outgrown its matter and belongs in `practice/`.
 
-Run monthly to calibrate your practice.
+Run quarterly, or every ~10 closed matters, to calibrate your practice.
 
 #### Update: pull latest content
 
@@ -303,7 +304,7 @@ Only relevant if you're developing Counsel OS itself:
 | `scripts/bump_content_versions.py [--date YYYY-MM-DD]` | Hashes each content group and bumps `content-version` frontmatter for groups that changed — this is what lets `/counsel-os:update` detect upstream law/practice changes. | After editing anything under `knowledge/law/` or `knowledge/practice-seed/`. |
 | `scripts/validate_law_frontmatter.py` | Validates law-area frontmatter against `knowledge/law/frontmatter-policy.json`; reports attestations coming due. Runs in CI. | After editing law frontmatter; periodically to see attestation debt. |
 | `scripts/run_evals.py [--generate] [--model <id>] [--only <fixture>] [--self-test] [--save-baseline <id>] [--compare-baseline <id>]` | Scores eval outputs in `evals/`; `--generate` runs the counsel agent headlessly against each fixture's mini-vault first (costs API tokens); `--self-test` validates the scorer (free, runs in CI); baselines snapshot per-model scores and gate on regressions. | Full generate+score before releases and when qualifying a new model; see `evals/README.md`. |
-| `scripts/gen_browse_reference.py [--check]` | Regenerates the browse skill's command reference from the source command registry; `--check` fails on drift (runs in CI). | After adding or changing a browse CLI command. |
+| `scripts/gen_browse_reference.py [--check]` | Regenerates the browse skill's command reference from the source command registry; `--check` fails on drift instead of rewriting. CI regenerates and fails on any resulting `git diff`. | After adding or changing a browse CLI command. |
 
 ---
 
@@ -412,7 +413,7 @@ This is also how the system stays small and extensible. New capability is a new 
 | Highest | `law/` | Never — hard legal constraints | Seeded by plugin, customizable by you |
 | 2 | Entity files | Per-deal only | You (via `remember`, proposed by counsel at close) |
 | 3 | `practice/` | Your standards | You (through `/counsel-os:setup` or direct edits) |
-| Lowest | `memory/` | Context only — informs, doesn't override | Automatic (via `remember` when counsel proposes) |
+| Lowest | `memory/` | Context only — informs, doesn't override | Proposed by `remember`, you approve |
 
 **Example:** Your standard liability cap is 12 months (`practice/standards/`). But for Acme Corp you've pre-approved 24 months (in your Acme Corp entity file). When reviewing an Acme contract, the system uses 24 months. If GDPR requires a specific data-processing provision (`law/`), though, that's non-negotiable regardless.
 
@@ -430,7 +431,7 @@ What gets proposed, when:
 - **When language works:** *"This counter-language landed cleanly. Want me to add it to `practice/library/` as a vendor-favorable variant?"*
 - **At matter close:** it proposes a counterparty file with deal history, position overrides, and negotiation notes you can refer to next time.
 
-You approve every change. Nothing gets written to your knowledge without consent. Over time, your `practice/` reflects your actual practice, your entity files capture relationship-specific context, and your `memory/patterns.md` accumulates cross-cutting observations that inform future work.
+You approve every change. Nothing gets written to your knowledge without consent (matter state — the working record of the engagement itself — saves automatically). Over time, your `practice/` reflects your actual practice, your entity files capture relationship-specific context, and your `memory/patterns.md` accumulates cross-cutting observations that inform future work.
 
 That's what makes Counsel OS more than a one-shot review: the positions it checks against are the ones you've actually taken.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -46,6 +46,7 @@ Fixtures may additionally carry:
 | `msa-liability-indemnity` | — | Legacy: liability/indemnity catches in an MSA (manual outputs). |
 | `nda-residuals` | — | Legacy: residuals-clause catch in an NDA (manual outputs). |
 | `saas-dpa-breach` | — | Legacy: DPA breach-notification catches (manual outputs). |
+| `demo-nda` | — | Guards the `/counsel-os:demo` showpiece: the bundled synthetic mutual NDA catches the RED/YELLOW calls the demo promises against the seeded confidentiality standard (manual outputs). |
 | `law-beats-practice` | yes | Safety rule: a law/ floor (GDPR Art. 33) overrides a permissive practice standard, and the conflicting standard itself gets flagged. |
 | `reference-never-governs` | yes | Safety rule: a matching sample form in practice/reference/ never blesses a clause — positions come from practice/standards/. |
 | `entity-override-scoping` | yes | Safety rule: a counterparty-specific concession in an entity file is not precedent for a different counterparty. |
@@ -65,14 +66,14 @@ python3 scripts/run_evals.py --generate [--model claude-opus-4-8] [--only fixtur
 
 Per fixture, the runner copies the mini-vault to a temp dir, rewrites `config.md`'s `__VAULT_PATH__`, and runs `claude -p` with `--plugin-dir <repo>` (evaluating the WORKING TREE) and `COUNSEL_OS_LEGAL_ROOT` pointed at the temp vault — the resolver's env override makes the whole knowledge system read the fixture. The task prompt instructs the agent to write findings JSON to `evals/outputs/{id}.json`; the temp vault is destroyed afterward. Legacy fixtures without a `vault` field still require manually produced outputs.
 
-**Score only** (free, used by CI):
+**Score only** (free):
 
 ```bash
-python3 scripts/run_evals.py --fixtures evals/fixtures --outputs evals/outputs --fail-under 0.80
-python3 scripts/run_evals.py --self-test
+python3 scripts/run_evals.py --fixtures evals/fixtures --outputs evals/outputs --fail-under 0.80   # full scored gate — run pre-release
+python3 scripts/run_evals.py --self-test                                                            # scorer self-test — this is what CI runs
 ```
 
-The self-test scores bundled sample outputs to verify the scorer itself. It does not call an LLM. When adding a fixture, also add a passing output to `evals/sample-outputs/` or CI's self-test will report it missing.
+CI runs `--self-test` only; the full scored gate is a pre-release step (it needs generated outputs, which CI does not produce). The self-test scores bundled sample outputs to verify the scorer itself. It does not call an LLM. When adding a fixture, also add a passing output to `evals/sample-outputs/` or CI's self-test will report it missing.
 
 **Cadence:** full generate+score before each release and when qualifying a new model (compare per-fixture scores across `--model` runs). Anchors must stay decisive — a fixture that flakes gets its anchors tightened or runs N=3/require-2; never leave a known-flaky fixture in the suite.
 

--- a/skills/counsel/SKILL.md
+++ b/skills/counsel/SKILL.md
@@ -306,6 +306,7 @@ Plugin (methodology + tooling):
     remember.md                                # Persist state and propose knowledge updates
     redline-output.md                          # Redline hygiene rules (loaded by draft --redline)
   skills/                                      # Utility skills
+    demo/SKILL.md                              # /counsel-os:demo — Guided tour + live NDA showpiece
     browse/SKILL.md                            # /counsel-os:browse — Web extraction
     retro/SKILL.md                             # /counsel-os:retro — Practice analytics
     setup/SKILL.md                             # /counsel-os:setup — Guided onboarding

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: retro
-description: "Practice analytics: matter and counterparty trends, knowledge-base health, and harvesting promotable knowledge from matters (archetype/corridor playbooks, proven clause language) — plus, at sufficient volume, position drift and exception-rate analysis. Use monthly."
+description: "Practice analytics: matter and counterparty trends, knowledge-base health, and harvesting promotable knowledge from matters (archetype/corridor playbooks, proven clause language) — plus, at sufficient volume, position drift and exception-rate analysis. Use quarterly, or every ~10 closed matters."
 ---
 
 # Retro — Practice Analytics
 
 You are running a retrospective analysis of the user's legal practice. Your job is to analyze accumulated data in the memory and matters files, identify trends, and recommend improvements to positions, processes, and priorities.
 
-**When to use:** Run monthly, or when the user wants insight into their practice patterns.
+**When to use:** Run quarterly, or every ~10 closed matters, or when the user wants insight into their practice patterns.
 
 **Calibrate to the practice's shape before analyzing.** Two archetypes:
 

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -330,7 +330,7 @@ If shell access and plugin-tree write access are available, and the plugin has `
 1. Check if `bun` is available: `command -v bun`
 2. If yes: run `cd "${CLAUDE_PLUGIN_ROOT}" && bun install && bun run build`
 3. Check whether Playwright Chromium is installed. If shell and network access are available, run `cd "${CLAUDE_PLUGIN_ROOT}" && bunx playwright install chromium`. If network access is unavailable, tell the user the browse skill will prompt them to run that command before first use.
-4. If Bun is unavailable: no action needed — `browse/bin/find-browse` downloads a prebuilt binary and the matching browser builds from the plugin's GitHub release on first browse use (~220MB, one time). Just mention that the first browse command will take a couple of minutes. `COUNSEL_OS_NO_DOWNLOAD=1` disables that fallback, in which case browse requires Bun.
+4. If Bun is unavailable: no action needed — `browse/bin/find-browse` downloads three assets from the plugin's GitHub release on first browse use — the prebuilt binary, the Playwright runtime packages, and the matching Chromium builds (~320MB total, one time). Just mention that the first browse command will take a couple of minutes. `COUNSEL_OS_NO_DOWNLOAD=1` disables that fallback, in which case browse requires Bun.
 
 If shell access or plugin-tree write access is unavailable, skip this step. The rest of Counsel OS still works.
 


### PR DESCRIPTION
Low-severity documentation drift batch from the founder's 2026-07-11 code review (cou-34). Docs-only — no code paths touched.

## What changed (a–h from the task notes)
- **(a) eval CI honesty** — `evals/README.md` said the score-only block was "used by CI", but CI only runs `--self-test`. Reworded: CI runs `--self-test`; the full scored gate is a pre-release step (it needs generated outputs CI doesn't produce). Also annotated each command inline.
- **(b) Fixture Index** — added the missing `demo-nda` row (13 fixtures on disk, 12 were listed).
- **(c) download size** — `setup/SKILL.md` said browse first-use is ~220MB; `browse/SKILL.md` says ~320MB (3 assets: binary + Playwright runtime + Chromium). Aligned setup to the measured 3-asset ~320MB.
- **(d) Knowledge Map** — `counsel/SKILL.md` listed 6 of 8 skills; added `demo`.
- **(e) retro cadence** — skill (frontmatter + body) and README said "monthly"; `docs/operations.md` says quarterly. Aligned skill + README to **quarterly, or every ~10 closed matters**.
- **(f) precedence table** — `memory/` owner was "Automatic", contradicting the consent rule. Now "Proposed by `remember`, you approve"; added "(matter state saves automatically)" to the consent sentence so the exception is explicit.
- **(g) optional deps** — README omitted **python-docx** (required by `apply_redlines`/`extract_redlines`/`diff_rounds` — the advertised markup ingest). Added.
- **(h) gen_browse_reference** — README said `--check` "runs in CI"; CI actually regenerates + `git diff`. Reworded to describe reality.

## Item (i) — launch drafts — NOT in this PR (needs founder pass)
`drafts/launch/{show-hn,reddit}.md` are **untracked local files** (not in git), and they're **outward content**. They pin "current release 0.9.27" but the repo is now **0.9.30** (past even the 0.9.29 the task noted). Version pin + claims re-verification is a founder GTM step — flagged in the task notes as **claims for founder pass**, not changed here.

## Verification
- `python3 scripts/run_evals.py --self-test` → PASS
- `python3 scripts/lint_knowledge.py --check-versions` → OK, 0 problems
- `gen_browse_reference.py` → no drift (browse/SKILL.md untouched)

Claims touched: retro cadence guidance, python-docx dependency, memory-consent phrasing — all factual/self-consistent with the repo; **founder claims pass** still applies to any public-facing wording.