### PR TITLE
Mechanical document QA — dangling cross-refs, unattached exhibits, term/party drift (cou-50)

### DIFF
--- a/browse/src/check-document.test.ts
+++ b/browse/src/check-document.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+// scripts/check_document.py is a deterministic mechanical-QA linter over a
+// contract draft (cou-50). Its markdown/text path imports no python-docx, so
+// those tests run everywhere; the .docx path is gated on python-docx being
+// present (matching apply-redlines.test.ts) and additionally proves the
+// accept-all extraction ignores tracked deletions.
+const repoRoot = path.resolve(import.meta.dir, '../..');
+const script = path.join(repoRoot, 'scripts', 'check_document.py');
+
+function hasPython(): boolean {
+  try {
+    execFileSync('python3', ['-c', 'import sys'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function hasPythonDocx(): boolean {
+  try {
+    execFileSync('python3', ['-c', 'import docx'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+type Finding = { type: string; severity: string; detail: string };
+type Report = {
+  summary: { error: number; warning: number; info: number; total: number };
+  notes: string[];
+  findings: Finding[];
+};
+
+function runJson(file: string): Report {
+  const out = execFileSync('python3', [script, file, '--json'], { encoding: 'utf8' });
+  return JSON.parse(out);
+}
+
+function types(report: Report): Set<string> {
+  return new Set(report.findings.map((f) => f.type));
+}
+
+function writeTmp(name: string, content: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdqa-'));
+  const p = path.join(dir, name);
+  fs.writeFileSync(p, content);
+  return p;
+}
+
+const mdTest = hasPython() ? test : test.skip;
+const docxTest = hasPythonDocx() ? test : test.skip;
+
+describe('check_document.py — markdown path (no python-docx needed)', () => {
+  mdTest('flags dangling cross-refs, unattached exhibits, unused/undefined terms, drift', () => {
+    const md = writeTmp(
+      'nda.md',
+      [
+        '# MUTUAL NONDISCLOSURE AGREEMENT',
+        '',
+        'This Agreement is between Acme Corporation ("Discloser") and Beta LLC ("Recipient").',
+        'Acme Corp. and Beta LLC agree as follows.',
+        '',
+        '## 1. Definitions',
+        '"Confidential Information" means non-public information.',
+        '"Representatives" means officers, employees, and agents of a party.',
+        '',
+        '## 2. Obligations',
+        'Recipient shall use Confidential Information. The parties protect confidential information.',
+        'See Section 4.2 for remedies and Exhibit A for the form.',
+      ].join('\n'),
+    );
+    const report = runJson(md);
+    const t = types(report);
+
+    // High-confidence errors.
+    expect(t.has('undefined_reference')).toBe(true); // Section 4.2 does not exist
+    expect(t.has('missing_exhibit')).toBe(true); // Exhibit A referenced, not attached
+    // Warnings.
+    expect(t.has('capitalization_drift')).toBe(true); // "confidential information"
+    expect(t.has('unused_definition')).toBe(true); // Discloser / Representatives
+    expect(t.has('party_name_drift')).toBe(true); // Acme Corporation vs Acme Corp.
+
+    // Precision guards: things that must NOT be flagged.
+    const unusedDetails = report.findings
+      .filter((f) => f.type === 'unused_definition')
+      .map((f) => f.detail);
+    expect(unusedDetails).toContain('Discloser');
+    expect(unusedDetails).not.toContain('Confidential Information'); // it IS used
+    expect(unusedDetails).not.toContain('Recipient'); // it IS used
+    expect(report.summary.error).toBeGreaterThanOrEqual(2);
+  });
+
+  mdTest('a clean document produces zero findings', () => {
+    const md = writeTmp(
+      'clean.md',
+      [
+        '# NDA',
+        'This Agreement is between Acme LLC ("Company") and Beta LLC ("Vendor").',
+        '',
+        '## 1. Definitions',
+        '"Confidential Information" means non-public information.',
+        '',
+        '## 2. Use',
+        'Vendor shall protect Confidential Information. Company may enforce this under Section 2.',
+      ].join('\n'),
+    );
+    const report = runJson(md);
+    expect(report.summary.total).toBe(0);
+  });
+
+  mdTest('auto-numbered doc: cross-ref check is skipped with a note, not false positives', () => {
+    const md = writeTmp(
+      'autonum.md',
+      [
+        '# Services Agreement',
+        'Provider shall deliver the Services. Payment terms are in Section 5.',
+        'Confidentiality is described in Section 9 and Article III.',
+      ].join('\n'),
+    );
+    const report = runJson(md);
+    expect(types(report).has('undefined_reference')).toBe(false);
+    expect(report.notes.join(' ')).toContain('auto-generated');
+  });
+
+  mdTest('--strict exits non-zero only when an error-severity finding exists', () => {
+    const bad = writeTmp(
+      'bad.md',
+      ['# 1. Scope', 'Provisions are in Section 2 and Section 9.', '# 2. Term', 'Two years.'].join(
+        '\n',
+      ),
+    );
+    let code = 0;
+    try {
+      execFileSync('python3', [script, bad, '--strict'], { stdio: 'ignore' });
+    } catch (e: any) {
+      code = e.status;
+    }
+    expect(code).toBe(3);
+  });
+});
+
+describe('check_document.py — docx path', () => {
+  docxTest('reads .docx and ignores tracked deletions (accept-all view)', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdqa-docx-'));
+    const docx = path.join(dir, 'tracked.docx');
+    const builder = String.raw`
+import sys
+from docx import Document
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+out = sys.argv[1]
+doc = Document()
+doc.add_paragraph('1. Scope')
+doc.add_paragraph('3. Payment')
+p = doc.add_paragraph('Remedies are set forth in ')
+ins = OxmlElement('w:ins'); ins.set(qn('w:author'), 'X'); ins.set(qn('w:date'), '2020-01-01T00:00:00Z')
+r = OxmlElement('w:r'); t = OxmlElement('w:t'); t.text = 'Section 3'; r.append(t); ins.append(r)
+p._p.append(ins)
+dele = OxmlElement('w:del'); dele.set(qn('w:author'), 'X'); dele.set(qn('w:date'), '2020-01-01T00:00:00Z')
+r2 = OxmlElement('w:r'); dt = OxmlElement('w:delText'); dt.text = ' Section 99'; r2.append(dt); dele.append(r2)
+p._p.append(dele)
+doc.save(out)
+`;
+    execFileSync('python3', ['-c', builder, docx]);
+    const report = runJson(docx);
+    // Deleted "Section 99" must NOT surface as a dangling reference; the
+    // inserted "Section 3" resolves to the '3. Payment' heading -> clean.
+    const dangling = report.findings.filter((f) => f.type === 'undefined_reference');
+    expect(dangling.map((f) => f.detail)).not.toContain('99');
+    expect(report.summary.total).toBe(0);
+  });
+
+  docxTest('reports paragraph locations for docx findings', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'cdqa-docx2-'));
+    const docx = path.join(dir, 'nda.docx');
+    const builder = String.raw`
+import sys
+from docx import Document
+out = sys.argv[1]
+doc = Document()
+doc.add_paragraph('1. Definitions')
+doc.add_paragraph('"Purpose" means the evaluation of a business relationship.')
+doc.add_paragraph('2. Term')
+doc.add_paragraph('Obligations survive per Section 7.1 of this Agreement.')
+doc.save(out)
+`;
+    execFileSync('python3', ['-c', builder, docx]);
+    const report = runJson(docx);
+    const ref = report.findings.find((f) => f.type === 'undefined_reference');
+    expect(ref).toBeDefined();
+    expect(report.findings.some((f) => f.type === 'unused_definition' && f.detail === 'Purpose')).toBe(
+      true,
+    );
+    // Locations are paragraph-based for docx.
+    const withLoc = report.findings.find((f) => (f as any).locations?.length);
+    expect(String((withLoc as any).locations[0])).toContain('¶');
+  });
+});

--- a/browse/src/check-document.test.ts
+++ b/browse/src/check-document.test.ts
@@ -128,6 +128,39 @@ describe('check_document.py — markdown path (no python-docx needed)', () => {
     expect(report.notes.join(' ')).toContain('auto-generated');
   });
 
+  mdTest('resolves a "Section N.N" ref to a no-period subsection heading (no false error)', () => {
+    // Regression (cou-51): the common legal subsection style "3.2 Late Fees"
+    // (dotted decimal, whitespace, capitalized word, NO trailing period) must
+    // register as a section so a valid "Section 3.2" ref resolves instead of
+    // false-flagging at error severity. Period-suffixed top-level headings sit
+    // alongside it, so the auto-numbering guard does not fire.
+    const mixed = writeTmp(
+      'mixed.md',
+      [
+        '# 1. Definitions',
+        '"Services" means the professional services.',
+        '# 2. Scope',
+        'Provider performs the Services.',
+        '# 3. Payment',
+        'Fees are due per the schedule below.',
+        '## 3.2 Late Fees',
+        'Overdue amounts accrue interest, and remedies are set forth in Section 3.2.',
+      ].join('\n'),
+    );
+    const report = runJson(mixed);
+    expect(types(report).has('undefined_reference')).toBe(false);
+    expect(report.summary.error).toBe(0);
+
+    // ...and --strict stays green (exit 0) on this clean mixed-heading doc.
+    let code = 0;
+    try {
+      execFileSync('python3', [script, mixed, '--strict'], { stdio: 'ignore' });
+    } catch (e: any) {
+      code = e.status;
+    }
+    expect(code).toBe(0);
+  });
+
   mdTest('--strict exits non-zero only when an error-severity finding exists', () => {
     const bad = writeTmp(
       'bad.md',

--- a/primitives/read.md
+++ b/primitives/read.md
@@ -95,6 +95,8 @@ After extracting the text, identify:
    - Whether comments were found, with count and authors
    - If neither was found, note that explicitly so the user knows it was checked
 
+7. **Mechanical QA (run last, on a full review).** Before concluding a full document review, run the deterministic checker (see `## --qa`) and fold any `error`-severity findings into your report. These are the tedious mechanical defects — dangling cross-references, exhibits named but not attached, defined-but-unused terms, party-name drift — that survive careful reading and are cheap to catch deterministically.
+
 ---
 
 ## --redline
@@ -132,6 +134,35 @@ python3 "${CLAUDE_PLUGIN_ROOT}/scripts/diff_rounds.py" --ours "<the version we s
 ```
 
 The report classifies the fate of every counter from our last round: **ACCEPTED** (our language survived), **REVERTED** (back to their text), **MODIFIED** (replaced with something new), **NEW** (fresh asks in paragraphs we never touched). Pass `--base` whenever the round N-1 baseline exists — without it, silent acceptances are invisible and unattributable edits surface as UNMATCHED_CHANGE. Fold the classifications into the delta report (step 4) — a REVERTED counter is a live dispute, not a new change — and log the round outcome per classification to the matter (step 5).
+
+---
+
+## --qa
+
+Mechanical document QA — a deterministic linter over a draft that catches the tedious defects a careful read still misses: a cross-reference to a section that was renumbered away, an exhibit named in the body but never attached, a term defined once and never used, a party named three different ways. Live evidence: a counterparty audit contract named three entities that don't exist, caught only because a human happened to look. This is pure mechanical tedium — do it with a script, spend judgment on judgment.
+
+### When to run
+
+- **Automatically as the last step of a full document review** (`### Understand the document`, step 7).
+- **On request** — "QA this", "check the references/definitions/exhibits", "did I break any cross-references?"
+- **After applying redlines**, before generating the send-out version (the numbering/cross-reference part of redline-output.md's pre-send verification is this check).
+
+### Instructions
+
+1. **Run the checker** over the draft (`.docx`, `.md`, or `.txt`):
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" "<file>" --json
+   ```
+   It emits `{summary, notes, findings}`. Each finding has a `type`, a `severity`, a `message`, and the paragraph/line `locations` where it occurs. Drop `--json` for a human-readable grouped report. On a `.docx` it checks the **accept-all** view (tracked insertions kept, deletions dropped) — the document as it will read once changes are accepted.
+
+2. **Severity tiers — surface accordingly:**
+   - `error` — high-confidence mechanical defect (**undefined_reference** — a cross-ref with no matching section/article; **missing_exhibit** — an exhibit/schedule referenced but not attached). Report these plainly; they are almost always real.
+   - `warning` — likely worth a look (**unused_definition**, **capitalization_drift** on a multi-word defined term, **party_name_drift**). Surface with light judgment.
+   - `info` — heuristic (**undefined_term** — a phrase capitalized like a defined term with no definition). Mention only if it looks substantive; these need your judgment.
+
+3. **Read the `notes`.** If the checker reports that section numbers are auto-generated (Word numbering rather than typed into the text), the cross-reference check was skipped to avoid false positives — say so, and offer to re-check after numbering is converted to text or changes are accepted.
+
+4. **This is a linter, not a lawyer.** It reports mechanical inconsistencies; you decide what matters and fold the real ones into the review. It does not read for legal substance — that is the rest of read + evaluate.
 
 ---
 

--- a/primitives/redline-output.md
+++ b/primitives/redline-output.md
@@ -126,13 +126,17 @@ The first-matched-run inheritance applies to all run-level formatting properties
 
 Before generating the final redline output via Word Compare:
 
-1. **Visually scan the modified `.docx`** for:
+1. **Run the mechanical QA checker first** — it does the tedious, deterministic part of the scan (cross-references to sections that no longer exist after renumbering, exhibits referenced but not attached, defined-term/party-name drift):
+   ```bash
+   python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" "<modified.docx>"
+   ```
+   Fix any `error`-severity findings (dangling cross-references especially — renumbering is exactly when these appear) before proceeding. See `read --qa`.
+2. **Visually scan the modified `.docx`** for what the checker can't judge:
    - Numbering duplicates and gaps
    - Orphan punctuation
-   - Cross-reference correctness
    - Section header bold/structure consistency
    - Counterparty placeholder fills (e.g., Partner name correctly inserted)
-2. **Open the post-Word-Compare redline in Word** and confirm:
+3. **Open the post-Word-Compare redline in Word** and confirm:
    - Strike and insert markings render where expected
    - No insertions are merged into adjacent text incorrectly
    - The flow reads naturally with tracked changes accepted

--- a/scripts/check_document.py
+++ b/scripts/check_document.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Deterministic mechanical QA for a contract draft (.docx / .md / .txt).
+
+Mechanical defects survive careful review because checking them by eye is
+tedious: a cross-reference to a section that was renumbered away, an exhibit
+named in the body but never attached, a defined term used once and never
+again, a party named three different ways. Live evidence in the roadmap: a
+counterparty audit contract named three entities that don't exist, caught
+only because a human happened to look. This script does the tedium
+deterministically so the reviewer's judgment is spent on judgment.
+
+It is a *linter*, not a lawyer: it reports mechanical inconsistencies with the
+paragraph they occur in, and counsel decides what matters. Precision is valued
+over recall — a noisy checker gets ignored — so heuristic findings (a
+capitalized phrase that looks like an undefined term) are tiered `info` and
+kept conservative, while only high-confidence mechanical defects (a dangling
+section reference, an unattached exhibit) are tiered `error`.
+
+Usage:
+  scripts/check_document.py <file> [--format docx|markdown|text|auto]
+                                   [--json] [--strict]
+
+Output (default): a grouped, human-readable findings report.
+Output (--json):  {file, format, summary, notes, findings:[...]} for a caller
+                  (the read primitive) to surface. Each finding is
+                  {type, severity, message, detail, locations:[...]}.
+
+Exit code: 0 on a successful analysis (whether or not findings were produced),
+1 on an I/O or input error, 2 on a usage error. `--strict` makes a run that
+produced any `error`-severity finding exit 3, for use in a gating pipeline.
+
+python-docx is imported lazily inside the .docx path only, so markdown/text QA
+runs on a machine that has no python-docx installed (virgin-hardware safe).
+"""
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+# --- Severity tiers -------------------------------------------------------
+ERROR = "error"      # high-confidence mechanical defect
+WARNING = "warning"  # likely issue worth a look
+INFO = "info"        # heuristic; needs judgment
+
+_SEV_RANK = {ERROR: 0, WARNING: 1, INFO: 2}
+_SEV_SYMBOL = {ERROR: "✗", WARNING: "⚠", INFO: "·"}
+
+
+# --- Text extraction ------------------------------------------------------
+def extract_docx_blocks(path):
+    """Return the accept-all text of each body paragraph, in document order.
+
+    "Accept-all" = inserted (tracked-change) text kept, deleted text dropped —
+    the document as it reads once changes are accepted, which is what a
+    reviewer QAs before it goes out. python-docx's Document() parser is
+    XXE-safe (it sets resolve_entities=False), so untrusted counterparty
+    .docx is safe to open here.
+    """
+    from docx import Document  # lazy: markdown/text QA needs no python-docx
+    from docx.oxml.ns import qn
+
+    doc = Document(str(path))
+    body = doc.element.body
+    del_tags = {qn("w:del"), qn("w:moveFrom")}
+    t_tag, tab_tag = qn("w:t"), qn("w:tab")
+    br_tag, cr_tag = qn("w:br"), qn("w:cr")
+
+    blocks = []
+    for p in body.iter(qn("w:p")):
+        parts = []
+        for r in p.iter(qn("w:r")):
+            # Skip runs inside a tracked deletion (their text is w:delText, but
+            # walk ancestors so a deleted normal run is dropped too).
+            anc, deleted = r.getparent(), False
+            while anc is not None and anc is not body:
+                if anc.tag in del_tags:
+                    deleted = True
+                    break
+                anc = anc.getparent()
+            if deleted:
+                continue
+            for child in r.iter():
+                if child.tag == t_tag:
+                    parts.append(child.text or "")
+                elif child.tag in (tab_tag, br_tag, cr_tag):
+                    parts.append(" ")
+        blocks.append("".join(parts).strip())
+    return blocks
+
+
+# Markdown atmospherics that carry no legal text: heading hashes, list
+# bullets, blockquote markers, and emphasis/formatting characters.
+_MD_LEAD = re.compile(r"^\s{0,3}(#{1,6}\s+|[-*+]\s+|>\s+|\d+[.)]\s+)")
+_MD_EMPH = re.compile(r"(\*\*|__|\*|_|`)")
+
+
+def extract_text_blocks(path, markdown):
+    """Return non-empty lines as blocks; strip markdown scaffolding if asked."""
+    raw = Path(path).read_text(encoding="utf-8", errors="replace")
+    blocks = []
+    for line in raw.splitlines():
+        s = line.rstrip()
+        if markdown:
+            s = _MD_LEAD.sub("", s)
+            s = _MD_EMPH.sub("", s)
+        s = s.strip()
+        if s:
+            blocks.append(s)
+    return blocks
+
+
+def detect_format(path):
+    ext = Path(path).suffix.lower()
+    if ext == ".docx":
+        return "docx"
+    if ext in (".md", ".markdown"):
+        return "markdown"
+    return "text"
+
+
+# --- Locating evidence ----------------------------------------------------
+def locate(blocks, needle, limit=3):
+    """1-based block numbers whose text contains needle (case-insensitive)."""
+    hits = []
+    low = needle.lower()
+    for i, b in enumerate(blocks, start=1):
+        if low in b.lower():
+            hits.append(i)
+            if len(hits) >= limit:
+                break
+    return hits
+
+
+def _loc_label(fmt, numbers):
+    if not numbers:
+        return []
+    unit = "¶" if fmt == "docx" else "line"
+    return [f"{unit} {n}" for n in numbers]
+
+
+# --- Section numbering ----------------------------------------------------
+# A heading's number when it is written in the text (manual numbering):
+#   "1. Definitions"  "8.3  Termination"  "Section 8.3"  "ARTICLE IV"
+# Bare numbers must carry trailing "." or ")" so dates/amounts/addresses do
+# not register as headings (mirrors extract_redlines.HEADING_NUM_RE).
+_HEADING_NUM = re.compile(
+    r"^\s*(?:Section\s+)?(\d+(?:\.\d+)*)[.)]\s+\S", re.IGNORECASE)
+_HEADING_ART = re.compile(r"^\s*ARTICLE\s+([IVXLC]+|\d+)\b", re.IGNORECASE)
+
+
+def collect_sections(blocks):
+    """Sets of section numbers and article numbers declared as headings.
+
+    For a dotted number every prefix is registered too, so a reference to
+    "Section 8" resolves when the document only spells out "8.1", "8.2".
+    """
+    sections, articles = set(), set()
+    for b in blocks:
+        m = _HEADING_NUM.match(b)
+        if m:
+            parts = m.group(1).split(".")
+            for k in range(1, len(parts) + 1):
+                sections.add(".".join(parts[:k]))
+        a = _HEADING_ART.match(b)
+        if a:
+            articles.add(a.group(1).upper())
+    return sections, articles
+
+
+_SECTION_REF = re.compile(
+    r"\bSections?\s+((?:\d+(?:\.\d+)*)(?:\s*(?:,|and|through|to|&|-|–|—)\s*\d+(?:\.\d+)*)*)",
+    re.IGNORECASE)
+_PILCROW_REF = re.compile(r"§{1,2}\s*((?:\d+(?:\.\d+)*)(?:\s*(?:,|and|&)\s*\d+(?:\.\d+)*)*)")
+_ARTICLE_REF = re.compile(r"\bArticle\s+([IVXLC]+|\d+)\b", re.IGNORECASE)
+_NUM_TOKEN = re.compile(r"\d+(?:\.\d+)*")
+
+
+def check_cross_references(blocks, findings, notes, fmt):
+    sections, articles = collect_sections(blocks)
+    full = "\n".join(blocks)
+
+    ref_secs, ref_arts = set(), set()
+    for m in _SECTION_REF.finditer(full):
+        ref_secs.update(_NUM_TOKEN.findall(m.group(1)))
+    for m in _PILCROW_REF.finditer(full):
+        ref_secs.update(_NUM_TOKEN.findall(m.group(1)))
+    for m in _ARTICLE_REF.finditer(full):
+        ref_arts.add(m.group(1).upper())
+
+    # Auto-numbering guard: if the body carries cross-references but almost no
+    # in-text section numbers, the numbering is Word-generated and lives in
+    # numbering.xml, not the text — resolving refs against an empty set would
+    # flag everything. Skip the check and say so instead of crying wolf.
+    if (ref_secs or ref_arts) and len(sections) < 2 and not articles:
+        notes.append(
+            "Section numbers appear to be auto-generated (Word numbering) rather "
+            "than typed into the text, so cross-references could not be resolved. "
+            "Accept changes / convert numbering to text, then re-run to check refs.")
+        return
+
+    for num in sorted(ref_secs, key=lambda s: [int(p) for p in s.split(".")]):
+        if num not in sections:
+            findings.append({
+                "type": "undefined_reference", "severity": ERROR,
+                "message": f'"Section {num}" is referenced but no Section {num} '
+                           f"appears in the document",
+                "detail": num,
+                "locations": _loc_label(fmt, locate(blocks, f"Section {num}")),
+            })
+    for art in sorted(ref_arts):
+        if art not in articles:
+            findings.append({
+                "type": "undefined_reference", "severity": ERROR,
+                "message": f'"Article {art}" is referenced but no Article {art} '
+                           f"appears in the document",
+                "detail": art,
+                "locations": _loc_label(fmt, locate(blocks, f"Article {art}")),
+            })
+
+
+# --- Exhibits / schedules -------------------------------------------------
+_ATTACH_KINDS = r"Exhibit|Schedule|Annex|Appendix|Attachment"
+_ATTACH_REF = re.compile(rf"\b({_ATTACH_KINDS})\s+([A-Z]|\d+)\b")
+# A heading is the marker anchored at the very start of a block (an attachment
+# cover line), which a mid-sentence reference is not.
+_ATTACH_HEADING = re.compile(rf"^\s*({_ATTACH_KINDS})\s+([A-Z]|\d+)\b", re.IGNORECASE)
+
+
+def check_exhibits(blocks, findings, fmt):
+    present = set()
+    for b in blocks:
+        m = _ATTACH_HEADING.match(b)
+        if m:
+            present.add((m.group(1).lower(), m.group(2).upper()))
+
+    referenced = {}  # (kind_lower, id) -> display kind
+    for b in blocks:
+        # Skip the heading line itself so an attachment isn't read as its own ref.
+        heading = _ATTACH_HEADING.match(b)
+        for m in _ATTACH_REF.finditer(b):
+            key = (m.group(1).lower(), m.group(2).upper())
+            if heading and m.start() == heading.start():
+                continue
+            referenced.setdefault(key, m.group(1))
+
+    for (kind_l, ident), disp in sorted(referenced.items()):
+        if (kind_l, ident) not in present:
+            findings.append({
+                "type": "missing_exhibit", "severity": ERROR,
+                "message": f"{disp} {ident} is referenced but no {disp} {ident} "
+                           f"is attached (no heading found for it)",
+                "detail": f"{disp} {ident}",
+                "locations": _loc_label(fmt, locate(blocks, f"{disp} {ident}")),
+            })
+
+
+# --- Defined terms --------------------------------------------------------
+_QUOTE = '["“”“”]'
+# `"Term" means ...` / `shall mean` / `has the meaning` / `refers to`
+_DEF_MEANS = re.compile(
+    rf'{_QUOTE}([A-Z][^"“”\n]{{0,80}}?){_QUOTE}\s+'
+    r'(?:means|shall\s+mean|will\s+mean|has\s+the\s+meaning|refers\s+to)\b')
+# Short-name parenthetical: (the "Term"), ("Term"), (each a "Term"),
+# (collectively, the "Term"). Capture the quoted phrase inside a parenthetical
+# that, once quoted terms and connective words are removed, is empty — i.e. a
+# pure definition, not a parenthetical that merely happens to quote something.
+_PAREN = re.compile(r"\(([^()\n]{0,120})\)")
+_QUOTED_TERM = re.compile(rf'{_QUOTE}([A-Z][^"“”\n]{{0,80}}?){_QUOTE}')
+_CONNECTIVES = {
+    "the", "a", "an", "each", "collectively", "individually", "together",
+    "referred", "to", "as", "or", "and", "being", "hereinafter", "this",
+}
+
+
+def collect_definitions(full):
+    """Return {term: def_site_count} for terms given an explicit definition."""
+    defs = {}
+    for m in _DEF_MEANS.finditer(full):
+        term = _norm_ws(m.group(1))
+        defs[term] = defs.get(term, 0) + 1
+    for m in _PAREN.finditer(full):
+        inner = m.group(1)
+        quoted = _QUOTED_TERM.findall(inner)
+        if not quoted:
+            continue
+        residue = _QUOTED_TERM.sub(" ", inner)
+        residue = re.sub(r"[^A-Za-z]+", " ", residue).strip().lower()
+        words = [w for w in residue.split() if w]
+        if all(w in _CONNECTIVES for w in words):
+            for term in quoted:
+                term = _norm_ws(term)
+                defs[term] = defs.get(term, 0) + 1
+    return defs
+
+
+def _norm_ws(s):
+    return re.sub(r"\s+", " ", s).strip()
+
+
+def _phrase_re(term, flags=0):
+    # Whole-phrase match with letter boundaries (so "Purpose" ≠ "Purposes").
+    return re.compile(r"(?<![A-Za-z])" + re.escape(term) + r"(?![A-Za-z])", flags)
+
+
+def check_definitions(blocks, findings, fmt):
+    full = "\n".join(blocks)
+    defs = collect_definitions(full)
+
+    for term, def_sites in sorted(defs.items()):
+        occurrences = _phrase_re(term).findall(full)
+        # Unused: the term appears only where it is being defined.
+        if len(occurrences) <= def_sites:
+            findings.append({
+                "type": "unused_definition", "severity": WARNING,
+                "message": f'"{term}" is defined but never used elsewhere in the '
+                           f"document",
+                "detail": term,
+                "locations": _loc_label(fmt, locate(blocks, term)),
+            })
+            continue
+        # Capitalization drift — multi-word terms only (single common words
+        # like "Term"/"Purpose" appear lowercased as ordinary English).
+        if len(term.split()) >= 2:
+            variants = set()
+            for m in _phrase_re(term, re.IGNORECASE).finditer(full):
+                surface = m.group(0)
+                if surface != term and surface != term.upper():
+                    variants.add(surface)
+            if variants:
+                shown = ", ".join(sorted(variants)[:3])
+                findings.append({
+                    "type": "capitalization_drift", "severity": WARNING,
+                    "message": f'Defined term "{term}" also appears with '
+                               f"inconsistent capitalization: {shown}",
+                    "detail": term,
+                    "locations": _loc_label(fmt, locate(blocks, sorted(variants)[0])),
+                })
+    return defs
+
+
+# --- Party-name drift -----------------------------------------------------
+_CORP_SUFFIX = (
+    r"Inc\.?|LLC|L\.L\.C\.|Corp\.?|Corporation|Company|Co\.?|Ltd\.?|Limited|"
+    r"LLP|L\.P\.|LP|GmbH|N\.A\.|N\.V\.|PLC|S\.A\.|S\.p\.A\.")
+_ENTITY = re.compile(
+    r"\b([A-Z][A-Za-z0-9&.'\-]*(?:\s+[A-Z][A-Za-z0-9&.'\-]*){0,5}?)\s+"
+    rf"({_CORP_SUFFIX})(?![A-Za-z])")
+
+
+def _entity_core(name):
+    return re.sub(r"[^a-z0-9]+", "", name.lower())
+
+
+def check_party_names(blocks, findings, fmt):
+    by_core = {}  # core -> {normalized display form -> display form}
+    for b in blocks:  # per-block: an entity name never spans a paragraph break
+        for m in _ENTITY.finditer(b):
+            name, suffix = m.group(1).strip(), m.group(2)
+            display = _norm_ws(f"{name} {suffix}")
+            norm = re.sub(r"[.,]", "", display.lower())
+            core = _entity_core(name)
+            if len(core) < 3:
+                continue
+            by_core.setdefault(core, {}).setdefault(norm, display)
+
+    for core, forms in sorted(by_core.items()):
+        if len(forms) >= 2:
+            shown = sorted(forms.values())
+            findings.append({
+                "type": "party_name_drift", "severity": WARNING,
+                "message": "Entity name is written inconsistently: "
+                           + " vs ".join(f'"{s}"' for s in shown),
+                "detail": core,
+                "locations": _loc_label(fmt, locate(blocks, shown[0])),
+            })
+
+
+# --- Possible undefined terms (heuristic, info tier) ----------------------
+# Two or more consecutive Title-Case words — the surface form of a defined
+# term. Kept deliberately narrow (no connective glue) to stay high-precision.
+_TITLE_PHRASE = re.compile(r"\b([A-Z][a-z][A-Za-z]*(?:\s+[A-Z][a-z][A-Za-z]*)+)\b")
+# Title-Case phrases that are common prose, not defined terms.
+_TITLE_STOP = {
+    "united states", "new york", "united kingdom", "supreme court",
+    "effective date",  # usually defined; if defined it's excluded anyway
+}
+
+
+def _sentence_initial(full, start):
+    j = start - 1
+    while j >= 0 and full[j] in " \t\"'“”‘’([":
+        j -= 1
+    return j < 0 or full[j] in ".!?\n:•"
+
+
+def check_undefined_terms(blocks, findings, fmt, defs):
+    defined_lower = {t.lower() for t in defs}
+
+    counts = {}  # phrase -> [total, non_sentence_initial]
+    for b in blocks:  # per-block: a Title-Case phrase never spans a paragraph
+        for m in _TITLE_PHRASE.finditer(b):
+            phrase = _norm_ws(m.group(1))
+            rec = counts.setdefault(phrase, [0, 0])
+            rec[0] += 1
+            if not _sentence_initial(b, m.start()):
+                rec[1] += 1
+
+    for phrase, (total, non_si) in sorted(counts.items()):
+        low = phrase.lower()
+        if low in defined_lower or low in _TITLE_STOP:
+            continue
+        # Skip if it's a substring/superstring of a defined term (a fragment of
+        # one), or a case-variant already flagged as drift.
+        if any(low in t or t in low for t in defined_lower):
+            continue
+        # Conservative gate: recurs, and mostly used mid-sentence (so it isn't
+        # just a sentence-initial proper noun or a heading).
+        if total < 2 or non_si < 2:
+            continue
+        findings.append({
+            "type": "undefined_term", "severity": INFO,
+            "message": f'"{phrase}" is capitalized like a defined term but has no '
+                       f"definition — confirm it is intended or define it",
+            "detail": phrase,
+            "locations": _loc_label(fmt, locate(blocks, phrase)),
+        })
+
+
+# --- Orchestration --------------------------------------------------------
+def analyze(path, fmt):
+    if fmt == "docx":
+        blocks = extract_docx_blocks(path)
+    else:
+        blocks = extract_text_blocks(path, markdown=(fmt == "markdown"))
+
+    findings, notes = [], []
+    check_cross_references(blocks, findings, notes, fmt)
+    check_exhibits(blocks, findings, fmt)
+    defs = check_definitions(blocks, findings, fmt)
+    check_party_names(blocks, findings, fmt)
+    check_undefined_terms(blocks, findings, fmt, defs)
+
+    findings.sort(key=lambda f: (_SEV_RANK[f["severity"]],
+                                  _TYPE_HEADING.get(f["type"], f["type"]),
+                                  f["type"], f["detail"]))
+    summary = {ERROR: 0, WARNING: 0, INFO: 0}
+    for f in findings:
+        summary[f["severity"]] += 1
+    summary["total"] = len(findings)
+    return {"file": str(path), "format": fmt, "summary": summary,
+            "notes": notes, "findings": findings}
+
+
+_TYPE_HEADING = {
+    "undefined_reference": "Cross-references",
+    "missing_exhibit": "Exhibits & schedules",
+    "unused_definition": "Defined terms",
+    "capitalization_drift": "Defined terms",
+    "undefined_term": "Possible undefined terms",
+    "party_name_drift": "Party & entity names",
+}
+
+
+def render(report):
+    lines = []
+    s = report["summary"]
+    lines.append(f"Document QA — {report['file']}")
+    if s["total"] == 0:
+        lines.append("No mechanical issues found.")
+    else:
+        lines.append(
+            f"{s['total']} finding(s): {s[ERROR]} error, {s[WARNING]} warning, "
+            f"{s[INFO]} info")
+    for note in report["notes"]:
+        lines.append(f"  note: {note}")
+
+    last_heading = None
+    for f in report["findings"]:
+        heading = _TYPE_HEADING.get(f["type"], f["type"])
+        if heading != last_heading:
+            lines.append("")
+            lines.append(heading.upper())
+            last_heading = heading
+        loc = f"  [{', '.join(f['locations'])}]" if f["locations"] else ""
+        lines.append(f"  {_SEV_SYMBOL[f['severity']]} {f['message']}{loc}")
+    return "\n".join(lines)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Deterministic mechanical QA for a contract draft.")
+    ap.add_argument("input", type=Path)
+    ap.add_argument("--format", choices=["docx", "markdown", "text", "auto"],
+                    default="auto")
+    ap.add_argument("--json", action="store_true",
+                    help="emit machine-readable JSON instead of a report")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 3 if any error-severity finding is produced")
+    args = ap.parse_args()
+
+    if not args.input.exists():
+        print(f"File not found: {args.input}", file=sys.stderr)
+        return 1
+
+    fmt = detect_format(args.input) if args.format == "auto" else args.format
+    try:
+        report = analyze(args.input, fmt)
+    except ImportError:
+        print("python-docx is required to read .docx files. Install it, or "
+              "convert the document to markdown/text first.", file=sys.stderr)
+        return 1
+    except Exception as exc:  # noqa: BLE001 — report cleanly, never traceback
+        print(f"Could not analyze {args.input}: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, ensure_ascii=False))
+    else:
+        print(render(report))
+
+    if args.strict and report["summary"][ERROR]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_document.py
+++ b/scripts/check_document.py
@@ -141,12 +141,22 @@ def _loc_label(fmt, numbers):
 
 
 # --- Section numbering ----------------------------------------------------
-# A heading's number when it is written in the text (manual numbering):
-#   "1. Definitions"  "8.3  Termination"  "Section 8.3"  "ARTICLE IV"
-# Bare numbers must carry trailing "." or ")" so dates/amounts/addresses do
-# not register as headings (mirrors extract_redlines.HEADING_NUM_RE).
+# A heading's number when it is written in the text (manual numbering). Two
+# accepted forms:
+#   - any number with a trailing "." or ")":     "1. Definitions"  "1) Scope"
+#   - a *dotted* decimal (N.N, N.N.N ...) followed by a Capitalized word, with
+#     no trailing punctuation:                   "3.2 Late Fees"  "8.3  Termination"
+# A bare integer must carry the trailing "." or ")" so dates/amounts/addresses
+# ("8 million", "5 Termination Road") do not register as headings; a dotted
+# decimal at block start is unambiguous enough to stand on its own, and the
+# required Capital after it keeps amount-sentences ("3.5 percent per annum")
+# from registering. (Mirrors extract_redlines.HEADING_NUM_RE, widened for the
+# common "N.N Heading" subsection style that omits the trailing period.)
 _HEADING_NUM = re.compile(
-    r"^\s*(?:Section\s+)?(\d+(?:\.\d+)*)[.)]\s+\S", re.IGNORECASE)
+    r"^\s*(?:Section\s+)?(?:"
+    r"(\d+(?:\.\d+)*)[.)]\s+\S"            # trailing "." or ")": permissive
+    r"|(\d+(?:\.\d+)+)\s+(?-i:[A-Z])"      # dotted, no punctuation: needs a Capital
+    r")", re.IGNORECASE)
 _HEADING_ART = re.compile(r"^\s*ARTICLE\s+([IVXLC]+|\d+)\b", re.IGNORECASE)
 
 
@@ -160,7 +170,7 @@ def collect_sections(blocks):
     for b in blocks:
         m = _HEADING_NUM.match(b)
         if m:
-            parts = m.group(1).split(".")
+            parts = (m.group(1) or m.group(2)).split(".")
             for k in range(1, len(parts) + 1):
                 sections.add(".".join(parts[:k]))
         a = _HEADING_ART.match(b)

--- a/skills/counsel/SKILL.md
+++ b/skills/counsel/SKILL.md
@@ -34,6 +34,7 @@ Match the user's request to primitives. This is guidance, not rigid rules — us
 | "What did we agree with [counterparty]?" | research --entity |
 | "Draft a response to [specific issue]" | research --entity --library → draft --counter-language |
 | "Summarize this for [person/team]" | read (if needed) → draft --summary --for [audience] |
+| "QA this / check the references, definitions, exhibits" | read --qa (deterministic mechanical checker) |
 | "Create a redline" | read → research → evaluate → draft --redline → remember --matter |
 | "They sent back a redline / what did they change?" | read --redline → research → evaluate → draft --counter-language → remember --matter |
 | "Is this [document] compliant with [regulation]?" | read → research --law → evaluate --compliance |
@@ -322,6 +323,7 @@ Plugin (methodology + tooling):
     import_reference.sh                        # Import third-party material into practice/reference/ (see remember --reference)
     extract_redlines.py                        # Structured tracked-changes + comments extraction (see read --redline)
     diff_rounds.py                             # Round-over-round redline comparison: ACCEPTED/REVERTED/MODIFIED/NEW (see read --redline)
+    check_document.py                          # Deterministic mechanical QA: dangling cross-refs, unattached exhibits, unused/undefined terms, party-name drift (see read --qa)
 
 User's vault (all knowledge — discovered via config + Knowledge Base Search):
   {legal_root}/


### PR DESCRIPTION
## What

Adds `scripts/check_document.py` — a **deterministic** mechanical-QA linter over a contract draft (`.docx` / `.md` / `.txt`), surfaced as a `read --qa` mode. Implements founder-approved roadmap #4 (cou-50, spawned from cou-36) — self-described "the highest want-it-tomorrow item."

It catches the tedious defects that survive a careful read:

| Type | Tier | What it catches |
|---|---|---|
| `undefined_reference` | error | A cross-ref ("Section 7.1", "Article IV") with no matching heading |
| `missing_exhibit` | error | An exhibit/schedule/annex referenced but never attached |
| `unused_definition` | warning | A defined term used only where it's defined |
| `capitalization_drift` | warning | A multi-word defined term also written lowercased |
| `party_name_drift` | warning | One entity written multiple ways (Acme Corp. vs Acme Corporation) |
| `undefined_term` | info | A phrase capitalized like a defined term, but undefined |

Live evidence for the need (roadmap): a counterparty audit contract named three entities that don't exist — caught only because a human happened to look.

## Design choices (precision over recall — a noisy linter gets ignored)

- Only the two high-confidence checks are **error**-tier; heuristics are **info**-tier and explicitly routed to counsel judgment.
- **Word auto-numbering guard**: if section numbers live in `numbering.xml` rather than the text, the cross-ref check is *skipped with a note* instead of flagging every reference.
- Drift is checked on **multi-word** terms only (single common words like "Term"/"Purpose" appear lowercased as ordinary English).
- On a `.docx` it checks the **accept-all** view (tracked insertions kept, deletions dropped) — the document as it reads once changes are accepted.
- **No new pip deps** (virgin-hardware safe): stdlib + python-docx, imported **lazily** so markdown/text QA runs on a machine without python-docx. python-docx's `Document()` parser is XXE-safe.

## Surfaced as `read --qa`

- Auto-run as the last step of a full document review (`primitives/read.md` step 7 + new `## --qa` section).
- Wired into `primitives/redline-output.md` pre-send verification (renumbering is exactly when dangling cross-refs appear).
- Intent row + scripts index in `skills/counsel/SKILL.md`.

## What to verify / AC

- [ ] `error`-tier findings (dangling cross-ref, unattached exhibit) are high-confidence and read plainly.
- [ ] No false-positive storm on real drafts — auto-numbering guard + multi-word drift + info-tier heuristics keep it conservative.
- [ ] `read --qa` mode reads correctly and the auto-run-on-full-review wiring is appropriately placed.
- [ ] Accept-all extraction: tracked deletions do not surface as findings (covered by test).

## Tests / CI

- New `browse/src/check-document.test.ts` (6 tests): markdown path runs everywhere; docx path gated on python-docx and proves accept-all ignores tracked deletions.
- Full local CI green: typecheck, `bun test` (57 pass), eval self-test, law frontmatter, knowledge lint + version sync, browse-reference drift, `py_compile`, `bash -n`.

No outward door. Demo/tests use synthetic content only.