### PR TITLE
Deadline docket v1: deadlines frontmatter + /counsel-os:docket sweep (cou-48)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ You describe what you need in plain language; the `/counsel-os:counsel` skill au
 - **Ingest a returned markup** → extracts every tracked change and comment into a change-by-change assessment.
 - **Recall and remember** → "what did we agree with Acme?"; counsel proposes knowledge updates as it works, and you approve every one.
 - **Draft** memos, policies, notices, and correspondence in your voice.
+- **Stay ahead of dates** → "what's due in the next 60 days?"; `/counsel-os:docket` sweeps every matter for renewal windows, notice deadlines, and objection periods.
 - **Maintain** your practice with `/counsel-os:retro` (analytics), `/counsel-os:doctor` (health check), and `/counsel-os:update` (content sync).
 
 Everything is grounded in a vault you own: plain markdown files you can read, edit, and version-control.
@@ -227,6 +228,19 @@ Analyzes your matter history and produces insights, calibrated to the shape of y
 - **Low-volume, heterogeneous practices** (most solo and in-house work) skip the statistics and center on **harvesting promotable knowledge**: sweeping matter and entity files for deal-archetype playbooks, regulatory-posture notes, and proven clause language that has outgrown its matter and belongs in `practice/`.
 
 Run quarterly, or every ~10 closed matters, to calibrate your practice.
+
+#### Docket: deadline sweep
+
+```
+/counsel-os:docket
+```
+
+Read-only sweep of every matter for time-based obligations — auto-renewal windows, termination-notice deadlines, sub-processor objection periods, filing and milestone dates. It reads the `deadlines:` frontmatter that `read` proposes and `remember` records as it works through your contracts, then reports one table: **overdue**, **due within a window** (60 days by default; ask for any horizon), and **upcoming**. Malformed dates are surfaced loudly rather than dropped — a silently missed date is the exact failure this exists to prevent. Closed matters still surface (a renewal window often outlives the deal). It's a reporter: it never writes to your vault. Not a calendar sync — a reliable local sweep that runs over your own markdown, offline.
+
+```
+> /counsel-os:docket
+> What's due in the next 90 days?
+```
 
 #### Update: pull latest content
 

--- a/browse/src/docket-sweep.test.ts
+++ b/browse/src/docket-sweep.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, test } from 'bun:test';
+import { execFileSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const repoRoot = path.resolve(import.meta.dir, '../..');
+const script = path.join(repoRoot, 'scripts', 'docket_sweep.py');
+
+function hasPython(): boolean {
+  try {
+    execFileSync('python3', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const docketTest = hasPython() ? test : test.skip;
+
+function runJson(mattersDir: string, extra: string[] = []) {
+  const out = execFileSync(
+    'python3',
+    [script, mattersDir, '--today', '2026-07-11', '--window', '60', '--format', 'json', ...extra],
+    { encoding: 'utf8' },
+  );
+  return JSON.parse(out);
+}
+
+function withMatters(files: Record<string, string>, fn: (dir: string) => void) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'counsel-docket-'));
+  try {
+    for (const [name, body] of Object.entries(files)) {
+      fs.writeFileSync(path.join(dir, name), body);
+    }
+    fn(dir);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('docket_sweep.py', () => {
+  docketTest('classifies overdue / due-soon / upcoming and hides done', () => {
+    withMatters(
+      {
+        // 2-space indented list style
+        'acme.md': `---
+counsel-os-type: matter
+matter-id: 2026-05-acme-msa
+stage: working
+counterparty: Acme Corp
+deadlines:
+  - date: 2026-06-01
+    action: "auto-renewal notice deadline"
+    type: renewal
+    source: "MSA §9.2"
+  - date: 2026-07-20
+    action: "objection window closes"
+  - date: 2026-12-01
+    action: "annual review"
+  - date: 2026-05-15
+    action: "already handled"
+    done: true
+---
+# Acme
+`,
+      },
+      (dir) => {
+        const result = runJson(dir);
+        expect(result.counts).toEqual({
+          overdue: 1,
+          due_soon: 1,
+          upcoming: 1,
+          malformed: 0,
+          done_hidden: 1,
+        });
+        const overdue = result.deadlines.find((d: any) => d.status === 'overdue');
+        expect(overdue.action).toBe('auto-renewal notice deadline');
+        expect(overdue.source).toBe('MSA §9.2');
+        expect(overdue.days_until).toBe(-40);
+      },
+    );
+  });
+
+  docketTest('surfaces malformed dates instead of dropping them', () => {
+    withMatters(
+      {
+        // column-0 list style, one broken date
+        'globex.md': `---
+counsel-os-type: matter
+matter-id: 2026-04-globex-nda
+stage: closed
+counterparty: Globex
+deadlines:
+- date: not-a-date
+  action: "broken entry"
+- date: 2026-08-30
+  action: "confidentiality survival check"
+---
+# Globex
+`,
+      },
+      (dir) => {
+        const result = runJson(dir);
+        expect(result.counts.malformed).toBe(1);
+        expect(result.malformed[0].matter_id).toBe('2026-04-globex-nda');
+        expect(result.malformed[0].reason).toContain('not-a-date');
+        // closed-matter future deadline still surfaces (renewal outlives the deal)
+        const survival = result.deadlines.find((d: any) => d.action === 'confidentiality survival check');
+        expect(survival.status).toBe('due_soon');
+        expect(survival.stage).toBe('closed');
+      },
+    );
+  });
+
+  docketTest('ignores non-matter files and files without a deadlines block', () => {
+    withMatters(
+      {
+        'note.md': `---
+counsel-os-type: memory-patterns
+---
+not a matter
+`,
+        'bare.md': `---
+counsel-os-type: matter
+matter-id: 2026-01-bare
+stage: intake
+---
+# no deadlines
+`,
+      },
+      (dir) => {
+        const result = runJson(dir);
+        expect(result.deadlines).toHaveLength(0);
+        expect(result.malformed).toHaveLength(0);
+      },
+    );
+  });
+
+  docketTest('--include-done reveals satisfied deadlines', () => {
+    withMatters(
+      {
+        'm.md': `---
+counsel-os-type: matter
+matter-id: 2026-02-m
+stage: working
+deadlines:
+  - date: 2026-05-15
+    action: "handled"
+    done: true
+---
+`,
+      },
+      (dir) => {
+        expect(runJson(dir).deadlines).toHaveLength(0);
+        expect(runJson(dir, ['--include-done']).deadlines).toHaveLength(1);
+      },
+    );
+  });
+});

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -7,6 +7,7 @@
 | What | Command | When |
 |------|---------|------|
 | Pull plugin + content updates | `/counsel-os:update` | Weekly, or when notified of a release |
+| Deadline sweep | `/counsel-os:docket` | Weekly, and before you go heads-down on other work |
 | Health check | `/counsel-os:doctor` | Monthly, and after every update |
 | Consistency spot-check | `/counsel-os:doctor --consistency` | Before significant negotiations, and after law refreshes or manual standards edits |
 | Practice analytics + knowledge harvest | `/counsel-os:retro` | Quarterly, or every ~10 closed matters |
@@ -17,6 +18,7 @@ Notes on the loop:
 
 - `update` is the only channel for plugin-managed law content and methodology; it never overwrites your practice files without approval.
 - `doctor` is read-only — it reports one ✅/⚠️/❌ table with a fix command per finding, so it is safe to run on a schedule.
+- `docket` is read-only too, and populated as you work: `read` proposes `deadlines:` entries when it extracts dates from a contract and `remember` records them, so the sweep is only as complete as the dates you've captured. It classifies overdue / due-soon / upcoming and surfaces malformed dates loudly rather than dropping them.
 - `retro` needs volume to be useful; below ~10 matters its statistics are noise, but its knowledge harvest (Step 6) is valuable at any volume.
 - Run `doctor` right after `update`: a failed or half-applied update is exactly what it catches.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -4,13 +4,13 @@ Forward-looking ideas, not commitments. Each entry records the observed gap that
 
 Counsel OS is single-lawyer by decision (2026-06-11): a multi-lawyer design was drafted, reviewed, and declined — do not reintroduce per-person assignment fields or shared-vault assumptions here.
 
-## 1. Deadline docket — ON HOLD (2026-06-12)
+## 1. Deadline docket — SHIPPED (v1, 2026-07-12)
 
-**Gap:** Matter files track `Next Action` but nothing time-based. Legal practice runs on dates — auto-renewal windows, termination notice deadlines, sub-processor objection periods, discovery response dates. Nothing in the system warns when a window opens or closes.
+**Gap:** Matter files tracked `Next Action` but nothing time-based. Legal practice runs on dates — auto-renewal windows, termination notice deadlines, sub-processor objection periods, discovery response dates. Nothing warned when a window opened or closed.
 
-**Shape:** `remember` extracts obligations-with-dates into matter/entity frontmatter (e.g. `deadlines: [{date: 2026-07-15, action: "renewal notice due", source: "MSA §9.2"}]`) at the moments deadlines become known — contract execution, matter close, returned redlines. A `/counsel-os:docket` skill sweeps the vault and reports what's due, overdue, and upcoming. Read-only sweep like doctor.
+**Shipped (cou-48):** a `deadlines:` frontmatter convention on matter files (`{date, action, type, source}`), `read` proposing entries when it extracts key dates from a contract and `remember` recording them, and a read-only `/counsel-os:docket` sweep (`scripts/docket_sweep.py`) that classifies every deadline as overdue / due-soon (default 60-day window) / upcoming and surfaces malformed dates loudly. Like doctor, it changes nothing.
 
-**Hold reason:** users already run their own task systems (Obsidian Tasks, other Claude skills); any design must coexist with that stack rather than emit into it unilaterally. An emit-as-Obsidian-Tasks-syntax design was proposed and parked. Needs more thought before building; revisit only when the user raises it.
+**How the hold was resolved:** the hold reason was task-stack *coexistence* — users already run their own task systems (Obsidian Tasks, other Claude skills), and an emit-as-Obsidian-Tasks-syntax design was parked as too unilateral. The shipped v1 coexists by *not touching* any external task system: it is a self-contained read-only sweep over the vault's own markdown, emitting into nothing. Deliberately **not** a calendar sync — a reliable local sweep beats a flaky integration. A future iteration could optionally emit into a user-chosen task system, but only opt-in.
 
 ## 2. Reference distillation
 

--- a/primitives/read.md
+++ b/primitives/read.md
@@ -86,7 +86,7 @@ After extracting the text, identify:
 
 3. **Clause inventory.** What provisions are in the document? Map each section to a clause type (limitation of liability, indemnification, confidentiality, IP ownership, termination, governing law, etc.). This inventory is what evaluate uses to work through the document.
 
-4. **Key dates.** Effective date, term/expiration, renewal dates, notice deadlines, milestone dates.
+4. **Key dates.** Effective date, term/expiration, renewal dates, notice deadlines, sub-processor objection periods, filing and milestone dates. For any date that carries a *future obligation or window* (an auto-renewal cutoff, a termination-notice deadline, an objection period, a filing date — not a bare effective date), propose a `deadlines:` frontmatter entry for the matter file so the `/counsel-os:docket` sweep can track it. Compute the actual calendar date where the clause states a relative window (e.g. "90 days before the anniversary of the Effective Date" → the concrete `YYYY-MM-DD`), and cite the source clause. `remember --matter` persists these (format in `primitives/remember.md`); surface them to the user as you capture them. Missing a date is the practice's #1 malpractice vector — err toward capturing.
 
 5. **Commercial terms.** Fees, payment terms, pricing structure, SLAs, deliverables, acceptance criteria.
 

--- a/primitives/remember.md
+++ b/primitives/remember.md
@@ -86,6 +86,11 @@ stage: intake
 counterparty: {name}
 created: {YYYY-MM-DD}
 updated: {YYYY-MM-DD}
+deadlines:                                     # optional — omit if none known yet
+  - date: {YYYY-MM-DD}
+    action: {what is due}
+    type: {renewal|notice|objection|milestone|filing}   # optional
+    source: {clause the date comes from, e.g. "MSA §9.2"}  # optional
 ---
 
 # {Counterparty} — {Description}
@@ -143,6 +148,31 @@ When updating, preserve existing content and append:
 - Update ## Next Action
 - Add new outputs to ## Generated Outputs
 - ALWAYS set `updated:` to today in frontmatter on every write — staleness detection and retro turnaround analytics depend on it. Update `stage` when it advanced.
+
+### Deadlines
+
+Legal practice runs on dates — auto-renewal windows, termination-notice deadlines, sub-processor objection periods, filing and milestone dates. Missing one is the practice's #1 malpractice vector. Capture time-based obligations as structured `deadlines:` frontmatter on the matter file so the `/counsel-os:docket` sweep can report what's due across all matters.
+
+**When to record.** Whenever a date-bearing obligation becomes known — contract execution, a returned redline, matter intake, or when `read` extracts key dates from a document (see `primitives/read.md`). `read` proposes the entries; you persist them here as part of the normal `--matter` write. Don't ask separately — fold them into the matter update, but do tell the user which deadlines you captured.
+
+**Format.** Each entry is a list item under `deadlines:`:
+
+```yaml
+deadlines:
+  - date: 2026-07-15          # required, YYYY-MM-DD
+    action: "renewal notice due"
+    type: renewal              # optional: renewal | notice | objection | milestone | filing
+    source: "MSA §9.2"         # optional: the clause the date comes from
+    done: false                # optional: true drops it from the sweep, kept for the audit trail
+```
+
+Rules:
+- `date` must be `YYYY-MM-DD`. A missing or malformed date is surfaced by the sweep as `MALFORMED`, never silently dropped — so get it right.
+- **Don't delete a satisfied deadline** — set `done: true`. The record stays for the audit trail and drops out of the default sweep.
+- **A deadline can outlive its matter.** Renewal windows and confidentiality-survival dates often fall after a matter closes, so keep them on the (closed) matter file; the sweep still surfaces them, tagged `[closed]`.
+- Deadlines belong on the **matter** file (single-lawyer, matter-scoped by design). Do not add per-person assignment or shared-vault fields.
+
+Docket is a read-only *reporter*; recording and updating deadlines is always this primitive's job, and always at the user's confirmation for anything beyond the automatic matter write.
 
 ### Version control on close
 

--- a/scripts/docket_sweep.py
+++ b/scripts/docket_sweep.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""Deadline docket sweep — read-only.
+
+Walks a matters directory, reads the `deadlines:` frontmatter block on every
+`counsel-os-type: matter` file, and classifies each entry as overdue, due
+within a window, or upcoming. Date arithmetic across the vault is a
+deterministic mechanical task, so it lives here (the /counsel-os:docket skill
+formats the result) rather than being eyeballed by the model — a missed date
+is the practice's #1 malpractice vector.
+
+Stdlib only — no PyYAML, no python-docx, no third-party deps (there is no
+Python requirements manifest; a new dep would ImportError on a fresh install).
+The deadline schema is fixed and simple, so a focused frontmatter parser is
+enough and stays deterministic.
+
+Deadline frontmatter convention (see primitives/remember.md):
+
+    deadlines:
+      - date: 2026-07-15
+        action: "renewal notice due"
+        type: renewal          # optional: renewal | notice | objection | milestone | filing
+        source: "MSA §9.2"     # optional: the clause the date comes from
+        done: false            # optional: true/done drops it from the sweep (kept for audit)
+
+Usage:
+    docket_sweep.py <matters_dir> [--window N] [--today YYYY-MM-DD]
+                                  [--format text|json] [--include-done]
+"""
+
+import argparse
+import json
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*(?:\n|$)", re.DOTALL)
+TOP_KEY_RE = re.compile(r"^([A-Za-z0-9_-]+):\s*(.*)$")
+DONE_VALUES = {"true", "yes", "done", "1", "satisfied", "complete", "completed"}
+ENTRY_KEYS = {"date", "action", "type", "source", "done", "status"}
+
+
+def _unquote(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def extract_frontmatter(text):
+    m = FRONTMATTER_RE.match(text)
+    return m.group(1) if m else None
+
+
+def scalar_fields(frontmatter):
+    """Top-level scalar keys (stage, matter-id, counterparty, ...)."""
+    fields = {}
+    for line in frontmatter.splitlines():
+        if line.startswith((" ", "\t", "-")):
+            continue
+        m = TOP_KEY_RE.match(line)
+        if m and m.group(2) != "":
+            fields[m.group(1)] = _unquote(m.group(2))
+    return fields
+
+
+def parse_deadlines(frontmatter):
+    """Parse the `deadlines:` list-of-maps block. Returns list of dicts."""
+    lines = frontmatter.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(r"^deadlines:\s*(.*)$", line):
+            start = i
+            break
+    if start is None:
+        return []
+
+    # Collect the block: blank lines, indented lines, and column-0 list items
+    # ("- ...") all belong; the next top-level key (e.g. "stage:") ends it.
+    block = []
+    for line in lines[start + 1:]:
+        if line.strip() == "":
+            block.append(line)
+            continue
+        if line.startswith((" ", "\t")) or line.lstrip().startswith("-"):
+            block.append(line)
+            continue
+        break
+
+    entries = []
+    current = None
+    for line in block:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("-"):
+            if current is not None:
+                entries.append(current)
+            current = {}
+            rest = stripped[1:].strip()  # first field may follow the dash
+            if rest:
+                _apply_field(current, rest)
+        elif current is not None:
+            _apply_field(current, stripped)
+    if current is not None:
+        entries.append(current)
+    return entries
+
+
+def _apply_field(entry, text):
+    m = TOP_KEY_RE.match(text)
+    if not m:
+        return
+    key, value = m.group(1).lower(), _unquote(m.group(2))
+    if key in ENTRY_KEYS:
+        entry[key] = value
+
+
+def is_done(entry):
+    if str(entry.get("done", "")).strip().lower() in DONE_VALUES:
+        return True
+    if str(entry.get("status", "")).strip().lower() in DONE_VALUES:
+        return True
+    return False
+
+
+def classify(days_until, window):
+    if days_until < 0:
+        return "overdue"
+    if days_until <= window:
+        return "due_soon"
+    return "upcoming"
+
+
+def sweep(matters_dir, today, window, include_done):
+    deadlines = []
+    malformed = []
+    skipped_done = 0
+
+    for path in sorted(matters_dir.rglob("*.md")):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        frontmatter = extract_frontmatter(text)
+        if frontmatter is None:
+            continue
+        fields = scalar_fields(frontmatter)
+        if fields.get("counsel-os-type") != "matter":
+            continue
+
+        matter_id = fields.get("matter-id") or path.stem
+        stage = fields.get("stage", "unknown")
+        counterparty = fields.get("counterparty", "")
+
+        for entry in parse_deadlines(frontmatter):
+            base = {
+                "matter_id": matter_id,
+                "stage": stage,
+                "counterparty": counterparty,
+                "file": str(path),
+                "action": entry.get("action", ""),
+                "type": entry.get("type", ""),
+                "source": entry.get("source", ""),
+                "date": entry.get("date", ""),
+            }
+            if is_done(entry) and not include_done:
+                skipped_done += 1
+                continue
+            raw_date = entry.get("date", "").strip()
+            try:
+                due = date.fromisoformat(raw_date)
+            except ValueError:
+                base["reason"] = (
+                    f"unparseable date {raw_date!r} (want YYYY-MM-DD)"
+                    if raw_date
+                    else "missing date"
+                )
+                malformed.append(base)
+                continue
+            days_until = (due - today).days
+            deadlines.append(
+                {**base, "days_until": days_until, "status": classify(days_until, window)}
+            )
+
+    deadlines.sort(key=lambda d: (d["date"], d["matter_id"]))
+    malformed.sort(key=lambda d: d["matter_id"])
+    return deadlines, malformed, skipped_done
+
+
+def render_text(deadlines, malformed, skipped_done, today, window):
+    out = []
+    groups = [
+        ("overdue", "OVERDUE"),
+        ("due_soon", f"DUE WITHIN {window} DAYS"),
+        ("upcoming", "UPCOMING (beyond window)"),
+    ]
+    out.append(f"Deadline docket — as of {today.isoformat()} (window: {window} days)")
+    out.append("")
+    any_shown = False
+    for key, heading in groups:
+        rows = [d for d in deadlines if d["status"] == key]
+        if not rows:
+            continue
+        any_shown = True
+        out.append(f"## {heading} ({len(rows)})")
+        for d in rows:
+            when = _relative(d["days_until"])
+            stage_tag = "" if d["stage"] in ("working", "intake", "unknown") else f" [{d['stage']}]"
+            cp = f" — {d['counterparty']}" if d["counterparty"] else ""
+            src = f"  ({d['source']})" if d["source"] else ""
+            action = d["action"] or "(no action recorded)"
+            out.append(f"  {d['date']}  {when:>12}  {action}{src}")
+            out.append(f"                            {d['matter_id']}{cp}{stage_tag}")
+        out.append("")
+    if not any_shown:
+        out.append("No open deadlines in range. (Nothing overdue or due within the window.)")
+        out.append("")
+    if malformed:
+        out.append(f"## MALFORMED ({len(malformed)}) — fix these; they were not classified")
+        for d in malformed:
+            out.append(f"  {d['matter_id']}: {d['reason']}  ({d['file']})")
+        out.append("")
+    if skipped_done:
+        out.append(f"({skipped_done} deadline(s) marked done and hidden — pass --include-done to show.)")
+    return "\n".join(out).rstrip() + "\n"
+
+
+def _relative(days):
+    if days < 0:
+        n = -days
+        return f"{n}d overdue" if n != 1 else "1d overdue"
+    if days == 0:
+        return "today"
+    return f"in {days}d"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Deadline docket sweep (read-only).")
+    parser.add_argument("matters_dir", help="Directory holding matter markdown files")
+    parser.add_argument("--window", type=int, default=60, help="Look-ahead window in days (default 60)")
+    parser.add_argument("--today", help="Override today's date (YYYY-MM-DD), for testing")
+    parser.add_argument("--format", choices=["text", "json"], default="text")
+    parser.add_argument("--include-done", action="store_true", help="Show deadlines marked done")
+    args = parser.parse_args(argv)
+
+    matters_dir = Path(args.matters_dir)
+    if not matters_dir.is_dir():
+        print(f"error: matters directory not found: {matters_dir}", file=sys.stderr)
+        return 2
+
+    if args.today:
+        try:
+            today = date.fromisoformat(args.today)
+        except ValueError:
+            print(f"error: --today must be YYYY-MM-DD, got {args.today!r}", file=sys.stderr)
+            return 2
+    else:
+        today = date.today()
+
+    deadlines, malformed, skipped_done = sweep(matters_dir, today, args.window, args.include_done)
+
+    if args.format == "json":
+        print(
+            json.dumps(
+                {
+                    "today": today.isoformat(),
+                    "window": args.window,
+                    "counts": {
+                        "overdue": sum(1 for d in deadlines if d["status"] == "overdue"),
+                        "due_soon": sum(1 for d in deadlines if d["status"] == "due_soon"),
+                        "upcoming": sum(1 for d in deadlines if d["status"] == "upcoming"),
+                        "malformed": len(malformed),
+                        "done_hidden": skipped_done,
+                    },
+                    "deadlines": deadlines,
+                    "malformed": malformed,
+                },
+                indent=2,
+            )
+        )
+    else:
+        sys.stdout.write(render_text(deadlines, malformed, skipped_done, today, args.window))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/counsel/SKILL.md
+++ b/skills/counsel/SKILL.md
@@ -39,6 +39,7 @@ Match the user's request to primitives. This is guidance, not rigid rules — us
 | "Is this [document] compliant with [regulation]?" | read → research --law → evaluate --compliance |
 | "Update the [counterparty] file" | remember --entity |
 | "Close this matter" | remember --matter (stage → closed) → remember --entity → remember --knowledge |
+| "What's due / any deadlines coming up / anything expiring?" | `/counsel-os:docket` (read-only sweep of `deadlines:` frontmatter across matters) |
 
 **Full document reviews require coverage checking.** When the user asks to review an entire document (not just a single clause), load the relevant method file from `practice/methods/` (e.g., `contract-review.md` for contracts, `nda-triage.md` for NDAs). The method file is a coverage checklist — use it to verify you've evaluated all relevant clause types, run compliance checks, and checked for missing provisions. Don't present findings until you've verified coverage.
 
@@ -313,8 +314,10 @@ Plugin (methodology + tooling):
     update/SKILL.md                            # /counsel-os:update — Pull latest content
     law-refresh/SKILL.md                       # /counsel-os:law-refresh — Refresh USER-OWNED law content (custom areas, managed-by: user files)
     doctor/SKILL.md                            # /counsel-os:doctor — Read-only health check (config, deps, currency, backups)
+    docket/SKILL.md                            # /counsel-os:docket — Read-only deadline sweep across matters (overdue / due-soon / upcoming)
   scripts/                                     # Automation
     apply_redlines.py                          # Apply text replacements + comments to .docx
+    docket_sweep.py                            # Deterministic deadline classifier over matter frontmatter (see /counsel-os:docket)
     clean_format.py                            # Reformat .docx to professional standards
     legal-template.docx                        # Style template for clean_format.py
     word_compare.sh                            # Drive Word Compare via AppleScript

--- a/skills/docket/SKILL.md
+++ b/skills/docket/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: docket
+description: "Read-only deadline sweep across your open matters: reads the deadlines: frontmatter on every matter file and reports what's overdue, due within a window (default 60 days), and upcoming — auto-renewal windows, termination-notice deadlines, sub-processor objection periods, filing and milestone dates. One sorted table; changes nothing. Missed dates are the practice's #1 malpractice vector. Use weekly, or whenever you ask 'what's due', 'what deadlines are coming up', 'anything expiring', 'what do I owe across my matters'."
+---
+
+# Docket — Deadline Sweep
+
+You are running a read-only sweep of the user's matter files for time-based obligations — renewal windows, notice deadlines, objection periods, filing dates, milestones. Present ONE table sorted by urgency. **Docket never writes** to the vault, the config, or anywhere else: it reports and recommends only. To *record* a deadline, that's `remember` (see "Recording deadlines" below), not this skill.
+
+## Step 0: Plugin root
+
+Resolve the plugin root: `${CLAUDE_PLUGIN_ROOT}` is set by Claude Code on every plugin invocation — use it directly. If unset, it's the directory containing this skill's parent `skills/` directory.
+
+## Step 1: Resolve the legal root and matters path
+
+Run the canonical resolver:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/scripts/resolve_legal_root.sh"
+```
+
+Exit-code contract: `0` = one marked root, stdout is the path; `1` = none found (tell the user to run `/counsel-os:setup`, then stop); `2` = multiple found (list the stderr candidates, ask which, or have them set `COUNSEL_OS_LEGAL_ROOT`).
+
+Matters may be relocated by the config. Read the override (default `matters`):
+
+```bash
+LEGAL_ROOT="{resolved legal root}"
+MATTERS_PATH=$(grep -m1 '^matters_path:' "$LEGAL_ROOT/config.md" | sed 's/^matters_path:[[:space:]]*//')
+MATTERS_DIR="$LEGAL_ROOT/${MATTERS_PATH:-matters}"
+```
+
+If `$MATTERS_DIR` does not exist, tell the user there are no matters yet and stop.
+
+## Step 2: Run the sweep
+
+The date arithmetic is deterministic, so a helper does it — don't eyeball dates by hand:
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/scripts/docket_sweep.py" "$MATTERS_DIR"
+```
+
+Useful flags:
+- `--window N` — look-ahead window in days (default `60`). The user may ask for a different horizon ("what's due in the next 90 days" → `--window 90`).
+- `--format json` — structured output if you want to reason over it before presenting.
+- `--include-done` — also show deadlines marked `done:` (hidden by default; kept in the file for audit).
+- `--today YYYY-MM-DD` — override "now" (testing only).
+
+The script needs only Python 3 stdlib — no pandoc, python-docx, or PyYAML.
+
+## Step 3: Present the result
+
+Show the sweep as one table, grouped and sorted the way the script emits it:
+
+- **OVERDUE** — the date has passed and the deadline is not marked done. Lead with these; they're the malpractice exposure.
+- **DUE WITHIN {window} DAYS** — the actionable horizon.
+- **UPCOMING** — beyond the window, for awareness (summarize the count rather than dumping every far-future row unless asked).
+- **MALFORMED** — entries with a missing or unparseable `date:`. Surface them loudly with the exact fix ("`{matter}` has `date: not-a-date` — set it to `YYYY-MM-DD`"). A silently dropped deadline is the one failure mode this feature exists to prevent, so never hide these.
+
+Notes on interpretation:
+- **Closed matters still surface.** A deadline can outlive its matter — an auto-renewal window or a confidentiality-survival date often falls after close. Closed-matter rows are tagged `[closed]`; treat them as real unless the user confirms they're moot.
+- Each row shows the date, relative timing, the action, the source clause (if recorded), and the matter. Offer to open any matter file the user wants to act on.
+- This is a read-only report. If a deadline is stale or already handled, offer to have `remember` mark it `done:` or update it — but only on the user's say-so, and that write happens through `remember`, not here.
+
+## Recording deadlines (how entries get here)
+
+Docket reads a `deadlines:` frontmatter block on matter files. The convention (full spec in `primitives/remember.md`):
+
+```yaml
+deadlines:
+  - date: 2026-07-15          # YYYY-MM-DD (required)
+    action: "renewal notice due"
+    type: renewal              # optional: renewal | notice | objection | milestone | filing
+    source: "MSA §9.2"         # optional: the clause the date comes from
+    done: false                # optional: true drops it from the sweep, kept for audit
+```
+
+`read` proposes these entries whenever it extracts key dates from a contract, and `remember --matter` persists them. If a user's matters have no `deadlines:` blocks yet, the sweep comes back empty — tell them the feature captures dates as `read` encounters them, and offer to backfill a matter's known dates now.
+
+## Cowork / no-shell runtimes
+
+If shell is unavailable, resolve the legal root and matters path from the conversation/config as `doctor` does, read the matter files directly, and do the date comparison yourself against today's date — same three groupings. Report the runtime limitation rather than guessing.


### PR DESCRIPTION
Ships **roadmap #1 — Deadline docket (v1)** (cou-48, spawned from approved proposal cou-39). Reconciles the 2026-06-12 HOLD: the hold reason was task-stack *coexistence*, and this v1 coexists by emitting into **no** external task system — a self-contained read-only sweep over the vault's own markdown. Deliberately not a calendar sync ("a reliable sweep beats a flaky sync").

## What's in it
1. **`deadlines:` frontmatter convention** on matter files — `{date, action, type?, source?, done?}` (documented in `primitives/remember.md`, shown in the matter-file format block).
2. **`scripts/docket_sweep.py`** — deterministic, **stdlib-only** classifier (no PyYAML/python-docx — no undeclared deps to ImportError on a fresh install). Classifies each deadline **overdue / due-soon (default 60-day window) / upcoming**, sorts by date, hides `done:` entries (kept for audit), and **surfaces malformed dates loudly** rather than dropping them — a silently missed date is the exact failure this feature exists to prevent. Sweeps closed matters too (a renewal window outlives the deal), tagging `[closed]`.
3. **`skills/docket/SKILL.md`** — read-only `/counsel-os:docket` wrapper: resolve legal root → read `matters_path` override → run the sweep → present one table. Modeled on `doctor`. Cowork/no-shell fallback included.
4. **`read` proposes** deadline entries when it extracts key dates from a contract; **`remember --matter` records/manages** them (set `done: true`, don't delete).
5. Docs: README (Utility Skills + capability bullet), `docs/roadmap.md` (#1 → SHIPPED with hold-resolution rationale), `docs/operations.md` (weekly cadence row).

## Verify
- `bun test browse/src/docket-sweep.test.ts` — 4 cases (classification, malformed-surfacing, non-matter/no-block skipping, `--include-done`). Both YAML list-indent styles covered.
- Full CI green locally: `bun run typecheck`, `bun test` (55 pass), `python3 scripts/lint_knowledge.py --check-versions` (OK), eval self-test, law frontmatter, browse-reference drift, `py_compile scripts/*.py`.
- AC: (a) a matter with a `deadlines:` block shows overdue/due-soon/upcoming correctly; (b) malformed dates appear under MALFORMED, never dropped; (c) `done:` deadlines hidden by default; (d) skill is read-only.

## Claims for founder pass
The README/roadmap/operations copy is user-facing product docs, not a marketing post, but the founder may want to eyeball the framing (esp. "#1 malpractice vector" phrasing and "not a calendar sync" positioning) before it ships in a release. No outward door in this PR itself.

No migrations. No new runtime deps.
