### PR TITLE
runtime: counsel loop, HTTP/SSE server with persistent threads, plugin adapter

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.44",
         "@ai-sdk/openai": "^4.0.50",
+        "@ai-sdk/openai-compatible": "^3.0.40",
         "@anthropic-ai/claude-agent-sdk": "^0.3.250",
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@openai/codex-sdk": "^0.150.1",
@@ -27,6 +28,8 @@
     "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.67", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.32", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-LtyxLkg7dZ2iz8Ouh1806BJbA+q+FKc/mXUCl4v/wdNNIGtbfk80dNtlhqjhqOZa4dnfc3caVafRL7ocxzoegA=="],
 
     "@ai-sdk/openai": ["@ai-sdk/openai@4.0.50", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.32" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-e2Jepw5RbSwsCsPwyiNzdlmOHoCQefCziNp3k1UxfIv8QD0/p4SF6+cx7GuWX98jAVNiWLjRv1W3NVSmx3FuEQ=="],
+
+    "@ai-sdk/openai-compatible": ["@ai-sdk/openai-compatible@3.0.40", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@ai-sdk/provider-utils": "5.0.33" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-4YvVykS7XfZEJMCe4gjxsT3CbCWXCONIK2QSVjEr+Xc4wbJcAxAM5xIWpx4x8ysFLlImhZc4OP4iTzeeGv76dA=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-aWO7iwhFUGf347tCwNGggggfmZigaSu7TF739IZSrWWABUp7zkb4Cr3fMqvBe5EIS7ABJJu3Cadn0g/zs1G0QQ=="],
 
@@ -297,6 +300,8 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "@ai-sdk/openai-compatible/@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.33", "", { "dependencies": { "@ai-sdk/provider": "4.0.8", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8", "undici": "^7.28.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-TfjJqJmRsQyxAlb+3hGmP1o1xLUIT79yhOgtJuTF4hqsB37IC3CufGsuFhU04EeTOg7R9iptQ6Bzm0MW0n/c3g=="],
 
     "body-parser/content-type": ["content-type@2.1.0", "", {}, "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag=="],
 

--- a/docs/superpowers/plans/2026-08-28-counsel-loop-api-adapter.md
+++ b/docs/superpowers/plans/2026-08-28-counsel-loop-api-adapter.md
@@ -1,0 +1,419 @@
+# Counsel Loop + HTTP/SSE API + Plugin Adapter Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistent threads, the counsel loop with the real methodology prompt and the `remember` gate, a local HTTP/SSE server (`counsel-os serve`), a providers registry with retry, and a plugin adapter that uses the server when present.
+
+**Architecture:** Threads live under `.counsel/threads/` in the vault (model-unwritable). A step resolves a provider, resumes the vendor session when one exists (Claude `resume`, Codex `resumeThread` from a persistent per-thread isolated home) or replays the windowed log (direct tier), streams `StepEvent`s, and appends them to the thread. The server exposes threads/steps/approve/vault over loopback with a bearer token and writes `~/.counsel-os/runtime.json` for the plugin adapter to find.
+
+**Tech Stack:** Bun 1.3.x, TypeScript, `bun test`, zod 4, `@anthropic-ai/claude-agent-sdk` 0.3.x, `@openai/codex-sdk` 0.150.x, `ai` 7.x, `@ai-sdk/openai-compatible` (new), existing `runtime/` from PR #21.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md` (parent: `2026-08-28-runtime-and-web-ui-design.md`)
+
+## Global Constraints
+
+- Providers yield `StepEvent`s and never throw. Harnesses stay restricted to the runtime's tools (do not loosen anything in `buildQueryOptions` / `buildCodexConfig`).
+- Threads, proposals, and run logs live under `.counsel/` and are written only by the runtime, never by a model tool.
+- `vault_write` refuses knowledge-system paths (`practice/**`, `memory/**`, `law/**`, `{entities_path}/**`); those go through `propose_update` + approval. `{matters_path}/**` stays directly writable.
+- Server binds `127.0.0.1` only; every route except none requires `Authorization: Bearer <token>`; `runtime.json` is mode 0600 and removed on exit.
+- SSE never drops a connection without a terminal event (`done` or `error`).
+- Markdown under `skills/`, `primitives/`, `knowledge/` is unchanged except the one adapter paragraph in `skills/counsel/SKILL.md`.
+- Imports: only `ai`, `@ai-sdk/*`, `ai-sdk-ollama` for models. Tests beside source. Commit messages `runtime: <what>` (adapter task: `plugin: <what>`).
+- Live model calls only where a step says so (they cost subscription credit).
+
+---
+
+## File structure
+
+```
+runtime/src/
+  core/types.ts               + StepRequest.session, done.sessionId (modify)
+  providers/
+    claude-harness.ts         + resume, capture session_id from init (modify)
+    codex-harness.ts          + resumeThread, persistent home option, capture thread_id (modify)
+    registry.ts               built-ins + ~/.counsel-os/providers.yaml → providers + router
+    registry.test.ts
+    retry.ts                  withRetry(provider)
+    retry.test.ts
+    direct.ts                 + openai-compatible/* (modify)
+  vault/
+    resolve-root.ts           port of scripts/resolve_legal_root.sh
+    resolve-root.test.ts
+    knowledge-paths.ts        isKnowledgePath(path, cfg)
+  threads/
+    store.ts, store.test.ts   ThreadStore
+    window.ts, window.test.ts history windowing
+  loop/
+    prompt.ts, prompt.test.ts assembleSystemPrompt
+    primitives.ts             read_primitive tool
+    proposals.ts, proposals.test.ts
+    counsel-loop.ts, counsel-loop.test.ts   runStep
+    run-log.ts                runs/<runId>.log.jsonl
+  tools/builtin.ts            + script tools (modify) 
+  server/
+    auth.ts, sse.ts, sse.test.ts, routes.ts, routes.test.ts, serve.ts
+  cli.ts                      + `serve` command (modify)
+scripts/runtime_step.sh
+skills/counsel/SKILL.md       + adapter paragraph (modify)
+```
+
+---
+
+### Task 1: Provider session hook (Claude resume, Codex resumeThread + persistent home)
+
+**Files:**
+- Modify: `runtime/src/core/types.ts`
+- Modify: `runtime/src/providers/claude-harness.ts`, `runtime/src/providers/claude-harness.test.ts`
+- Modify: `runtime/src/providers/codex-harness.ts`, `runtime/src/providers/codex-harness.test.ts`
+
+**Interfaces:**
+- Consumes: existing `StepRequest`, `StepEvent`, `buildQueryOptions`, `buildThreadOptions`, `prepareIsolatedHome`, `cleanupIsolatedHome`, `mapClaudeMessage`, `mapCodexEvent`.
+- Produces: `StepRequest.session?: { id?: string }`; `StepEvent` `done` gains `sessionId?: string`; `mapClaudeMessage` yields `{ type: 'session', id }` for the `system/init` message; `CodexHarnessProvider` constructor gains `homeDir?: string` (persistent isolated home; when set, `run()` neither creates nor removes it); `mapCodexEvent` yields `{ type: 'session', id }` for `thread.started`. New `StepEvent` variant: `{ type: 'session'; id: string }` (internal; the loop stores it and does not forward it to clients).
+
+- [ ] **Step 1: Types.** In `runtime/src/core/types.ts` add to `StepRequest`: `session?: { id?: string };` and to the `StepEvent` union: `| { type: 'session'; id: string }`. Extend `done`: `| { type: 'done'; output: unknown; usage: Usage; sessionId?: string }`.
+
+- [ ] **Step 2: Failing tests (Claude).** Append to `claude-harness.test.ts`:
+```ts
+describe('sessions', () => {
+  test('system/init → session event with the session id', () => {
+    expect(mapClaudeMessage({ type: 'system', subtype: 'init', session_id: 'sess-1', cwd: '/x' })).toEqual([{ type: 'session', id: 'sess-1' }]);
+  });
+  test('buildQueryOptions passes resume when a session id is given, omits it otherwise', () => {
+    const base = { tenant: 'default', system: 's', messages: [], tools: [] };
+    expect(buildQueryOptions({ ...base, session: { id: 'sess-1' } }, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBe('sess-1');
+    expect(buildQueryOptions(base, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBeUndefined();
+  });
+});
+```
+Run: `bun test runtime/src/providers/claude-harness.test.ts` → FAIL.
+
+- [ ] **Step 3: Implement (Claude).** In `mapClaudeMessage`, before the `assistant|user` branch: `if (msg.type === 'system' && msg.subtype === 'init' && typeof msg.session_id === 'string') return [{ type: 'session', id: msg.session_id }];`. In `buildQueryOptions` add `...(req.session?.id ? { resume: req.session.id } : {})`. In `run()`, when a `session` event is mapped, remember it in a local `sessionId` and, when yielding `done`, spread `sessionId` in: replace the inner loop with
+```ts
+let sessionId: string | undefined;
+for await (const msg of stream) {
+  for (const ev of mapClaudeMessage(msg, req.outputSchema)) {
+    if (ev.type === 'session') { sessionId = ev.id; yield ev; continue; }
+    yield ev.type === 'done' && sessionId ? { ...ev, sessionId } : ev;
+  }
+}
+```
+Run the test → PASS. Note: when `resume` is set, the loop sends only the new user message as `prompt` (the caller decides; see Task 6).
+
+- [ ] **Step 4: Failing tests (Codex).** Append to `codex-harness.test.ts`:
+```ts
+describe('sessions', () => {
+  test('thread.started → session event with the thread id', () => {
+    expect(mapCodexEvent({ type: 'thread.started', thread_id: 'th-1' })).toEqual([{ type: 'session', id: 'th-1' }]);
+  });
+  test('a persistent homeDir is used as CODEX_HOME and is not removed by run()', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    const p = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v', homeDir: home });
+    expect(p.homeDir).toBe(home);
+    // run() is not executed here (live); the contract is asserted via the exported helper:
+    expect(resolveCodexHome({ homeDir: home, realHome: '/real' })).toEqual({ isolatedHome: home, ephemeral: false });
+    expect(resolveCodexHome({ realHome: '/real' }).ephemeral).toBe(true);
+  });
+});
+```
+(import `mkdtempSync`, `tmpdir`, `join`, `CodexHarnessProvider`, `resolveCodexHome`.) Run → FAIL.
+
+- [ ] **Step 5: Implement (Codex).** In `mapCodexEvent` add: `if (ev.type === 'thread.started' && typeof ev.thread_id === 'string') return [{ type: 'session', id: ev.thread_id }];`. Add and export:
+```ts
+export function resolveCodexHome(opts: { homeDir?: string; realHome: string }): { isolatedHome: string; ephemeral: boolean } {
+  if (opts.homeDir) {
+    if (opts.homeDir === opts.realHome) throw new Error('homeDir must not be the real CODEX_HOME');
+    mkdirSync(opts.homeDir, { recursive: true, mode: 0o700 });
+    const authSrc = join(opts.realHome, 'auth.json');
+    if (existsSync(authSrc) && !existsSync(join(opts.homeDir, 'auth.json'))) copyFileSync(authSrc, join(opts.homeDir, 'auth.json'));
+    return { isolatedHome: opts.homeDir, ephemeral: false };
+  }
+  return { isolatedHome: prepareIsolatedHome(opts.realHome), ephemeral: true };
+}
+```
+Constructor: `constructor(private readonly opts: { model: string; vaultRoot: string; id?: string; homeDir?: string })` with `readonly homeDir = opts.homeDir`. In `run()`: `const { isolatedHome, ephemeral } = resolveCodexHome({ homeDir: this.opts.homeDir, realHome })` inside the try; thread = `req.session?.id ? codex.resumeThread(req.session.id, buildThreadOptions(...)) : codex.startThread(buildThreadOptions(...))`; track `sessionId` from `session` events and spread into `done` as in Claude; in `finally`, `if (ephemeral && isolatedHome) cleanupIsolatedHome(isolatedHome)`. Run tests → PASS. `bun run typecheck:runtime` clean.
+
+- [ ] **Step 6: Live spike (two subscription calls, authorized).** Temp vault with `acme.md`. Claude: run the CLI step "Remember the word pineapple." then a second `step` passing the captured session id — add `--session <id>` to `cli.ts` `step` (parse option, pass `session: { id }`) — asking "What word did I ask you to remember?"; expect "pineapple". Codex: same, with `--codex-home $(mktemp -d)` option threaded to `homeDir`. Record both transcripts in `docs/superpowers/spikes/2026-08-28-runtime-spikes.md` under a new "Step 2 — resume" section. If Claude resume fails because the temp cwd differs, try `--session` again with the same cwd (add a `--cwd` debug option) and record which is needed.
+
+- [ ] **Step 7: Commit.** `git commit -m "runtime: provider session hook — Claude resume, Codex resumeThread with persistent home"`
+
+---
+
+### Task 2: Providers registry, openai-compatible, retry
+
+**Files:**
+- Create: `runtime/src/providers/registry.ts`, `registry.test.ts`, `retry.ts`, `retry.test.ts`
+- Modify: `runtime/src/providers/direct.ts`, `runtime/src/providers/index.ts`
+- Modify: `package.json` (`bun add @ai-sdk/openai-compatible`)
+
+**Interfaces:**
+- Produces: `loadRegistry(opts: { file?: string; vaultRoot: string; env?: NodeJS.ProcessEnv }): { providers: ModelProvider[]; router: Router; defaultId: string }`; `RegistryFile` zod schema; `withRetry(p: ModelProvider, opts?: { tries?: number; baseMs?: number; sleep?: (ms)=>Promise<void> }): ModelProvider`; `directProviderFromId(id, reg?: { baseURL?: string; apiKeyEnv?: string; capabilities?: Partial<Capabilities> })`.
+
+- [ ] **Step 1: Failing registry test.**
+```ts
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs'; import { tmpdir } from 'node:os'; import { join } from 'node:path';
+import { loadRegistry, BUILTIN_DEFAULT } from './registry';
+
+describe('loadRegistry', () => {
+  test('no file → built-ins with the built-in default', () => {
+    const r = loadRegistry({ file: '/nonexistent/providers.yaml', vaultRoot: '/v' });
+    expect(r.defaultId).toBe(BUILTIN_DEFAULT);
+    expect(r.providers.map(p => p.id)).toContain('claude-sub/claude-opus-5');
+    expect(r.router.resolve().id).toBe(BUILTIN_DEFAULT);
+  });
+  test('file adds openai-compatible providers and overrides default + tasks', () => {
+    const f = join(mkdtempSync(join(tmpdir(), 'reg-')), 'providers.yaml');
+    writeFileSync(f, `default: openai-compatible/groq\nproviders:\n  - id: openai-compatible/groq\n    baseURL: https://api.groq.com/openai/v1\n    apiKeyEnv: GROQ_API_KEY\n    capabilities: { contextTokens: 128000 }\ntasks:\n  classify: { prefer: openai-compatible/groq }\n`);
+    const r = loadRegistry({ file: f, vaultRoot: '/v', env: { GROQ_API_KEY: 'k' } });
+    const groq = r.providers.find(p => p.id === 'openai-compatible/groq')!;
+    expect(groq.capabilities.contextTokens).toBe(128000);
+    expect(groq.capabilities.auth).toBe('apikey');
+    expect(r.router.resolve('classify').id).toBe('openai-compatible/groq');
+  });
+  test('unknown id prefix fails at load time', () => {
+    const f = join(mkdtempSync(join(tmpdir(), 'reg-')), 'providers.yaml');
+    writeFileSync(f, `providers:\n  - id: nope/x\n`);
+    expect(() => loadRegistry({ file: f, vaultRoot: '/v' })).toThrow(/unknown provider/);
+  });
+});
+```
+Run → FAIL.
+
+- [ ] **Step 2: Implement.** `bun add @ai-sdk/openai-compatible`. In `direct.ts` extend `directProviderFromId(id, reg = {})`: if vendor is `openai-compatible`, `const model = createOpenAICompatible({ name, baseURL: reg.baseURL!, apiKey: reg.apiKey })(name)` (import `createOpenAICompatible` from `@ai-sdk/openai-compatible`; require `baseURL` else throw `unknown provider`); merge `reg.capabilities` over the vendor's defaults. `registry.ts`:
+```ts
+import { z } from 'zod';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os'; import { join } from 'node:path';
+import type { Capabilities, ModelProvider } from '../core/types';
+import { Router, parseRouterConfig, type RouterConfig } from '../router/router';
+import { buildProviders } from './index';
+import { directProviderFromId } from './direct';
+
+export const BUILTIN_DEFAULT = 'claude-sub/claude-opus-5';
+export const BUILTIN_IDS = ['claude-sub/claude-opus-5', 'codex-sub/gpt-5.6-terra', 'ollama/gemma4:e4b'];
+export const DEFAULT_REGISTRY_FILE = join(homedir(), '.counsel-os', 'providers.yaml');
+
+const Entry = z.object({ id: z.string(), baseURL: z.string().optional(), apiKeyEnv: z.string().optional(),
+  capabilities: z.object({ tools: z.boolean(), caching: z.boolean(), thinking: z.boolean(), contextTokens: z.number(), auth: z.enum(['subscription','apikey','local']) }).partial().optional() });
+export const RegistryFile = z.object({ default: z.string().optional(), providers: z.array(Entry).optional(), tasks: z.record(z.string(), z.any()).optional() });
+
+export function loadRegistry(opts: { file?: string; vaultRoot: string; env?: NodeJS.ProcessEnv }) {
+  const file = opts.file ?? DEFAULT_REGISTRY_FILE; const env = opts.env ?? process.env;
+  const raw = existsSync(file) ? RegistryFile.parse(Bun.YAML.parse(readFileSync(file, 'utf8'))) : {};
+  const providers: ModelProvider[] = buildProviders({ ids: BUILTIN_IDS, vaultRoot: opts.vaultRoot });
+  for (const e of raw.providers ?? []) {
+    const [vendor] = e.id.split('/');
+    if (vendor === 'claude-sub' || vendor === 'codex-sub') { providers.push(...buildProviders({ ids: [e.id], vaultRoot: opts.vaultRoot })); continue; }
+    if (!['anthropic','openai','ollama','openai-compatible'].includes(vendor ?? '')) throw new Error(`unknown provider id prefix: ${e.id}`);
+    providers.push(directProviderFromId(e.id, { baseURL: e.baseURL, apiKey: e.apiKeyEnv ? env[e.apiKeyEnv] : undefined, capabilities: e.capabilities as Partial<Capabilities> }));
+  }
+  const defaultId = raw.default ?? BUILTIN_DEFAULT;
+  const cfg: RouterConfig = { default: defaultId, tasks: raw.tasks };
+  return { providers, router: new Router(cfg, providers), defaultId };
+}
+```
+(`buildProviders` must not throw for `codex-sub/gpt-5.6-terra` without a live login — it does not; construction is lazy.) Run → PASS.
+
+- [ ] **Step 3: Failing retry test.**
+```ts
+import { describe, expect, test } from 'bun:test';
+import { withRetry } from './retry';
+import type { ModelProvider, StepEvent } from '../core/types';
+function flaky(fails: number, msg: string): ModelProvider & { calls: number } {
+  const p = { id: 'x/y', kind: 'direct' as const, calls: 0, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1, auth: 'apikey' as const },
+    async *run(): AsyncIterable<StepEvent> { p.calls++; if (p.calls <= fails) { yield { type: 'error', message: msg }; return; } yield { type: 'done', output: 'ok', usage: { inputTokens: 0, outputTokens: 0 } }; } };
+  return p;
+}
+async function last(it: AsyncIterable<StepEvent>) { let e: StepEvent | undefined; for await (const x of it) e = x; return e!; }
+const req = { tenant: 'default', system: '', messages: [], tools: [] };
+describe('withRetry', () => {
+  test('retries a 429/5xx-shaped error and succeeds', async () => {
+    const p = flaky(2, 'HTTP 429 rate limited'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('done'); expect(p.calls).toBe(3);
+  });
+  test('does not retry other errors', async () => {
+    const p = flaky(5, 'structured output failed validation'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('error'); expect(p.calls).toBe(1);
+  });
+  test('gives up after tries and yields the last error', async () => {
+    const p = flaky(5, 'HTTP 503'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('error'); expect(p.calls).toBe(3);
+  });
+});
+```
+Run → FAIL.
+
+- [ ] **Step 4: Implement `retry.ts`.**
+```ts
+import type { ModelProvider, StepEvent, StepRequest } from '../core/types';
+const RETRYABLE = /\b(429|5\d\d|rate limit|overloaded|ECONNRESET|ETIMEDOUT)\b/i;
+export function withRetry(p: ModelProvider, opts: { tries?: number; baseMs?: number; sleep?: (ms: number) => Promise<void> } = {}): ModelProvider {
+  const tries = opts.tries ?? 3, baseMs = opts.baseMs ?? 500, sleep = opts.sleep ?? (ms => new Promise(r => setTimeout(r, ms)));
+  return { id: p.id, kind: p.kind, capabilities: p.capabilities,
+    async *run(req: StepRequest): AsyncIterable<StepEvent> {
+      for (let attempt = 1; ; attempt++) {
+        const buffered: StepEvent[] = []; let failed: StepEvent | undefined;
+        for await (const ev of p.run(req)) { if (ev.type === 'error') { failed = ev; break; } buffered.push(ev); if (buffered.length > 1 || ev.type !== 'session') break; }
+        // Retry only if the error arrived before any user-visible output (so nothing is duplicated).
+        if (failed && attempt < tries && RETRYABLE.test(failed.message) && buffered.every(e => e.type === 'session')) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
+        for (const e of buffered) yield e;
+        if (failed) { yield failed; return; }
+        // Not failed and not finished: continue draining the same iterator is impossible after break —
+        // so re-run without buffering when the first event was not an error:
+        for await (const ev of p.run(req)) yield ev; return;
+      }
+    } };
+}
+```
+Hmm — that double-runs on success. Replace the body with a single pass that buffers only until the first non-`session` event:
+```ts
+      for (let attempt = 1; ; attempt++) {
+        const it = p.run(req)[Symbol.asyncIterator]();
+        const head: StepEvent[] = []; let first = await it.next();
+        while (!first.done && first.value.type === 'session') { head.push(first.value); first = await it.next(); }
+        if (!first.done && first.value.type === 'error' && attempt < tries && RETRYABLE.test(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
+        for (const e of head) yield e;
+        if (first.done) return;
+        yield first.value;
+        if (first.value.type === 'error') return;
+        for (let n = await it.next(); !n.done; n = await it.next()) yield n.value;
+        return;
+      }
+```
+Use this second version only. Run → PASS. Wire: `loadRegistry` wraps every `kind === 'direct'` provider with `withRetry`.
+
+- [ ] **Step 5: Commit.** `runtime: providers registry (providers.yaml, openai-compatible) and retry wrapper`
+
+---
+
+### Task 3: Vault root resolution and knowledge paths
+
+**Files:**
+- Create: `runtime/src/vault/resolve-root.ts`, `resolve-root.test.ts`, `knowledge-paths.ts`, `knowledge-paths.test.ts`
+
+**Interfaces:**
+- Produces: `resolveLegalRoot(opts: { env?: NodeJS.ProcessEnv; cwd?: string; home?: string; conventional?: string[] }): { ok: true; root: string } | { ok: false; code: 1 | 2; candidates: string[] }` — same search order as `scripts/resolve_legal_root.sh` (read the script first; a "marked root" is a dir whose `config.md` contains both `counsel-os-config: true` and a `legal_root:` line). `readVaultConfig(root): { entitiesPath: string; mattersPath: string }` (defaults `entities`, `matters`; overrides `entities_path:` / `matters_path:` in `config.md` frontmatter). `isKnowledgePath(path, cfg): boolean` true for `practice/`, `memory/`, `law/`, `${entitiesPath}/` prefixes.
+
+- [ ] **Step 1: Failing tests.** Build fixture dirs with `mkdtempSync`: (a) `COUNSEL_OS_LEGAL_ROOT` set to a marked dir → ok; set to an unmarked dir → `{ok:false, code:1}`; (b) pointer file `<home>/.counsel-os/legal-root` → ok; (c) cwd three levels below a marked root → ok; four levels → not found; (d) two marked roots in the conventional list → `{ok:false, code:2, candidates:[both]}`. Plus `readVaultConfig` with and without overrides, and `isKnowledgePath('practice/standards/x.md')` true / `'matters/acme/notes.md'` false / `'clients/acme.md'` true when `entitiesPath: 'clients'`.
+
+- [ ] **Step 2: Implement** by transcribing the script's algorithm (read `scripts/resolve_legal_root.sh` in full first; keep its conventional-paths list verbatim and its depth limits). Sync `readFileSync`; no shell.
+
+- [ ] **Step 3: Run, typecheck, commit.** `runtime: vault root resolution (port of resolve_legal_root.sh) and knowledge-path classifier`
+
+---
+
+### Task 4: ThreadStore and history window
+
+**Files:**
+- Create: `runtime/src/threads/store.ts`, `store.test.ts`, `window.ts`, `window.test.ts`
+
+**Interfaces:**
+- Consumes: `VaultStore` — but threads are under `.counsel/`, which `FsVaultStore.abs()` rejects. The store therefore takes the vault **root path** and uses `node:fs` directly (it is runtime-owned, not model-reachable). Codex per-thread homes live at `join(homedir(), '.counsel-os', 'codex', id)`; `remove()` deletes that dir too (`opts.codexHomeRoot` injectable for tests).
+- Produces: `ThreadHeader`, `ThreadEvent` (as in spec §4.1), `class ThreadStore { constructor(root: string, opts?: { codexHomeRoot?: string }); create(tenant, init); get(tenant, id); list(tenant); append(tenant, id, ev); setSession(tenant, id, providerId, sessionId); updateProposal(tenant, id, proposalId, status); remove(tenant, id); codexHomeFor(id): string }`. Ids: `crypto.randomUUID()`. Header file `<root>/.counsel/threads/<tenant>/<id>.json`, log `<id>.jsonl`. `window(events, budgetTokens, estimate = s => Math.ceil(s.length / 4)): Message[]` — converts `user`/`text` events to `Message`s (consecutive `text` events merged into one assistant message; tool events skipped), then drops oldest pairs until under budget, always keeping the last user message.
+
+- [ ] **Step 1: Failing tests** covering: create → list → get (header + empty events); append three events → get returns them in order; setSession persists into the header; updateProposal flips status of the matching `proposal` event (rewrite the log); remove deletes both files and the codex home dir; ids of two creates differ; `window` merges consecutive text, drops oldest first, keeps the last user message even when over budget.
+
+- [ ] **Step 2: Implement; run; typecheck; commit.** `runtime: ThreadStore under .counsel/threads and history windowing`
+
+---
+
+### Task 5: Prompt assembly, `read_primitive`, proposals, builtin script tools
+
+**Files:**
+- Create: `runtime/src/loop/prompt.ts`, `prompt.test.ts`, `primitives.ts`, `proposals.ts`, `proposals.test.ts`
+- Modify: `runtime/src/tools/builtin.ts`, `builtin.test.ts`; `runtime/src/vault/vault-tools.ts`, `vault-tools.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `assembleSystemPrompt(opts: { pluginRoot: string; vaultRoot: string; matterPath?: string; platform: Platform; toolNames: string[] }): string` = `HOST_PREAMBLE(toolNames, platform)` + body of `skills/counsel/SKILL.md` (frontmatter removed) + `\n\n## Practice profile\n` + `practice/profile.md` if present + `\n\n## Current matter\n` + matter file if present. Pure given file contents (read via injected `readFile = readFileSync`).
+  - `HOST_PREAMBLE`: states the host is the counsel-os runtime; `{legal_root}` is already resolved (do not run `resolve_legal_root.sh`); where the methodology says `python3 "${CLAUDE_PLUGIN_ROOT}/scripts/X.py" …` call tool `X` with the same arguments as named fields; where it says read `primitives/{name}.md`, call `read_primitive {name}`; knowledge-system writes go through `propose_update`, matter writes through `vault_write`; list the tools available on this platform and which are unavailable and why.
+  - `readPrimitiveTool(pluginRoot): ToolDef<{ name: string }, string>` — allowlist = files in `<pluginRoot>/primitives/*.md`; unknown name → error.
+  - `proposeUpdateTool(store: ThreadStore, vault: VaultStore, threadId, tenant): ToolDef<{ path; content; rationale }, { proposalId }>` — appends a `proposal` event with `expectedVersion = await vault.version(tenant, path)`.
+  - `guardedVaultTools(vault, cfg): ToolDef[]` — same as `vaultTools` but `vault_write` returns an error result `use propose_update for knowledge-system paths` when `isKnowledgePath(path, cfg)`.
+  - `applyProposal(store, vault, tenant, threadId, proposalId, decision): Promise<{ status; version?; conflict?: { expected; actual } }>`.
+  - `builtinTools({ vaultRoot, repoRoot })` adds `extract_redlines {docx}`, `check_document {docx}`, `clean_format {input, output}`, `apply_redlines {original, edits, output, track?}`, `word_compare {original, modified, author, output}` (macOS only), each via `pythonScriptTool` (`word_compare` via a bash wrapper with the same `Tool` shape: reuse `pythonScriptTool`'s spawn logic by adding `command?: string[]` option defaulting to `['python3', script]`).
+
+- [ ] **Step 1: Failing tests:** snapshot of `assembleSystemPrompt` with a fixture plugin root (tiny SKILL.md with frontmatter, one primitive) and fixture vault (profile + matter) — assert frontmatter absent, preamble present, profile and matter sections present, `read_primitive` mentioned; changing the fixture primitive does not change the output. `readPrimitiveTool`: known name returns content; unknown → error via `runToolDef`. Proposals: `vault_write` to `practice/standards/x.md` → isError with /propose_update/; `vault_write` to `matters/a.md` → ok; `propose_update` appends a `proposal` event with `expectedVersion`; `applyProposal(approve)` writes and returns version; approve after an external edit → conflict; reject → status rejected, nothing written. `builtin.test.ts`: five new tools present with the expected platform sets; `word_compare` only macOS.
+
+- [ ] **Step 2: Implement; run; typecheck; commit.** `runtime: prompt assembly from SKILL.md + profile + matter, read_primitive, propose_update gate, script tools`
+
+---
+
+### Task 6: Counsel loop and run logs
+
+**Files:**
+- Create: `runtime/src/loop/counsel-loop.ts`, `counsel-loop.test.ts`, `run-log.ts`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: `runStep(deps: { tenant; vaultRoot; pluginRoot; vault: VaultStore; store: ThreadStore; providers: ModelProvider[]; router: Router; platform?: Platform }, opts: { threadId; message; task?; providerId?; outputSchema? }): AsyncIterable<StepEvent & { runId: string }>` — behavior per spec §4.3; `session` events are consumed (stored via `setSession`) and not yielded; `text` events are appended to the log as-is (coalescing is the server's job); `done` appended with `provider`, `runId`. `writeRunLog(vaultRoot, tenant, runId, entries)` → `<root>/.counsel/runs/<tenant>/<runId>.log.jsonl` with `{ at, provider, task, inputTokens, outputTokens, costUsd, durationMs, toolCalls: [{name, ms, isError}] }`.
+- Codex providers get `homeDir: store.codexHomeFor(threadId)` — construct per-thread Codex providers via a `providerFor(id, threadId)` helper that clones a `codex-sub/*` registry entry with `homeDir` set (add `withHome(dir)` method to `CodexHarnessProvider` returning a new instance).
+
+- [ ] **Step 1: Failing tests** with `FakeModelProvider` and a temp vault/plugin fixture: (a) first step appends `user`, `step`, events, `done`; the request seen by the fake has `messages` from the window and no `session`; (b) a fake that yields `{type:'session', id:'s1'}` then `done` → header `sessions['fake/fake'] === 's1'` and the `session` event is not yielded to the caller; (c) second step on the same thread with that provider → request has `session.id === 's1'` and `messages` = only the new message; (d) a run log file exists with tokens and one tool call; (e) unknown thread → yields a single `error`; (f) router hard error (task requirement unsatisfiable) → single `error`, nothing appended except the `user` event.
+
+(For (a)–(c) make `FakeModelProvider` record `lastRequest` — add a public field in `core/fake-provider.ts`.)
+
+- [ ] **Step 2: Implement; run; typecheck; commit.** `runtime: counsel loop — threads, sessions, proposals, run logs`
+
+---
+
+### Task 7: Server (auth, SSE, routes, serve)
+
+**Files:**
+- Create: `runtime/src/server/auth.ts`, `sse.ts`, `sse.test.ts`, `routes.ts`, `routes.test.ts`, `serve.ts`
+- Modify: `runtime/src/cli.ts` (add `serve [--port N] [--vault DIR]`)
+
+**Interfaces:**
+- `createApp(deps): (req: Request) => Promise<Response>` — a plain fetch handler (testable without a socket) implementing spec §4.5; `deps = { token, tenant, vaultRoot, pluginRoot, vault, store, providers, router, platform }`.
+- `sseFromEvents(events: AsyncIterable<StepEvent>, opts?: { coalesceMs?: number; maxChars?: number }): Response` — `text/event-stream`; `text` deltas buffered and flushed at `coalesceMs` (default 50) or `maxChars` (200); every other event flushes the buffer first; the stream always ends with `done` or `error` (if the source ends without one, emit `error: "provider ended without a terminal event"`).
+- `serve.ts`: resolve vault (`resolveLegalRoot` → 503-style exit with the script's messages on 1/2, `--vault` overrides), `loadRegistry`, pick a free port (default 7431, else OS-assigned), `Bun.serve({ hostname: '127.0.0.1', port, fetch: createApp(...) })`, write `~/.counsel-os/runtime.json` (`{ port, token, vault, pid, startedAt }`, mode 0600), remove on SIGINT/SIGTERM/exit, print one line `counsel-os runtime on http://127.0.0.1:<port> (vault: …)`.
+- `pluginRoot` = repo root (`resolve(import.meta.dir, '../..')` from `server/`), or `COUNSEL_PLUGIN_ROOT` env override for installed-plugin layouts.
+
+- [ ] **Step 1: Failing SSE test:** feed events `text 'a'`, `text 'b'`, `tool_call`, `text 'c'`, `done` with `coalesceMs: 0` (flush only on non-text) → parsed SSE frames are `text 'ab'`, `tool_call`, `text 'c'`, `done`; a source that ends early → last frame is `error`. Write a tiny `parseSse(text)` helper in the test.
+
+- [ ] **Step 2: Failing routes test** via `createApp` with the fake provider and temp fixtures: 401 without/with wrong token; `GET /health` lists providers and default; `POST /threads` → 201 header; `GET /threads` lists it; `POST /threads/:id/steps` → `text/event-stream`, frames end with `done`, `x-run-id` header present; `GET /threads/:id` shows the appended events; `POST …/approve` on a pending proposal (seed via the fake's tool call to `propose_update`) → approved and the vault file written; 404 unknown thread; 422 unknown provider id; `GET /vault/read?path=../x` → 400.
+
+- [ ] **Step 3: Implement** `auth.ts` (constant-time compare), `sse.ts`, `routes.ts` (hand-rolled router on `new URL(req.url).pathname` + method; JSON bodies parsed with zod schemas per route), `serve.ts`, and the `serve` subcommand in `cli.ts` (parse `--port`, `--vault`; call `serve.ts`'s exported `startServer(opts)` which returns `{ port, stop }`).
+
+- [ ] **Step 4: Run all, typecheck; manual smoke:** `bun runtime/src/cli.ts serve --vault <temp marked vault>` in the background, `curl -H "Authorization: Bearer $(jq -r .token ~/.counsel-os/runtime.json)" localhost:<port>/health`, then a step with `--provider ollama/gemma4:e4b` via curl (`-N` to stream). Kill the server; confirm `runtime.json` is gone.
+
+- [ ] **Step 5: Commit.** `runtime: local HTTP/SSE server (threads, steps, approve, vault) and \`counsel-os serve\``
+
+---
+
+### Task 8: Plugin adapter
+
+**Files:**
+- Create: `scripts/runtime_step.sh`, `scripts/runtime_step.test.ts` (Bun test that spawns the script against `createApp` served on a random port)
+- Modify: `skills/counsel/SKILL.md` (one paragraph in the "How This System Works" section, before "The 5 Primitives")
+
+**Interfaces:**
+- `scripts/runtime_step.sh "<request>"`: exit 3 (silently) if `~/.counsel-os/runtime.json` missing, unreadable, or `curl -sf --max-time 1 /health` fails; otherwise thread id from `${TMPDIR:-/tmp}/counsel-os-thread-${CLAUDE_SESSION_ID:-$PPID}` (create via `POST /threads` if absent), `POST /threads/<id>/steps` with `curl -sN`, parse SSE lines with a small `awk`: print `text` payloads verbatim, print `→ tool <name>` lines for tool calls to stderr, print `⚠ <message>` and exit 1 on `error`, exit 0 on `done`. Dependencies: `curl`, `jq` (fall back to exit 3 if `jq` is missing — the skill then proceeds normally).
+
+- [ ] **Step 1: Failing test:** start `createApp` with the fake provider on a random port and a temp `HOME` whose `.counsel-os/runtime.json` points at it; run the script with `HOME` set → stdout contains the fake's text, exit 0; with no `runtime.json` → exit 3 and empty stdout; with a dead port → exit 3.
+
+- [ ] **Step 2: Write the script and the SKILL.md paragraph:**
+> **Runtime hand-off (Claude Code only).** Before any other step, run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/runtime_step.sh" "<the user's request, verbatim>"`. Exit 0 means the local counsel-os runtime handled the request: relay its output to the user and stop. Exit 3 means no runtime is running: continue with this skill exactly as below. Exit 1 means the runtime hit an error: show the message and continue with this skill.
+
+- [ ] **Step 3: Run, commit.** `plugin: hand off to the local runtime when it is running (scripts/runtime_step.sh)`
+
+---
+
+### Task 9: Live smokes and findings
+
+**Files:**
+- Modify: `docs/superpowers/spikes/2026-08-28-runtime-spikes.md` (append "Step 2 — server + resume")
+
+- [ ] **Step 1:** With `counsel-os serve` on a temp marked vault (seed `config.md`, `practice/profile.md`, `matters/acme.md`, `practice/standards/nda.md`): (a) Claude: two steps on one thread; second must recall the first (resume). (b) Codex: same. (c) Ollama: one step that calls `vault_read`. (d) Any provider: ask it to update `practice/standards/nda.md` → expect a `proposal` event, not a write; approve via the API → file changed with the proposal content. Record transcripts (abridged), token usage, wall-clock, and any defect found. Authorized cost: ~4 subscription calls.
+
+- [ ] **Step 2: Commit.** `runtime: step-2 live findings — resume, proposals, server`
+
+---
+
+## Self-review
+
+**Spec coverage:** §4.1 threads → T4; §4.2 session hook → T1; §4.3 loop → T6; §4.4 proposals → T5/T7; §4.5 API → T7; §4.6 registry → T2; §4.7 adapter → T8; §5 errors → T2 (retry), T6 (f), T7 (SSE terminal guarantee, status codes); §6 tests → per task; resume spikes → T1 step 6, T9. Vault discovery port → T3.
+
+**Placeholder scan:** Task 2 step 4 shows a rejected first draft explicitly followed by the version to use — implementers use the second block only. No TBDs.
+
+**Type consistency:** `StepEvent` `session` variant defined in T1 and consumed in T2 (retry buffers it), T6 (stores it). `ThreadStore.codexHomeFor(id)` (T4) used in T6. `isKnowledgePath(path, cfg)` (T3) used in T5. `createApp(deps)` deps mirror `runStep` deps (T6) plus `token`.

--- a/docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md
+++ b/docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md
@@ -1,0 +1,202 @@
+# Counsel loop, HTTP/SSE API, and plugin adapter — design (build step 2)
+
+Date: 2026-08-28
+Status: approved in brainstorm
+Parent spec: `2026-08-28-runtime-and-web-ui-design.md` (build order step 2)
+Prior work: PR #21 (`runtime/` skeleton: seams, router, three providers, `step` CLI)
+
+## 1. Goal
+
+Turn the runtime engine into something a lawyer can talk to, from the plugin today and
+from the web UI later, with one shared conversation history. Three deliverables:
+
+1. **Counsel loop** — the freeform step with the real methodology as its system prompt and
+   the `remember` propose-then-approve gate enforced by tool shape.
+2. **`counsel-os serve`** — a local HTTP/SSE server owning threads, runs, and the vault.
+3. **Plugin adapter** — the Claude Code skill uses the server when it is running and
+   behaves exactly as today when it is not.
+
+Plus two carry-overs: a providers registry file (long-tail direct providers), and
+provider retry with backoff.
+
+## 2. Decisions
+
+| Decision | Choice | Why |
+|---|---|---|
+| Conversation state | Runtime-owned persistent threads in the vault; vendor sessions mapped underneath | Plugin, CLI, and UI share one history; harness tiers keep their own context and cache, so history is not re-sent as one forgeable prompt |
+| Thread location | `.counsel/threads/<id>.jsonl` + `<id>.json` header | Under `.counsel/` so `vault_write` cannot touch it (guard from PR #21) |
+| Harness sessions | Claude: `resume: <session_id>` (sessions live under the real `HOME/.claude`). Codex: `resumeThread(id)` from a **persistent per-thread isolated home** `~/.counsel-os/codex/<threadId>/` (0700), removed with the thread | Codex sessions live inside `CODEX_HOME`; a per-run temp dir cannot resume |
+| Direct tier history | Replay the thread log, windowed to `contextTokens` | No vendor session to resume |
+| Prompt assembly | Host preamble + `skills/counsel/SKILL.md` body + practice profile + matter file; primitives via a `read_primitive` tool | Keeps the system prompt small and cacheable; mirrors the skill's own on-demand pattern; markdown stays untouched |
+| Script conventions | Preamble maps `python3 ${CLAUDE_PLUGIN_ROOT}/scripts/X.py` → tool `X`; scripts registered in `tools/builtin.ts` with platform sets | One methodology source; host differences live in the preamble |
+| `remember` gate | Entity/knowledge paths are writable only via `propose_update`; approval applies the write | Spec §5.1 "no silent writes", enforced by tool shape, not prompt |
+| Plugin adapter | `~/.counsel-os/runtime.json` (port, token, vault, pid) + `GET /health`; absent or unanswered → today's behavior | Zero change for users without the runtime |
+| Vault discovery | Port `scripts/resolve_legal_root.sh`'s algorithm to TS, same search order | One discovery algorithm, not two |
+| Long-tail providers | `~/.counsel-os/providers.yaml` registry merged over built-in defaults; `openai-compatible/<name>` with `baseURL` + `apiKeyEnv` | Adding a model is config, not a PR |
+| Generic CLI harness | Designed, not built (see parent discussion); built on first real request | Cost is small; demand is unproven |
+| Retry | `withRetry` wrapper on direct providers: 429/5xx, 3 tries, exponential backoff | Harness CLIs retry internally |
+| Streaming | SSE; text deltas coalesced server-side (≥ 50 ms or ≥ 200 chars) | Ollama streams per token; the UI must not |
+| Auth | Loopback only + random bearer token in `runtime.json` | Local product; no multi-user yet |
+
+## 3. Architecture
+
+```
+runtime/src/
+  server/
+    serve.ts         entry: resolve vault, bind 127.0.0.1:<port>, write runtime.json, routes
+    routes.ts        handlers (health, threads, steps, approve, vault)
+    sse.ts           StepEvent → SSE with delta coalescing
+    auth.ts          bearer check
+  loop/
+    prompt.ts        assembleSystemPrompt(vault, thread) — pure
+    counsel-loop.ts  runStep(thread, message, opts) → AsyncIterable<StepEvent>
+    proposals.ts     propose_update tool + apply on approval
+    primitives.ts    read_primitive tool (reads primitives/<name>.md from the plugin root)
+  threads/
+    store.ts         ThreadStore over VaultStore paths under .counsel/threads
+    window.ts        history windowing to a token budget
+  providers/
+    registry.ts      built-in defaults + ~/.counsel-os/providers.yaml → ModelProvider[]
+    retry.ts         withRetry(provider)
+    (claude-harness, codex-harness gain `sessionId` in/out)
+  vault/
+    resolve-root.ts  port of resolve_legal_root.sh
+  tools/builtin.ts   + extract_redlines, check_document, clean_format, apply_redlines, word_compare
+scripts/runtime_step.sh   plugin adapter (bash)
+skills/counsel/SKILL.md   + one preamble paragraph: use the runtime when present
+```
+
+## 4. Interfaces
+
+### 4.1 Threads
+
+```ts
+interface ThreadHeader {
+  id: string;                 // ulid
+  title?: string;
+  matter?: string;            // vault-relative matter path
+  createdAt: string; updatedAt: string;
+  sessions: Record<string, string>;   // providerId → vendor session/thread id
+}
+type ThreadEvent =
+  | { t: 'user'; at: string; content: string }
+  | { t: 'step'; at: string; runId: string; provider: string; task?: string }
+  | StepEvent & { at: string }          // text (coalesced), tool_call, tool_result, done, error
+  | { t: 'proposal'; at: string; id: string; path: string; content: string; rationale: string; status: 'pending'|'approved'|'rejected'; expectedVersion: string|null };
+
+interface ThreadStore {
+  create(tenant, init: { title?, matter? }): Promise<ThreadHeader>;
+  get(tenant, id): Promise<{ header: ThreadHeader; events: ThreadEvent[] }>;
+  list(tenant): Promise<ThreadHeader[]>;
+  append(tenant, id, ev: ThreadEvent): Promise<void>;
+  setSession(tenant, id, providerId, sessionId): Promise<void>;
+  remove(tenant, id): Promise<void>;   // also removes ~/.counsel-os/codex/<id>
+}
+```
+
+### 4.2 Provider session hook
+
+`StepRequest` gains `session?: { id?: string }`; `StepEvent` `done` gains
+`sessionId?: string`. Claude harness passes `resume: session.id` and reports
+`session_id` from the result; Codex harness uses `resumeThread(id)` and reports
+`thread_id` from `thread.started`. Direct providers ignore both.
+
+### 4.3 Loop
+
+```ts
+runStep(opts: {
+  tenant; thread: ThreadHeader; message: string; task?: string; providerId?: string;
+  outputSchema?: ZodType;
+}): AsyncIterable<StepEvent>
+```
+1. Append `user` event. 2. Resolve provider (explicit id or router by task).
+3. Build `StepRequest`: `system = assembleSystemPrompt(vault, thread)`; if the provider has a
+   session for this thread → `messages = [message]` + `session`; else `messages = window(log)`.
+   Tools = vault tools (with `vault_write` refusing entity/knowledge paths) + `propose_update` +
+   `read_primitive` + `builtinTools()` filtered by platform. 4. Stream, appending each event;
+   on `done`, store `sessionId` if present and write `runs/<runId>.log.jsonl`
+   (per step: provider, tokens, cost, duration, tool calls).
+
+### 4.4 Proposals
+
+`propose_update { path, content, rationale }` → appends a `proposal` event (with the
+current version of `path`) and returns the proposal id to the model. `vault_write` on
+`entities/**`, `knowledge/**`, `practice/**` (the vault's knowledge-system dirs, read from the
+practice config) → error result "use propose_update". `POST /threads/:id/approve
+{ proposalId, decision: 'approve'|'reject' }` → on approve, `VaultStore.write(path, content,
+{ expectedVersion })`; conflict → 409 with both versions; the event's status is updated.
+
+### 4.5 HTTP API
+
+| Method | Path | Body → Response |
+|---|---|---|
+| GET | `/health` | → `{ vault, tenant, providers: [{id,kind,auth,capabilities}], default }` |
+| GET/POST | `/threads` | POST `{ title?, matter? }` → header |
+| GET/DELETE | `/threads/:id` | GET → `{ header, events }` |
+| POST | `/threads/:id/steps` | `{ message, task?, provider?, outputSchema? }` → `text/event-stream` of `StepEvent` (+ `runId` on first event) |
+| POST | `/threads/:id/approve` | `{ proposalId, decision }` → updated proposal event |
+| GET | `/vault/list?dir=` `/vault/read?path=` | read-only |
+
+All routes require `Authorization: Bearer <token>`; bind `127.0.0.1` only.
+`runtime.json` = `{ port, token, vault, pid, startedAt }` at `~/.counsel-os/runtime.json`,
+mode 0600, removed on SIGINT/SIGTERM.
+
+### 4.6 Providers registry
+
+```yaml
+# ~/.counsel-os/providers.yaml (merged over built-ins)
+default: claude-sub/claude-opus-5
+providers:
+  - id: openai-compatible/groq
+    baseURL: https://api.groq.com/openai/v1
+    apiKeyEnv: GROQ_API_KEY
+    capabilities: { contextTokens: 128000, tools: true, caching: false, thinking: false, auth: apikey }
+tasks:
+  classify: { prefer: ollama/gemma4:e4b }
+```
+`loadRegistry()` → `{ providers: ModelProvider[], router: Router }`. Unknown id prefix → error
+at load time, not at step time.
+
+### 4.7 Plugin adapter
+
+`scripts/runtime_step.sh "<request>"`: reads `runtime.json`; `curl /health` with a 1 s
+timeout; on success, creates/reuses a thread id stored at
+`${TMPDIR}/counsel-os-thread-${CLAUDE_SESSION_ID:-$$}`, POSTs the step, and prints the
+SSE text as it arrives plus a one-line summary of tool calls; exits 0. On any failure it
+prints nothing and exits 3. `SKILL.md` gains one paragraph: run the script first; on exit 3,
+continue with the existing methodology. Everything else in the skill is unchanged.
+
+## 5. Error handling
+
+- Provider `error` → thread log records it; SSE sends `error` then closes; HTTP 200 (the
+  stream carried the failure). Never a dropped connection without a terminal event.
+- `withRetry` (direct only): 429/5xx → 3 tries, 500 ms × 2ⁿ; other errors pass through.
+- 401 bad token · 404 unknown thread/proposal · 409 approve conflict · 422 unknown provider
+  or task requirement unsatisfiable (router error text) · 503 vault not found at startup.
+- Resume failure (vendor session gone) → log a warning event, drop the stored session id,
+  fall back to replaying the log for that step.
+
+## 6. Testing
+
+- Pure: `assembleSystemPrompt` (snapshot; a primitive edit must not change it, a SKILL.md edit
+  must), `window()`, `ThreadStore` (append/read/list/remove incl. codex home cleanup),
+  proposals (refusal on knowledge paths; approve/reject/conflict), registry merge and errors,
+  `withRetry`, `resolveLegalRoot` (fixture dirs for each search-order case), SSE coalescing.
+- Server: routes end-to-end with `FakeModelProvider` (SSE parsed back into events).
+- Adapter: `runtime_step.sh` against a local fake-provider server; exit 3 when no server.
+- Live (before the PR, two subscription calls): Claude resume across two steps on one thread;
+  Codex resume from the persistent per-thread home. Ollama end-to-end via the server.
+
+## 7. Out of scope
+
+Flow engine, web UI, hosted mode, generic CLI harness, multi-tenant auth.
+
+## 8. Build order
+
+1. Provider session hook + registry + retry (`providers/`).
+2. `resolve-root.ts`, `ThreadStore`, `window`.
+3. Prompt assembly, `read_primitive`, proposals, builtin script tools.
+4. Counsel loop (`runStep`) + run logs.
+5. Server: auth, routes, SSE, `serve.ts`, `runtime.json`.
+6. Plugin adapter script + SKILL.md paragraph.
+7. Live smokes; spikes for Claude/Codex resume are the first live checks in task 1.

--- a/docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md
+++ b/docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md
@@ -72,7 +72,7 @@ skills/counsel/SKILL.md   + one preamble paragraph: use the runtime when present
 
 ```ts
 interface ThreadHeader {
-  id: string;                 // ulid
+  id: string;                 // uuid v4
   title?: string;
   matter?: string;            // vault-relative matter path
   createdAt: string; updatedAt: string;
@@ -98,8 +98,9 @@ interface ThreadStore {
 
 `StepRequest` gains `session?: { id?: string }`; `StepEvent` `done` gains
 `sessionId?: string`. Claude harness passes `resume: session.id` and reports
-`session_id` from the result; Codex harness uses `resumeThread(id)` and reports
-`thread_id` from `thread.started`. Direct providers ignore both.
+`session_id` from the `system/init` message; Codex harness uses
+`resumeThread(id)` and reports `thread_id` from `thread.started`. Direct
+providers ignore both.
 
 ### 4.3 Loop
 

--- a/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
+++ b/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
@@ -583,3 +583,362 @@ and is left for a future spike if the loop's fast-follow needs stronger proof.
 
 No retries were needed on either side; the 2+2 call budget was used exactly
 once per side.
+
+---
+
+## Step 2 — server, resume, proposals, adapter
+
+Task 9. Question: does the whole stack work end to end against real
+providers — the HTTP/SSE server, per-provider session resume across two
+steps of one thread, the propose-then-approve write gate, and the plugin
+adapter's exit-code contract?
+
+Budget: 4 subscription calls (2 Claude, 2 Codex), all 4 used, none retried.
+Ollama covered the rest.
+
+### Setup
+
+A fresh temp vault, marked and fictional:
+
+```
+<vault>/config.md                      # counsel-os-config: true, legal_root: <vault>
+<vault>/practice/profile.md            # Wren Halloway, Halloway Law PLLC (fictional solo practice)
+<vault>/practice/standards/nda.md      # two NDA positions
+<vault>/matters/acme.md                # Acme Robotics reseller agreement, deadline 2026-09-15
+```
+
+The server ran with `COUNSEL_OS_HOME` pointed at a temp directory, so it
+never touched the real `~/.counsel-os/runtime.json`:
+
+```bash
+COUNSEL_OS_HOME=<home> bun runtime/src/cli.ts serve --vault <vault>
+# counsel-os runtime on http://127.0.0.1:7431 (vault: <vault>)
+```
+
+`<home>/runtime.json` appeared with mode `0600`:
+
+```json
+{ "port": 7431, "token": "<64 hex chars>", "vault": "<vault>", "pid": 9334,
+  "startedAt": "2026-08-29T02:31:52.915Z" }
+```
+
+`GET /health` (bearer token from that file) listed all three builtin
+providers and `"default": "claude-sub/claude-opus-5"`. The same request
+without the header returned **401**.
+
+Every step below used:
+
+```bash
+curl -sN -H "Authorization: Bearer $TOK" -H 'Content-Type: application/json' \
+  --data-binary '{"message":"…","provider":"…"}' \
+  "http://127.0.0.1:$PORT/threads/$TID/steps"
+```
+
+### (a) Claude — resume across two steps · PASS
+
+Thread `9b79cf78`, provider `claude-sub/claude-opus-5`.
+
+Step 1 — `"Remember the codeword 'tangerine' for this thread."` (3.0 s):
+
+```
+event: text
+data: {"type":"text","text":"Got it — the codeword for this thread is **tangerine**.",…}
+event: done
+data: {"type":"done","output":"Got it …","usage":{"inputTokens":12878,"outputTokens":22,"costUsd":0.130304},
+       "sessionId":"386d84be-b4e7-4d23-a36e-aeb82c5d33c0","runId":"9837478b-…"}
+```
+
+The thread header then held the session:
+
+```json
+{ "id": "9b79cf78-…", "sessions": { "claude-sub/claude-opus-5": "386d84be-b4e7-4d23-a36e-aeb82c5d33c0" } }
+```
+
+Step 2 — `"What codeword did I give you?"` (2.5 s):
+
+```
+event: text
+data: {"type":"text","text":"The codeword you gave me is **tangerine**.",…}
+event: done
+data: {"type":"done","usage":{"inputTokens":12937,"outputTokens":18,"costUsd":0.007488},
+       "sessionId":"386d84be-b4e7-4d23-a36e-aeb82c5d33c0","runId":"cbfcaac6-…"}
+```
+
+**PASS.** How the resume was verified — four independent signals, since no
+event says "this request carried a session id":
+
+1. The header carried the id **before** step 2 ran (shown above).
+2. Step 2 recalled `tangerine`. The word appears nowhere in the vault, the
+   system prompt, or step 2's own message, so only the vendor-side session
+   could supply it.
+3. The thread log holds **no `warning` event**. `runStep` appends
+   `session expired; replaying history` whenever the resume attempt fails and
+   it falls back to replaying the window. Its absence means the resume
+   attempt stood.
+4. `done.sessionId` on step 2 equals step 1's id, and `inputTokens` moved
+   only 12,878 → 12,937 (+59) — a new turn on a live session, not a replayed
+   two-turn window.
+
+The full thread log, in order: `user`, `step`, `text`, `done`, `user`,
+`step`, `text`, `done` — one `step` event per request, each naming its
+provider and `runId`.
+
+### (b) Codex — resume across two steps · PASS
+
+Thread `8961dec6`, provider `codex-sub/gpt-5.6-terra`.
+
+Step 1 (5.3 s):
+
+```
+event: text
+data: {"type":"text","text":"I’ll remember “tangerine” for this thread.",…}
+event: done
+data: {"type":"done","usage":{"inputTokens":18281,"outputTokens":34},
+       "sessionId":"01a04b5e-73dc-7011-9df9-4ef6285e949b","runId":"54e7fd42-…"}
+```
+
+Step 2 (3.1 s):
+
+```
+event: text
+data: {"type":"text","text":"Tangerine.",…}
+event: done
+data: {"type":"done","usage":{"inputTokens":25086,"outputTokens":8},
+       "sessionId":"01a04b5e-73dc-7011-9df9-4ef6285e949b","runId":"64be9481-…"}
+```
+
+**PASS**, and cleaner than the Task 1 spike above: the model answered from
+conversational memory with **zero** tool calls, so this run does distinguish
+"the resumed thread remembers" from "the model re-read the vault". The Task 1
+caveat is now retired. No `warning` event, same `sessionId`, `inputTokens`
+18,281 → 25,086 (the prior turn carried forward).
+
+**Where the Codex home actually landed:** `ThreadStore.codexHomeFor(id)`
+returns `join(this.codexHomeRoot, id)`, and `codexHomeRoot` defaults to
+`join(homedir(), '.counsel-os', 'codex')`. `serve.ts` constructs
+`new ThreadStore(vaultRoot)` with **no** `codexHomeRoot` option, so the
+directory was created at
+
+```
+~/.counsel-os/codex/8961dec6-0c7d-47f7-8042-8a518e8cb4b5/
+```
+
+— in the developer's real home, **not** under `COUNSEL_OS_HOME`. It held
+`auth.json`, `sessions/`, `thread_history_1.sqlite`, and the rest of a live
+Codex home. The session id round-tripped into the rollout file name:
+
+```
+sessions/2026/08/28/rollout-2026-08-28T19-34-36-01a04b5e-73dc-7011-9df9-4ef6285e949b.jsonl
+```
+
+Session storage works. The location ignores the environment override — see
+defect 1. The directory was removed after the run.
+
+### (c) Ollama — vault tools · PASS
+
+Thread `8aaedd7a`, provider `ollama/gemma4:e4b`, one step:
+`"List the vault root and read matters/acme.md, then summarize the deadline"`.
+28.8 s wall-clock.
+
+```json
+{"type":"tool_call","name":"vault_read","input":{"path":"matters/acme.md"}}
+{"type":"tool_call","name":"docket_sweep","input":{"days":60}}
+{"type":"tool_result","name":"vault_read","output":{"content":"# Matter: Acme Robotics — reseller agreement…"},"isError":false}
+{"type":"tool_result","name":"docket_sweep","output":{"stdout":"{\"today\":\"2026-08-28\",\"window\":60,\"counts\":{…}}"},"isError":false}
+{"type":"done","usage":{"inputTokens":16659,"outputTokens":1139}}
+```
+
+Answer (abridged): *"the specific, critical deadline for the Acme Robotics
+matter is **September 15, 2026** … Borealis Components LLC plans to withdraw
+its pricing afterward."*
+
+**PASS** on the graded behavior: the vault tools attached over HTTP, both
+calls returned `isError:false`, and the deadline summary is correct.
+
+One deviation from the expected shape: the model never called `vault_list`.
+It read the named file directly and reached for `docket_sweep` instead, then
+asserted *"the current directory context is treated as the vault root"*
+without having listed anything. `docket_sweep` proves the platform script
+tools reach the model through the server, which the prompt did not ask for.
+
+### (d) Proposal gate · PASS
+
+Thread `dd166299`, provider `ollama/gemma4:e4b` (free tier, per the brief).
+Step: `"Update practice/standards/nda.md to add a position: term of
+confidentiality is 3 years."` 14.0 s.
+
+```json
+{"type":"tool_call","name":"vault_read","input":{"path":"practice/standards/nda.md"}}
+{"type":"tool_call","name":"propose_update","input":{"path":"practice/standards/nda.md",
+  "content":"# NDA standards\n\n## Positions\n\n- Mutual by default…\n- Carve-outs…\n- Term of confidentiality: 3 years.",
+  "rationale":"Proposed update to reflect the standard 3-year term…"}}
+{"type":"tool_result","name":"propose_update","output":"{\"proposalId\":\"284689ff-0c54-44f1-a3c6-c7137c682e56\"}","isError":false}
+{"type":"done","usage":{"inputTokens":24970,"outputTokens":893}}
+```
+
+The thread log carried the proposal, pending, with the path's version at
+proposal time:
+
+```json
+{"t":"proposal","id":"284689ff-…","path":"practice/standards/nda.md","status":"pending",
+ "expectedVersion":"64a7bfe4cca650c41b87d74a4c68dd9771e561317ba21a253c6f0886cd37b01d"}
+```
+
+`practice/standards/nda.md` was **byte-identical** to before the step
+(`shasum` `ccc573c4…` before and after). The gate held.
+
+Approve:
+
+```bash
+curl -X POST … -d '{"proposalId":"284689ff-…","decision":"approve"}' \
+  "http://127.0.0.1:$PORT/threads/$TID/approve"
+```
+
+```json
+{ "proposal": { "status": "approved", "path": "practice/standards/nda.md" },
+  "version": "ed8abed66b10be053b05a4e89293e11ca66f44629de5c354934c439dffd91e01" }
+```
+
+The file then held the proposal content verbatim, `shasum` `db739d34…`, with
+the new position appended. The proposal event in the log reads
+`"status":"approved"`. A **second** approve of the same proposal returned
+**409** and wrote nothing.
+
+**PASS.** Propose does not write, approve does, and the decision is
+idempotent.
+
+### (e) Plugin adapter · PASS
+
+`scripts/runtime_step.sh` was exercised against a server whose router default
+was set to `ollama/gemma4:e4b`, so the adapter's own step cost no
+subscription call. (Setting that default required writing
+`~/.counsel-os/providers.yaml` in the real home — see defect 2. The file was
+removed afterwards.)
+
+Server **running** (11 s):
+
+```bash
+COUNSEL_OS_HOME=<home> CLAUDE_SESSION_ID=task9-smoke bash scripts/runtime_step.sh "What matters do I have?"
+# exit 0
+# stdout: 380 bytes of prose
+# stderr: "→ tool vault_search"
+```
+
+The adapter created its own thread (`f13ed831-…`) and cached the id at
+`$TMPDIR/counsel-os-thread-task9-smoke`. Exit **0**, text on stdout, the tool
+trace on stderr where it belongs.
+
+Server **stopped** (`SIGTERM`, `runtime.json` removed by the signal handler):
+
+```
+exit 3   stdout 0 bytes   stderr 0 bytes
+```
+
+A **stale** `runtime.json` (a hand-written file naming a dead pid and a
+closed port) behaved the same way: exit **3**, both streams empty — the
+`/health` probe caught it.
+
+**PASS** on all three arms of the exit-code contract.
+
+Content note, not an adapter defect: `gemma4:e4b` answered *"I didn't find
+any currently recorded matters"* after searching for the string
+`counsel-os-type: matter`. The vault does contain `matters/acme.md`. The
+model invented a frontmatter marker the system prompt never mentions, rather
+than listing `matters/`, which the preamble does name. The adapter relayed
+that answer faithfully.
+
+### Usage and wall-clock
+
+Wall-clock is measured at `curl`; `durationMs` is the run log's own number.
+
+| # | Provider | Wall | `durationMs` | in / out tokens | costUsd |
+|---|---|---|---|---|---|
+| (a) 1 | `claude-sub/claude-opus-5` | 3.0 s | **9** | 12,878 / 22 | 0.130304 |
+| (a) 2 | `claude-sub/claude-opus-5` | 2.5 s | **7** | 12,937 / 18 | 0.007488 |
+| (b) 1 | `codex-sub/gpt-5.6-terra` | 5.3 s | **20** | 18,281 / 34 | — |
+| (b) 2 | `codex-sub/gpt-5.6-terra` | 3.1 s | **12** | 25,086 / 8 | — |
+| (c) | `ollama/gemma4:e4b` | 28.8 s | 9,148 | 16,659 / 1,139 | — |
+| (d) | `ollama/gemma4:e4b` | 14.0 s | 9,281 | 24,970 / 893 | — |
+| (e) | `ollama/gemma4:e4b` | 11 s | 3,730 | 16,348 / 684 | — |
+
+Two things stand out. The `durationMs` column is wrong on every row (defect
+3). And the system prompt is now the floor of every step: ~12.9 k input
+tokens on Claude for a two-sentence exchange, against ~1.3 k in the Task 1
+resume spike, because `assembleSystemPrompt` prepends the host preamble plus
+the whole 27 KB `skills/counsel/SKILL.md`. Codex's first call cost $0.13 on
+Claude and 18 k input tokens on Codex for the same reason.
+
+### Verdict
+
+| Smoke | Result |
+|---|---|
+| (a) Claude resume across two steps | **PASS** |
+| (b) Codex resume across two steps | **PASS** — and the Task 1 vault-read caveat is retired |
+| (c) Ollama vault tools over the server | **PASS** — `vault_read` + `docket_sweep`; no `vault_list` |
+| (d) Propose → no write → approve → write | **PASS** — double-approve is 409 |
+| (e) Adapter exit 0 / 3 (live, stopped, stale) | **PASS** |
+
+The server, the loop, the session hook, the proposal gate, and the adapter
+all work end to end against real providers.
+
+### Defects found — Step 2
+
+Recorded, not fixed.
+
+1. **Codex thread homes ignore `COUNSEL_OS_HOME`.** `serve.ts` builds
+   `new ThreadStore(vaultRoot)` with no `codexHomeRoot`, and the store's
+   default is `join(homedir(), '.counsel-os', 'codex')`. A server started
+   with `COUNSEL_OS_HOME=<temp>` still wrote
+   `~/.counsel-os/codex/<threadId>/` — including a copy of `auth.json` —
+   into the real home. `serve.ts` already has `counselHome(env)` for
+   `runtime.json`; the store is simply not given it. Two costs: a test or a
+   sandboxed run cannot be isolated, and credentials land somewhere the
+   operator did not point at.
+   (`runtime/src/server/serve.ts`, `runtime/src/threads/store.ts`.)
+2. **The provider registry ignores `COUNSEL_OS_HOME` too.**
+   `DEFAULT_REGISTRY_FILE` is `join(homedir(), '.counsel-os', 'providers.yaml')`,
+   not `counselHome(env)`. Overriding the default provider for this smoke
+   required writing into the developer's real home. Same one-line family as
+   defect 1. (`runtime/src/providers/registry.ts`.)
+3. **Run-log `durationMs` measures almost nothing.** `stream()` starts its
+   clock **after** `beginAttempt()` has already awaited the provider's first
+   non-`session` event — which, on both harnesses, is the whole model turn.
+   Claude steps of 3.0 s and 2.5 s logged `durationMs` of **9** and **7**;
+   Codex steps of 5.3 s and 3.1 s logged **20** and **12**. The Ollama rows
+   are wrong by a smaller factor (28.8 s wall → 9,148 ms) because that tier
+   streams early. Any latency or cost report built on this field is wrong by
+   two orders of magnitude on the harness tiers. The clock belongs at the top
+   of `runStep`, not inside `stream`. (`runtime/src/loop/counsel-loop.ts`.)
+4. **The thread log stores one `text` event per Ollama token.** SSE
+   coalescing lives in `sseFromEvents`, downstream of `store.append`, so the
+   log keeps the raw deltas: smoke (c) wrote **177** `text` events / 13 KB of
+   JSONL for one ~800-character answer, while the client saw 45 coalesced
+   frames. `window()` re-joins consecutive `text` events, so replay is
+   correct — this is size and client ergonomics, not correctness. But every
+   consumer of `GET /threads/:id` now has to redo the coalescing the SSE
+   layer already does. (`runtime/src/loop/counsel-loop.ts` `stream`,
+   `runtime/src/server/sse.ts`.)
+5. **No `proposal` frame on the SSE stream.** The proposal reaches the thread
+   log and `GET /threads/:id`, but a client watching only the step's stream
+   sees an ordinary `tool_call` / `tool_result` pair for `propose_update`. To
+   render the diff and to get the `proposalId` that `POST /approve` requires,
+   it must parse the tool call's arguments or re-`GET` the whole thread.
+   Spec §4.4's approve flow is reachable but not streamable.
+   (`runtime/src/loop/counsel-loop.ts`, `runtime/src/server/sse.ts`.)
+
+### What the next plan should assume — Step 2
+
+- The stack is viable end to end. Nothing here blocks the API or the adapter.
+- **Fix the three `homedir()` call sites together** (defects 1 and 2). One
+  shared `counselHome(env)` helper, passed into `ThreadStore` and
+  `loadRegistry`, closes both — and makes the runtime testable without
+  writing to the developer's home.
+- **Do not report `durationMs` to a user until defect 3 is fixed.** It is not
+  slightly off; it is off by ~300× on the Claude tier.
+- **The system prompt is the dominant cost of a small step.** 12.9 k input
+  tokens before the user says anything. If short exchanges matter, the
+  preamble plus `SKILL.md` needs trimming, or the harness tiers need prompt
+  caching that our usage numbers can actually see (spike 9.x defect 4 is
+  still open).
+- **A UI needs the proposal as a first-class frame** (defect 5), or it will
+  reverse-engineer the gate out of tool-call arguments.

--- a/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
+++ b/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
@@ -454,3 +454,132 @@ disambiguate the failures above. They re-import the real
 `buildQueryOptions` / `mapClaudeMessage` / `buildCodexConfig` /
 `buildThreadOptions` / `buildCodexEnv` / `mapCodexEvent` and change exactly one
 thing each. Nothing under `runtime/src` was modified for any spike.
+
+---
+
+## Step 2 — resume
+
+Task 1 (`runtime: provider session hook`). Question: does a session captured
+from one `step` actually let a second, independent `step` invocation resume
+it — Claude via `Options.resume`, Codex via `codex.resumeThread(id, ...)` with
+a persistent `CODEX_HOME` — and recall something only the first turn was told?
+
+Budget: 2 Claude calls + 2 Codex calls, both used, none retried. Driver: the
+Task 1 CLI additions — `--session <id>` (both harnesses; parsed into
+`session: { id }` on the `StepRequest`), `--codex-home <dir>` (threaded to
+`CodexHarnessProvider`'s new persistent `homeDir` option), `--cwd <dir>`
+(debug-only pin for the Claude harness's temp cwd — added per the brief in
+case resume needed a stable cwd; turned out not to be needed, see below).
+
+Same temp vault as spikes 9.x: `acme.md` (root) + `matters/beta.md`.
+
+### Claude — `claude-sub/claude-opus-5`
+
+Call 1 — no `--session`, fresh temp cwd (as always):
+
+```bash
+bun runtime/src/cli.ts step --vault <vault> --provider claude-sub/claude-opus-5 \
+  "Remember the word pineapple."
+```
+
+```json
+{"type":"session","id":"4e0914a9-9d0c-465b-9e7c-569029f9405b"}
+{"type":"text","text":"Got it — pineapple. I'll keep it in mind for this conversation."}
+{"type":"done","output":"Got it — pineapple. I'll keep it in mind for this conversation.","usage":{"inputTokens":1335,"outputTokens":26,"costUsd":0.014967},"sessionId":"4e0914a9-9d0c-465b-9e7c-569029f9405b"}
+```
+
+Call 2 — `--session <id from call 1>`, deliberately **no** `--cwd` (a brand
+new `mkdtempSync` cwd, different from call 1's):
+
+```bash
+bun runtime/src/cli.ts step --vault <vault> --provider claude-sub/claude-opus-5 \
+  --session 4e0914a9-9d0c-465b-9e7c-569029f9405b \
+  "What word did I ask you to remember?"
+```
+
+```json
+{"type":"session","id":"4e0914a9-9d0c-465b-9e7c-569029f9405b"}
+{"type":"text","text":"Pineapple."}
+{"type":"done","output":"Pineapple.","usage":{"inputTokens":1400,"outputTokens":8,"costUsd":0.0015265},"sessionId":"4e0914a9-9d0c-465b-9e7c-569029f9405b"}
+```
+
+**PASS.** `resume` worked on the first try, with a *different* cwd on the
+second call — the `--cwd` debug option the brief anticipated needing was not
+needed here; the CLI resolves and reuses the same `session_id` and the model
+answers "Pineapple." with no re-derivation available (nothing else in the
+prompt mentions the word). `--cwd` is kept in `cli.ts` regardless, since the
+brief calls it a useful debug option and this is one data point, not a proof
+it's never needed on another machine or CLI version.
+
+### Codex — `codex-sub/gpt-5.6-terra`
+
+Call 1 — fresh `--codex-home $(mktemp -d)`:
+
+```bash
+CHOME=$(mktemp -d)
+bun runtime/src/cli.ts step --vault <vault> --provider codex-sub/gpt-5.6-terra \
+  --codex-home "$CHOME" "Remember the word pineapple."
+```
+
+```json
+{"type":"session","id":"01a04ac7-79d1-71d2-b101-5b85650e4cda"}
+{"type":"text","text":"I'll save that in your vault."}
+{"type":"tool_call","id":"item_1","name":"vault_list","input":{"dir":"."}}
+{"type":"tool_call","id":"item_2","name":"vault_read","input":{"path":"acme.md"}}
+{"type":"tool_call","id":"item_3","name":"vault_write","input":{"path":"acme.md","content":"# Acme Corp\n\n- Remember: pineapple.\n", ...}}
+{"type":"text","text":"Remembered: pineapple."}
+{"type":"done","output":"Remembered: pineapple.","usage":{"inputTokens":62601,"outputTokens":323},"sessionId":"01a04ac7-79d1-71d2-b101-5b85650e4cda"}
+```
+
+(The model chose to persist the word into the vault via `vault_write` on its
+own initiative — not requested — which matters for reading call 2 below.)
+
+Confirmed `$CHOME` was not removed after call 1 (`resolveCodexHome`'s
+`ephemeral: false` path): `ls "$CHOME"` afterward showed `auth.json`,
+`sessions`, `thread_history_1.sqlite`, and other live Codex state, seeded from
+the real `~/.codex/auth.json`.
+
+Call 2 — same `--codex-home "$CHOME"`, `--session <thread_id from call 1>`:
+
+```bash
+bun runtime/src/cli.ts step --vault <vault> --provider codex-sub/gpt-5.6-terra \
+  --codex-home "$CHOME" --session 01a04ac7-79d1-71d2-b101-5b85650e4cda \
+  "What word did I ask you to remember?"
+```
+
+```json
+{"type":"session","id":"01a04ac7-79d1-71d2-b101-5b85650e4cda"}
+{"type":"text","text":"I'll check the vault."}
+{"type":"tool_call","id":"item_1","name":"vault_search","input":{"query":"Remember"}}
+{"type":"tool_call","id":"item_2","name":"vault_search","input":{"query":"pineapple"}}
+{"type":"tool_call","id":"item_3","name":"vault_list","input":{"dir":"."}}
+{"type":"tool_call","id":"item_4","name":"vault_read","input":{"path":"acme.md"}}
+{"type":"text","text":"Pineapple."}
+{"type":"done","output":"Pineapple.","usage":{"inputTokens":66743,"outputTokens":299},"sessionId":"01a04ac7-79d1-71d2-b101-5b85650e4cda"}
+```
+
+**PASS, with a caveat.** The thread resumed (same `sessionId` echoed back,
+`inputTokens` rose from 62,601 → 66,743 — consistent with the prior turn's
+history being carried forward rather than a fresh thread) and the model
+answered "Pineapple." correctly. But unlike Claude's call 2, the model didn't
+answer straight from conversational memory — it re-verified by searching and
+re-reading the vault file it had itself written in call 1. That file is the
+only place "pineapple" appears outside the resumed thread's own history, so
+this run does not by itself distinguish "the resumed thread remembers the
+word" from "the model is cautious and always checks the vault before
+answering." The `sessionId` continuity and the input-token growth are still
+real, positive evidence that `resumeThread` is wiring up the same thread
+rather than starting a new one; a cleaner follow-up (ask something the
+resumed turn could only answer from conversational memory, with nothing
+written to the vault) is one call outside this task's two-call Codex budget
+and is left for a future spike if the loop's fast-follow needs stronger proof.
+
+### Verdict
+
+| Side | Result |
+|---|---|
+| Claude `resume` | **PASS** — clean recall, no `--cwd` needed |
+| Codex `resumeThread` + persistent `CODEX_HOME` | **PASS** (with the vault-read caveat above) — same `sessionId`, thread state carried forward, correct answer |
+
+No retries were needed on either side; the 2+2 call budget was used exactly
+once per side.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.44",
     "@ai-sdk/openai": "^4.0.50",
+    "@ai-sdk/openai-compatible": "^3.0.40",
     "@anthropic-ai/claude-agent-sdk": "^0.3.250",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@openai/codex-sdk": "^0.150.1",

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -28,7 +28,7 @@ const { values, positionals } = parseArgs({
 
 const [cmd, ...rest] = positionals;
 if (cmd !== 'step' || !values.vault || !values.provider || rest.length === 0) {
-  console.error('usage: bun runtime/src/cli.ts step --vault <dir> --provider <id> [--task <name>] [--schema <json>] "<prompt>"');
+  console.error('usage: bun runtime/src/cli.ts step --vault <dir> --provider <id> [--task <name>] [--schema <json>] [--session <id>] [--codex-home <dir>] [--cwd <dir>] "<prompt>"');
   process.exit(2);
 }
 

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -4,7 +4,8 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { z } from 'zod';
 import { FsVaultStore } from './vault/fs-store';
-import { vaultTools } from './vault/vault-tools';
+import { guardedVaultTools } from './vault/vault-tools';
+import { readVaultConfig } from './vault/resolve-root';
 import { ToolRegistry } from './tools/registry';
 import { builtinTools } from './tools/builtin';
 import { Router, parseRouterConfig } from './router/router';
@@ -59,7 +60,7 @@ try {
   process.exit(1);
 }
 
-const tools = [...vaultTools(store), ...registry.available()];
+const tools = [...guardedVaultTools(store, readVaultConfig(vaultRoot)), ...registry.available()];
 let exit = 1;
 for await (const ev of provider.run({
   tenant: DEFAULT_TENANT,

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -20,6 +20,9 @@ const { values, positionals } = parseArgs({
     task: { type: 'string' },
     schema: { type: 'string' },
     system: { type: 'string', default: 'You are counsel. Use the vault tools to answer. Be brief.' },
+    session: { type: 'string' },      // resume a prior session/thread by id (Claude `resume` / Codex `resumeThread`)
+    'codex-home': { type: 'string' }, // persistent CODEX_HOME so a resumed thread's isolated home survives across steps
+    cwd: { type: 'string' },          // debug: pin the Claude harness's cwd (see docs/superpowers/spikes/2026-08-28-runtime-spikes.md, Step 2 — resume)
   },
 });
 
@@ -38,7 +41,12 @@ for (const t of builtinTools({ vaultRoot, repoRoot })) registry.register(t);
 let provider: ModelProvider;
 let outputSchema: z.ZodType | undefined;
 try {
-  const providers = buildProviders({ ids: [values.provider], vaultRoot });
+  const providers = buildProviders({
+    ids: [values.provider],
+    vaultRoot,
+    ...(values.cwd ? { claudeCwd: resolve(values.cwd) } : {}),
+    ...(values['codex-home'] ? { codexHomeDir: resolve(values['codex-home']) } : {}),
+  });
   const router = new Router(parseRouterConfig(`default: ${values.provider}\n`), providers);
   // --task only has effect once a `tasks:` block exists in the router config;
   // this CLI always builds a bare `default: <provider>` config, so today it's a no-op.
@@ -59,6 +67,7 @@ for await (const ev of provider.run({
   messages: [{ role: 'user', content: rest.join(' ') }],
   tools,
   ...(outputSchema ? { outputSchema } : {}),
+  ...(values.session ? { session: { id: values.session } } : {}),
 })) {
   console.log(JSON.stringify(ev));
   if (isTerminal(ev)) exit = ev.type === 'done' ? 0 : 1;

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -11,6 +11,7 @@ import { builtinTools } from './tools/builtin';
 import { Router, parseRouterConfig } from './router/router';
 import { buildProviders } from './providers/index';
 import { DEFAULT_TENANT, isTerminal, type ModelProvider } from './core/types';
+import { startServer } from './server/serve';
 
 const { values, positionals } = parseArgs({
   args: Bun.argv.slice(2),
@@ -18,6 +19,7 @@ const { values, positionals } = parseArgs({
   options: {
     vault: { type: 'string' },
     provider: { type: 'string' },
+    port: { type: 'string' },       // `serve`: bind port (default 7431, then an OS-assigned one)
     task: { type: 'string' },
     schema: { type: 'string' },
     system: { type: 'string', default: 'You are counsel. Use the vault tools to answer. Be brief.' },
@@ -28,49 +30,75 @@ const { values, positionals } = parseArgs({
 });
 
 const [cmd, ...rest] = positionals;
-if (cmd !== 'step' || !values.vault || !values.provider || rest.length === 0) {
+
+function usage(): never {
   console.error('usage: bun runtime/src/cli.ts step --vault <dir> --provider <id> [--task <name>] [--schema <json>] [--session <id>] [--codex-home <dir>] [--cwd <dir>] "<prompt>"');
+  console.error('       bun runtime/src/cli.ts serve [--port <n>] [--vault <dir>]');
   process.exit(2);
 }
 
-const vaultRoot = resolve(values.vault);
-const repoRoot = resolve(import.meta.dir, '../..');
-const store = new FsVaultStore(vaultRoot);
-const registry = new ToolRegistry();
-for (const t of builtinTools({ vaultRoot, repoRoot })) registry.register(t);
-
-let provider: ModelProvider;
-let outputSchema: z.ZodType | undefined;
-try {
-  const providers = buildProviders({
-    ids: [values.provider],
-    vaultRoot,
-    ...(values.cwd ? { claudeCwd: resolve(values.cwd) } : {}),
-    ...(values['codex-home'] ? { codexHomeDir: resolve(values['codex-home']) } : {}),
+// `serve` runs the local HTTP/SSE runtime and then just stays up — Bun.serve
+// keeps the process alive, and the signal handlers startServer installs are
+// what remove ~/.counsel-os/runtime.json on the way out.
+if (cmd === 'serve') {
+  let port: number | undefined;
+  if (values.port !== undefined) {
+    port = Number(values.port);
+    if (!Number.isInteger(port) || port < 0 || port > 65535) {
+      console.error(`--port must be a port number, got: ${values.port}`);
+      process.exit(2);
+    }
+  }
+  await startServer({
+    ...(values.vault ? { vault: values.vault } : {}),
+    ...(port === undefined ? {} : { port }),
   });
-  const router = new Router(parseRouterConfig(`default: ${values.provider}\n`), providers);
-  // --task only has effect once a `tasks:` block exists in the router config;
-  // this CLI always builds a bare `default: <provider>` config, so today it's a no-op.
-  provider = router.resolve(values.task);
-  outputSchema = values.schema
-    ? z.fromJSONSchema(JSON.parse(readFileSync(values.schema, 'utf8')) as Record<string, unknown>)
-    : undefined;
-} catch (err) {
-  console.log(JSON.stringify({ type: 'error', message: err instanceof Error ? err.message : String(err) }));
-  process.exit(1);
+} else {
+  await step();
 }
 
-const tools = [...guardedVaultTools(store, readVaultConfig(vaultRoot)), ...registry.available()];
-let exit = 1;
-for await (const ev of provider.run({
-  tenant: DEFAULT_TENANT,
-  system: values.system!,
-  messages: [{ role: 'user', content: rest.join(' ') }],
-  tools,
-  ...(outputSchema ? { outputSchema } : {}),
-  ...(values.session ? { session: { id: values.session } } : {}),
-})) {
-  console.log(JSON.stringify(ev));
-  if (isTerminal(ev)) exit = ev.type === 'done' ? 0 : 1;
+async function step(): Promise<void> {
+  if (cmd !== 'step' || !values.vault || !values.provider || rest.length === 0) usage();
+
+  const vaultRoot = resolve(values.vault);
+  const repoRoot = resolve(import.meta.dir, '../..');
+  const store = new FsVaultStore(vaultRoot);
+  const registry = new ToolRegistry();
+  for (const t of builtinTools({ vaultRoot, repoRoot })) registry.register(t);
+
+  let provider: ModelProvider;
+  let outputSchema: z.ZodType | undefined;
+  try {
+    const providers = buildProviders({
+      ids: [values.provider],
+      vaultRoot,
+      ...(values.cwd ? { claudeCwd: resolve(values.cwd) } : {}),
+      ...(values['codex-home'] ? { codexHomeDir: resolve(values['codex-home']) } : {}),
+    });
+    const router = new Router(parseRouterConfig(`default: ${values.provider}\n`), providers);
+    // --task only has effect once a `tasks:` block exists in the router config;
+    // this CLI always builds a bare `default: <provider>` config, so today it's a no-op.
+    provider = router.resolve(values.task);
+    outputSchema = values.schema
+      ? z.fromJSONSchema(JSON.parse(readFileSync(values.schema, 'utf8')) as Record<string, unknown>)
+      : undefined;
+  } catch (err) {
+    console.log(JSON.stringify({ type: 'error', message: err instanceof Error ? err.message : String(err) }));
+    process.exit(1);
+  }
+
+  const tools = [...guardedVaultTools(store, readVaultConfig(vaultRoot)), ...registry.available()];
+  let exit = 1;
+  for await (const ev of provider.run({
+    tenant: DEFAULT_TENANT,
+    system: values.system!,
+    messages: [{ role: 'user', content: rest.join(' ') }],
+    tools,
+    ...(outputSchema ? { outputSchema } : {}),
+    ...(values.session ? { session: { id: values.session } } : {}),
+  })) {
+    console.log(JSON.stringify(ev));
+    if (isTerminal(ev)) exit = ev.type === 'done' ? 0 : 1;
+  }
+  process.exit(exit);
 }
-process.exit(exit);

--- a/runtime/src/core/fake-provider.ts
+++ b/runtime/src/core/fake-provider.ts
@@ -1,9 +1,14 @@
-import type { Capabilities, ModelProvider, StepEvent, StepRequest, ToolDef } from './types';
+import type { Capabilities, ModelProvider, StepEvent, StepRequest, ToolDef, Usage } from './types';
 
 export interface FakeScript {
   toolCalls?: Array<{ name: string; input: unknown }>;
+  /** Emitted before anything else, as a `session` event. */
+  session?: string;
   text?: string;
   output?: unknown;
+  usage?: Usage;
+  /** When set, the step ends with this `error` instead of a `done`. */
+  error?: string;
 }
 
 export async function runToolDef(tools: ToolDef[], name: string, input: unknown, tenant: string):
@@ -25,11 +30,18 @@ export class FakeModelProvider implements ModelProvider {
   readonly capabilities: Capabilities = { tools: true, caching: false, thinking: false, contextTokens: 1_000_000, auth: 'local' };
   private calls = 0;
 
+  /** The most recent `StepRequest` this provider was handed — the seam tests
+   * use to assert what the caller assembled (system prompt, tools, messages,
+   * `session`) without a live model call. */
+  lastRequest?: StepRequest;
+
   constructor(private readonly script: FakeScript[]) {}
 
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
+    this.lastRequest = req;
     const s = this.script[this.calls++] ?? {};
     let n = 0;
+    if (s.session) yield { type: 'session', id: s.session };
     for (const call of s.toolCalls ?? []) {
       const id = `fake-${this.calls}-${n++}`;
       yield { type: 'tool_call', id, name: call.name, input: call.input };
@@ -37,6 +49,10 @@ export class FakeModelProvider implements ModelProvider {
       yield { type: 'tool_result', id, name: call.name, output: r.output, isError: r.isError };
     }
     if (s.text) yield { type: 'text', text: s.text };
-    yield { type: 'done', output: s.output ?? null, usage: { inputTokens: 0, outputTokens: 0 } };
+    if (s.error) {
+      yield { type: 'error', message: s.error };
+      return;
+    }
+    yield { type: 'done', output: s.output ?? null, usage: s.usage ?? { inputTokens: 0, outputTokens: 0 } };
   }
 }

--- a/runtime/src/core/home.ts
+++ b/runtime/src/core/home.ts
@@ -1,0 +1,19 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * The runtime's own state directory: `~/.counsel-os`, or `COUNSEL_OS_HOME`
+ * when the operator points somewhere else (what the tests use so they never
+ * touch the developer's real home).
+ *
+ * It lives in `core/` rather than in `server/serve.ts`, where it started,
+ * because everything that writes under this directory has to agree on it —
+ * `runtime.json`, the per-thread Codex homes (which hold a copy of
+ * `auth.json`), and `providers.yaml`. The provider registry cannot import it
+ * from the server without dragging the whole HTTP layer in, and a second
+ * `join(homedir(), '.counsel-os')` spelled out somewhere else is exactly how
+ * the override came to be honored in one place and ignored in two.
+ */
+export function counselHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.COUNSEL_OS_HOME ?? join(homedir(), '.counsel-os');
+}

--- a/runtime/src/core/types.ts
+++ b/runtime/src/core/types.ts
@@ -29,6 +29,7 @@ export interface StepRequest {
   outputSchema?: ZodType<unknown>;   // when set, `done.output` is the parsed object
   maxTokens?: number;
   maxToolCalls?: number;             // default 20
+  session?: { id?: string };
 }
 
 export interface Usage {
@@ -41,7 +42,8 @@ export type StepEvent =
   | { type: 'text'; text: string }
   | { type: 'tool_call'; id: string; name: string; input: unknown }
   | { type: 'tool_result'; id: string; name: string; output: unknown; isError?: boolean }
-  | { type: 'done'; output: unknown; usage: Usage }
+  | { type: 'session'; id: string }
+  | { type: 'done'; output: unknown; usage: Usage; sessionId?: string }
   | { type: 'error'; message: string };
 
 export function isTerminal(e: StepEvent): boolean {

--- a/runtime/src/core/types.ts
+++ b/runtime/src/core/types.ts
@@ -82,7 +82,11 @@ export interface Hit {
 
 export interface VaultStore {
   read(tenant: Tenant, path: string): Promise<string>;
-  write(tenant: Tenant, path: string, content: string, opts?: { expectedVersion?: Version }): Promise<Version>;
+  // `expectedVersion: null` means "expect the file NOT to exist yet" (the
+  // new-file case a proposal records when nothing was there to hash) —
+  // distinct from omitting `expectedVersion`, which skips the check
+  // entirely and always overwrites.
+  write(tenant: Tenant, path: string, content: string, opts?: { expectedVersion?: Version | null }): Promise<Version>;
   list(tenant: Tenant, dir: string): Promise<Entry[]>;
   search(tenant: Tenant, query: string): Promise<Hit[]>;
   history(tenant: Tenant, path: string): Promise<Version[]>;

--- a/runtime/src/loop/__snapshots__/prompt.test.ts.snap
+++ b/runtime/src/loop/__snapshots__/prompt.test.ts.snap
@@ -1,0 +1,69 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`assembleSystemPrompt assembles preamble + SKILL.md body (frontmatter stripped) + profile + matter 1`] = `
+"# Host: Counsel OS runtime
+
+You run inside the Counsel OS runtime, not inside Claude Code. Some steps in
+the methodology below do not apply here. Use this section to translate them.
+
+## The legal root is already resolved
+
+The runtime resolved \`{legal_root}\` before this session started. Do not run
+\`scripts/resolve_legal_root.sh\`. Do not ask the user for the legal root.
+Treat every vault path in the methodology as already resolved.
+
+## Scripts are tools
+
+The methodology tells you to run scripts directly, for example
+\`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" ...\`. In this
+runtime, call the matching tool instead. Do not run \`python3\` or \`bash\`
+yourself. Pass the tool's arguments as named fields, not as a command line.
+
+| Script call in the methodology | Tool | Fields |
+|---|---|---|
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/docket_sweep.py" <matters_dir> --window <days> --format json\` | \`docket_sweep\` | \`days\` (optional, default 60) |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <input.docx>\` | \`extract_redlines\` | \`docx\` |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <input>\` | \`check_document\` | \`docx\` |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/clean_format.py" <input.docx> <output.docx>\` | \`clean_format\` | \`input\`, \`output\` |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <edits.json> <output.docx>\` | \`apply_redlines\` | \`original\`, \`edits\`, \`output\`, \`track\` (optional) |
+| \`"\${CLAUDE_PLUGIN_ROOT}/scripts/word_compare.sh" <original.docx> <modified.docx> <author> <output.docx>\` | \`word_compare\` | \`original\`, \`modified\`, \`author\`, \`output\` |
+
+## Primitives are a tool call
+
+The methodology tells you to read \`primitives/{name}.md\` for the detailed
+steps of a mode. In this runtime, call \`read_primitive\` with that name
+instead of reading the file yourself. For example, call
+\`read_primitive {"name": "draft"}\` to load \`primitives/draft.md\`.
+
+## Writes go through two paths
+
+Matter files stay under direct control. Call \`vault_write\` for any path
+under \`matters/\`.
+
+Knowledge-system files do not write directly. This covers \`practice/\`,
+\`memory/\`, \`law/\`, and the entities directory. Call \`propose_update\` for
+these paths instead. \`propose_update\` does not write the file — it records
+a proposed change for the user to approve or reject. Tell the user what you
+proposed and why.
+
+## Tools on this platform (macos)
+
+Available: \`docket_sweep\`, \`propose_update\`, \`read_primitive\`, \`vault_list\`, \`vault_read\`, \`vault_search\`, \`vault_write\`.
+
+Unavailable: \`extract_redlines\` (not available on this platform), \`check_document\` (not available on this platform), \`clean_format\` (not available on this platform), \`apply_redlines\` (not available on this platform), \`word_compare\` (requires Microsoft Word for Mac)
+
+# Counsel OS
+
+Body text goes here.
+
+
+## Practice profile
+Firm: Acme Legal
+Attorney: Jane Doe
+
+
+## Current matter
+Matter: Acme NDA
+Status: active
+"
+`;

--- a/runtime/src/loop/__snapshots__/prompt.test.ts.snap
+++ b/runtime/src/loop/__snapshots__/prompt.test.ts.snap
@@ -12,6 +12,15 @@ The runtime resolved \`{legal_root}\` before this session started. Do not run
 \`scripts/resolve_legal_root.sh\`. Do not ask the user for the legal root.
 Treat every vault path in the methodology as already resolved.
 
+## Vault paths
+
+The methodology writes vault paths as \`{legal_root}/x/y.md\`. Vault tools do
+not take that prefix. Drop \`{legal_root}/\`. Pass \`x/y.md\` instead. Never
+pass an absolute path.
+
+Matter files live under \`matters/\`. Entity files live under
+\`entities/\`.
+
 ## Scripts are tools
 
 The methodology tells you to run scripts directly, for example
@@ -22,11 +31,15 @@ yourself. Pass the tool's arguments as named fields, not as a command line.
 | Script call in the methodology | Tool | Fields |
 |---|---|---|
 | \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/docket_sweep.py" <matters_dir> --window <days> --format json\` | \`docket_sweep\` | \`days\` (optional, default 60) |
-| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <input.docx>\` | \`extract_redlines\` | \`docx\` |
-| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <input>\` | \`check_document\` | \`docx\` |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <file> --format json\` | \`extract_redlines\` | \`docx\` |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <file> --json\` | \`check_document\` | \`file\` — accepts .docx, .md, or .txt; always run with --json |
 | \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/clean_format.py" <input.docx> <output.docx>\` | \`clean_format\` | \`input\`, \`output\` |
-| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <edits.json> <output.docx>\` | \`apply_redlines\` | \`original\`, \`edits\`, \`output\`, \`track\` (optional) |
+| \`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <redlines.json> <output.docx>\` | \`apply_redlines\` | \`original\`, \`edits\`, \`output\`, \`track\` (optional) |
 | \`"\${CLAUDE_PLUGIN_ROOT}/scripts/word_compare.sh" <original.docx> <modified.docx> <author> <output.docx>\` | \`word_compare\` | \`original\`, \`modified\`, \`author\`, \`output\` |
+
+If a methodology step calls for a script or shell command with no tool
+listed above, do not improvise. Tell the user what you cannot do. Continue
+with the rest of the request.
 
 ## Primitives are a tool call
 
@@ -41,7 +54,7 @@ Matter files stay under direct control. Call \`vault_write\` for any path
 under \`matters/\`.
 
 Knowledge-system files do not write directly. This covers \`practice/\`,
-\`memory/\`, \`law/\`, and the entities directory. Call \`propose_update\` for
+\`memory/\`, \`law/\`, and \`entities/\`. Call \`propose_update\` for
 these paths instead. \`propose_update\` does not write the file — it records
 a proposed change for the user to approve or reject. Tell the user what you
 proposed and why.
@@ -50,7 +63,7 @@ proposed and why.
 
 Available: \`docket_sweep\`, \`propose_update\`, \`read_primitive\`, \`vault_list\`, \`vault_read\`, \`vault_search\`, \`vault_write\`.
 
-Unavailable: \`extract_redlines\` (not available on this platform), \`check_document\` (not available on this platform), \`clean_format\` (not available on this platform), \`apply_redlines\` (not available on this platform), \`word_compare\` (requires Microsoft Word for Mac)
+Unavailable: \`extract_redlines\` (needs macos, linux, windows, hosted), \`check_document\` (needs macos, linux, windows, hosted), \`clean_format\` (needs macos, linux, windows, hosted), \`apply_redlines\` (needs macos, linux, windows, hosted), \`word_compare\` (needs macos)
 
 # Counsel OS
 

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FakeModelProvider } from '../core/fake-provider';
+import type { ModelProvider, StepEvent } from '../core/types';
+import { Router } from '../router/router';
+import { ThreadStore, type ThreadEvent } from '../threads/store';
+import { FsVaultStore } from '../vault/fs-store';
+import { runStep, type CounselLoopDeps } from './counsel-loop';
+import type { RunLogEntry } from './run-log';
+
+let vaultRoot: string;
+let pluginRoot: string;
+let vault: FsVaultStore;
+let store: ThreadStore;
+
+beforeEach(() => {
+  vaultRoot = mkdtempSync(join(tmpdir(), 'loop-vault-'));
+  pluginRoot = mkdtempSync(join(tmpdir(), 'loop-plugin-'));
+  mkdirSync(join(pluginRoot, 'skills', 'counsel'), { recursive: true });
+  writeFileSync(
+    join(pluginRoot, 'skills', 'counsel', 'SKILL.md'),
+    '---\nname: counsel\n---\n\nTHE METHODOLOGY BODY.\n',
+    'utf8',
+  );
+  mkdirSync(join(pluginRoot, 'primitives'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'primitives', 'draft.md'), 'DRAFT PRIMITIVE STEPS.\n', 'utf8');
+  vault = new FsVaultStore(vaultRoot);
+  store = new ThreadStore(vaultRoot, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'loop-codex-')) });
+});
+
+function deps(providers: ModelProvider[], router?: Router): CounselLoopDeps {
+  return {
+    tenant: 'default',
+    vaultRoot,
+    pluginRoot,
+    vault,
+    store,
+    providers,
+    router: router ?? new Router({ default: providers[0]!.id }, providers),
+    platform: 'macos',
+  };
+}
+
+async function collect(it: AsyncIterable<StepEvent & { runId: string }>): Promise<Array<StepEvent & { runId: string }>> {
+  const out: Array<StepEvent & { runId: string }> = [];
+  for await (const ev of it) out.push(ev);
+  return out;
+}
+
+/** The log's discriminator: thread-only events carry `t`, StepEvents `type`. */
+function kindOf(ev: ThreadEvent): string {
+  return 't' in ev ? ev.t : ev.type;
+}
+
+async function logKinds(threadId: string): Promise<string[]> {
+  const { events } = await store.get('default', threadId);
+  return events.map(kindOf);
+}
+
+describe('runStep', () => {
+  test('(a) first step appends user, step, the model events, and done; the request replays the window with no session', async () => {
+    const fake = new FakeModelProvider([{ text: 'hi there' }]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'done']);
+    expect(events[0]!.runId).toBeTruthy();
+    expect(new Set(events.map(e => e.runId)).size).toBe(1);
+
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'done']);
+
+    expect(fake.lastRequest).toBeDefined();
+    expect(fake.lastRequest!.session).toBeUndefined();
+    expect(fake.lastRequest!.messages).toEqual([{ role: 'user', content: 'hello' }]);
+    // The system prompt is the assembled one: host preamble + SKILL.md body.
+    expect(fake.lastRequest!.system).toContain('THE METHODOLOGY BODY.');
+    expect(fake.lastRequest!.system).toContain('Host: Counsel OS runtime');
+    // Tools: the guarded vault tools, propose_update, read_primitive, scripts.
+    const toolNames = fake.lastRequest!.tools.map(t => t.name);
+    expect(toolNames).toContain('vault_read');
+    expect(toolNames).toContain('vault_write');
+    expect(toolNames).toContain('propose_update');
+    expect(toolNames).toContain('read_primitive');
+    expect(toolNames).toContain('docket_sweep');
+
+    // The step event records the run id and the provider that served it.
+    const { events: log } = await store.get('default', id);
+    const step = log.find(ev => 't' in ev && ev.t === 'step') as Extract<ThreadEvent, { t: 'step' }>;
+    expect(step.runId).toBe(events[0]!.runId);
+    expect(step.provider).toBe('fake/fake');
+  });
+
+  test('(a2) vault_write on a knowledge path is refused — the loop hands the model the guarded tools', async () => {
+    const fake = new FakeModelProvider([
+      { toolCalls: [{ name: 'vault_write', input: { path: 'practice/standards/x.md', content: 'nope' } }] },
+    ]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'write it' }));
+
+    const result = events.find(e => e.type === 'tool_result') as Extract<StepEvent, { type: 'tool_result' }>;
+    expect(result.isError).toBe(true);
+    expect(String(result.output)).toContain('propose_update');
+  });
+
+  test('(b) a session event is stored on the header and never yielded to the caller', async () => {
+    const fake = new FakeModelProvider([{ session: 's1', text: 'ok' }]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'done']);
+    const { header } = await store.get('default', id);
+    expect(header.sessions['fake/fake']).toBe('s1');
+    // Nor is it written to the log — it is consumed, not recorded.
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'done']);
+  });
+
+  test('(c) a second step on the same thread resumes the session and sends only the new message', async () => {
+    const fake = new FakeModelProvider([{ session: 's1', text: 'one' }, { text: 'two' }]);
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([fake]), { threadId: id, message: 'first' }));
+    await collect(runStep(deps([fake]), { threadId: id, message: 'second' }));
+
+    expect(fake.lastRequest!.session).toEqual({ id: 's1' });
+    expect(fake.lastRequest!.messages).toEqual([{ role: 'user', content: 'second' }]);
+  });
+
+  test('(d) a run log records the provider, tokens, duration, and each tool call', async () => {
+    const fake = new FakeModelProvider([
+      {
+        toolCalls: [{ name: 'read_primitive', input: { name: 'draft' } }],
+        text: 'drafted',
+        usage: { inputTokens: 12, outputTokens: 34, costUsd: 0.5 },
+      },
+    ]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'draft it', task: 'draft' }));
+    const runId = events[0]!.runId;
+
+    const raw = readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${runId}.log.jsonl`), 'utf8');
+    const lines = raw.split('\n').filter(Boolean);
+    expect(lines).toHaveLength(1);
+    const entry = JSON.parse(lines[0]!) as RunLogEntry;
+
+    expect(entry.provider).toBe('fake/fake');
+    expect(entry.task).toBe('draft');
+    expect(entry.inputTokens).toBe(12);
+    expect(entry.outputTokens).toBe(34);
+    expect(entry.costUsd).toBe(0.5);
+    expect(typeof entry.durationMs).toBe('number');
+    expect(entry.durationMs).toBeGreaterThanOrEqual(0);
+    expect(typeof entry.at).toBe('string');
+    expect(entry.toolCalls).toHaveLength(1);
+    expect(entry.toolCalls[0]!.name).toBe('read_primitive');
+    expect(entry.toolCalls[0]!.isError).toBe(false);
+    expect(typeof entry.toolCalls[0]!.ms).toBe('number');
+    expect(entry.toolCalls[0]!.ms).toBeGreaterThanOrEqual(0);
+  });
+
+  test('(e) an unknown thread yields a single error and writes nothing', async () => {
+    const fake = new FakeModelProvider([{ text: 'never' }]);
+
+    const events = await collect(runStep(deps([fake]), { threadId: randomUUID(), message: 'hello' }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('error');
+    expect(fake.lastRequest).toBeUndefined();
+  });
+
+  test('(e2) a malformed thread id yields an error rather than throwing', async () => {
+    const fake = new FakeModelProvider([{ text: 'never' }]);
+
+    const events = await collect(runStep(deps([fake]), { threadId: '../../etc', message: 'hello' }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('error');
+  });
+
+  test('(f) a router hard error yields a single error, with only the user event appended', async () => {
+    const fake = new FakeModelProvider([{ text: 'never' }]);
+    const router = new Router(
+      { default: 'fake/fake', tasks: { classify: { prefer: 'nope/nope', require: { contextTokens: 10_000_000 } } } },
+      [fake],
+    );
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake], router), { threadId: id, message: 'classify this', task: 'classify' }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('error');
+    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('classify');
+    expect(await logKinds(id)).toEqual(['user']);
+    expect(fake.lastRequest).toBeUndefined();
+  });
+
+  test('(f2) an unknown explicit provider id yields a single error', async () => {
+    const fake = new FakeModelProvider([{ text: 'never' }]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hi', providerId: 'nope/nope' }));
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.type).toBe('error');
+    expect(await logKinds(id)).toEqual(['user']);
+  });
+
+  test('a resume failure drops the stored session and replays the log once', async () => {
+    const fake = new FakeModelProvider([
+      { session: 's1', text: 'one' },
+      { error: 'session not found' },
+      { text: 'recovered' },
+    ]);
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([fake]), { threadId: id, message: 'first' }));
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'second' }));
+
+    // The caller never sees the resume failure — only the replayed answer.
+    expect(events.map(e => e.type)).toEqual(['text', 'done']);
+    expect((events[0] as Extract<StepEvent, { type: 'text' }>).text).toBe('recovered');
+
+    // The dead session id is dropped from the header.
+    const { header } = await store.get('default', id);
+    expect(header.sessions['fake/fake']).toBeUndefined();
+
+    // The replay sends the windowed log, not just the new message.
+    expect(fake.lastRequest!.session).toBeUndefined();
+    expect(fake.lastRequest!.messages).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'one' },
+      { role: 'user', content: 'second' },
+    ]);
+
+    // Nothing from the abandoned attempt reached the log.
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'done', 'user', 'step', 'text', 'done']);
+  });
+
+  test('a session-shaped error on a step with no session is a real error, not a retry', async () => {
+    const fake = new FakeModelProvider([{ error: 'session not found' }, { text: 'should never run' }]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'error']);
+  });
+
+  test('a provider error mid-stream is appended to the log and yielded', async () => {
+    const fake = new FakeModelProvider([{ text: 'partial', error: 'model exploded' }]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'error']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'error']);
+  });
+
+  test('a provider that ends without a terminal event gets one synthesized', async () => {
+    const silent: ModelProvider = {
+      id: 'fake/silent',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 100_000, auth: 'local' },
+      // Ends its stream with no `done` and no `error` — the failure mode
+      // spec §5 forbids the caller from ever seeing.
+      async *run(): AsyncIterable<StepEvent> {},
+    };
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([silent]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'error']);
+  });
+
+  test('a codex-sub provider is rebound to the thread\'s persistent codex home', async () => {
+    const homes: string[] = [];
+    const fake = new FakeModelProvider([{ text: 'ok' }]);
+    const codexish: ModelProvider & { withHome(dir: string): ModelProvider } = {
+      id: 'codex-sub/gpt-5.6-terra',
+      kind: 'harness',
+      capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' },
+      run: fake.run.bind(fake),
+      withHome(dir: string) {
+        homes.push(dir);
+        return { ...this, run: fake.run.bind(fake) };
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([codexish]), { threadId: id, message: 'hello', providerId: 'codex-sub/gpt-5.6-terra' }));
+
+    expect(homes).toEqual([store.codexHomeFor(id)]);
+  });
+});

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -8,7 +8,7 @@ import type { ModelProvider, StepEvent } from '../core/types';
 import { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
-import { runStep, type CounselLoopDeps } from './counsel-loop';
+import { runStep, RESUME_WARNING, type CounselLoopDeps } from './counsel-loop';
 import type { RunLogEntry } from './run-log';
 
 let vaultRoot: string;
@@ -238,8 +238,12 @@ describe('runStep', () => {
       { role: 'user', content: 'second' },
     ]);
 
-    // Nothing from the abandoned attempt reached the log.
-    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'done', 'user', 'step', 'text', 'done']);
+    // Nothing from the abandoned attempt reached the log except spec §5's
+    // warning — in particular the user turn is not appended twice.
+    expect(await logKinds(id)).toEqual([
+      'user', 'step', 'text', 'done',
+      'user', 'step', 'warning', 'text', 'done',
+    ]);
   });
 
   test('a session-shaped error on a step with no session is a real error, not a retry', async () => {
@@ -279,16 +283,16 @@ describe('runStep', () => {
     expect(await logKinds(id)).toEqual(['user', 'step', 'error']);
   });
 
-  test('a codex-sub provider is rebound to the thread\'s persistent codex home', async () => {
-    const homes: string[] = [];
+  test('a codex-sub provider is bound to the thread: home, thread id, and plugin root', async () => {
+    const bindings: Array<{ homeDir: string; threadId: string; pluginRoot: string }> = [];
     const fake = new FakeModelProvider([{ text: 'ok' }]);
-    const codexish: ModelProvider & { withHome(dir: string): ModelProvider } = {
+    const codexish: ModelProvider & { withThread(o: { homeDir: string; threadId: string; pluginRoot: string }): ModelProvider } = {
       id: 'codex-sub/gpt-5.6-terra',
       kind: 'harness',
       capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' },
       run: fake.run.bind(fake),
-      withHome(dir: string) {
-        homes.push(dir);
+      withThread(o) {
+        bindings.push(o);
         return { ...this, run: fake.run.bind(fake) };
       },
     };
@@ -296,6 +300,207 @@ describe('runStep', () => {
 
     await collect(runStep(deps([codexish]), { threadId: id, message: 'hello', providerId: 'codex-sub/gpt-5.6-terra' }));
 
-    expect(homes).toEqual([store.codexHomeFor(id)]);
+    expect(bindings).toEqual([{ homeDir: store.codexHomeFor(id), threadId: id, pluginRoot }]);
+  });
+
+  test('a non-codex provider is never re-bound', async () => {
+    let bound = false;
+    const fake = new FakeModelProvider([{ text: 'ok' }]);
+    const bindable: ModelProvider & { withThread(): ModelProvider } = {
+      id: 'claude-sub/claude-opus-5',
+      kind: 'harness',
+      capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' },
+      run: fake.run.bind(fake),
+      withThread() {
+        bound = true;
+        return this;
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([bindable]), { threadId: id, message: 'hi', providerId: 'claude-sub/claude-opus-5' }));
+
+    expect(bound).toBe(false);
+  });
+});
+
+describe('runStep — resume detection behind leading session events', () => {
+  test('the first NON-session event decides: a session then a resume failure still falls back', async () => {
+    const fake = new FakeModelProvider([
+      { session: 's1', text: 'one' },
+      // Attempt 1 of step 2: the harness opens with a fresh session event
+      // (Claude's `system/init`) and only then reports the dead session.
+      { session: 'new', error: 'session not found' },
+      { session: 'ok', text: 'recovered' },
+    ]);
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([fake]), { threadId: id, message: 'first' }));
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'second' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'done']);
+    expect((events[0] as Extract<StepEvent, { type: 'text' }>).text).toBe('recovered');
+
+    // The failed attempt's session id is discarded unread; the successful
+    // one is what sticks.
+    const { header } = await store.get('default', id);
+    expect(header.sessions['fake/fake']).toBe('ok');
+
+    // Exactly one warning, and the user turn is not duplicated.
+    const { events: log } = await store.get('default', id);
+    const warnings = log.filter(ev => 't' in ev && ev.t === 'warning');
+    expect(warnings).toHaveLength(1);
+    expect((warnings[0] as Extract<ThreadEvent, { t: 'warning' }>).message).toBe(RESUME_WARNING);
+    expect(log.map(kindOf)).toEqual(['user', 'step', 'text', 'done', 'user', 'step', 'warning', 'text', 'done']);
+    expect(log.filter(ev => 't' in ev && ev.t === 'user')).toHaveLength(2);
+
+    // The replay sends the windowed history, not just the new turn.
+    expect(fake.lastRequest!.session).toBeUndefined();
+    expect(fake.lastRequest!.messages).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'one' },
+      { role: 'user', content: 'second' },
+    ]);
+  });
+
+  test('a failed attempt\'s session id is never written to disk at all', async () => {
+    // Stronger than checking the final header: `clearSession` would erase an
+    // eagerly-written id anyway, so the only way to prove the write was
+    // deferred is to watch the writes themselves. A session id that briefly
+    // lands on disk is a real hazard — a crash in the fallback would leave
+    // the thread pinned to a session the vendor is already rejecting.
+    const writes: string[] = [];
+    class RecordingThreadStore extends ThreadStore {
+      override async setSession(tenant: string, id: string, providerId: string, sessionId: string): Promise<void> {
+        writes.push(sessionId);
+        return super.setSession(tenant, id, providerId, sessionId);
+      }
+    }
+    const recording = new RecordingThreadStore(vaultRoot, {
+      codexHomeRoot: mkdtempSync(join(tmpdir(), 'loop-codex-')),
+    });
+    const fake = new FakeModelProvider([
+      { session: 's1', text: 'one' },
+      { session: 'new', error: 'session not found' },
+      { session: 'ok', text: 'recovered' },
+    ]);
+    const { id } = await recording.create('default', {});
+    const d = { ...deps([fake]), store: recording };
+
+    await collect(runStep(d, { threadId: id, message: 'first' }));
+    await collect(runStep(d, { threadId: id, message: 'second' }));
+
+    expect(writes).toEqual(['s1', 'ok']);
+    expect(writes).not.toContain('new');
+  });
+
+  test('a leading session event on a healthy step is still stored', async () => {
+    const fake = new FakeModelProvider([{ session: 's1', text: 'ok' }]);
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    const { header } = await store.get('default', id);
+    expect(header.sessions['fake/fake']).toBe('s1');
+  });
+});
+
+/** A store whose `append` starts throwing after `failAfter` successful calls. */
+class FlakyThreadStore extends ThreadStore {
+  calls = 0;
+  constructor(root: string, private readonly failAfter: number, opts?: { codexHomeRoot?: string }) {
+    super(root, opts);
+  }
+  override async append(tenant: string, id: string, ev: ThreadEvent): Promise<void> {
+    if (this.calls++ >= this.failAfter) throw new Error('disk full');
+    return super.append(tenant, id, ev);
+  }
+}
+
+describe('runStep — the caller always gets a terminal event', () => {
+  test('a thread-log write failure on the step event ends the stream with an error', async () => {
+    const fake = new FakeModelProvider([{ text: 'never' }]);
+    const flaky = new FlakyThreadStore(vaultRoot, 1, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'loop-codex-')) });
+    const { id } = await flaky.create('default', {});
+
+    const events = await collect(runStep({ ...deps([fake]), store: flaky }, { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('thread log write failed');
+    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('disk full');
+  });
+
+  test('a thread-log write failure mid-stream ends the stream with an error', async () => {
+    const fake = new FakeModelProvider([{ text: 'partial' }]);
+    // user + step succeed; the first event append inside stream() throws.
+    const flaky = new FlakyThreadStore(vaultRoot, 2, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'loop-codex-')) });
+    const { id } = await flaky.create('default', {});
+
+    const events = await collect(runStep({ ...deps([fake]), store: flaky }, { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('thread log write failed');
+  });
+
+  test('a run-log write failure does not cost the caller its done event', async () => {
+    const fake = new FakeModelProvider([{ text: 'fine' }]);
+    // `.counsel/runs/default` cannot be created because `runs` is a file.
+    mkdirSync(join(vaultRoot, '.counsel'), { recursive: true });
+    writeFileSync(join(vaultRoot, '.counsel', 'runs'), 'not a directory', 'utf8');
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'done']);
+  });
+});
+
+describe('runStep — context budget', () => {
+  test('a system prompt that cannot fit the context window fails the step', async () => {
+    const tiny: ModelProvider = {
+      id: 'fake/tiny',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 10, auth: 'local' },
+      async *run(): AsyncIterable<StepEvent> {
+        yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([tiny]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toMatch(
+      /system prompt exceeds the provider's context window \(\d+ > 10\)/,
+    );
+    expect(await logKinds(id)).toEqual(['user', 'step', 'error']);
+  });
+});
+
+describe('runStep — run-log tool call tallies', () => {
+  test('an unmatched tool_call is logged with a null duration and outcome', async () => {
+    const orphan: ModelProvider = {
+      id: 'fake/orphan',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 100_000, auth: 'local' },
+      async *run(): AsyncIterable<StepEvent> {
+        yield { type: 'tool_call', id: 'c1', name: 'vault_read', input: {} };
+        // No tool_result for c1 — the harness dropped it.
+        yield { type: 'tool_result', id: 'unknown', name: 'vault_search', output: 'x', isError: false };
+        yield { type: 'done', output: null, usage: { inputTokens: 1, outputTokens: 2 } };
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([orphan]), { threadId: id, message: 'hello' }));
+    const runId = events[0]!.runId;
+    const entry = JSON.parse(
+      readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${runId}.log.jsonl`), 'utf8').trim(),
+    ) as RunLogEntry;
+
+    // The result with no matching call: real outcome, unknown duration.
+    expect(entry.toolCalls[0]).toEqual({ name: 'vault_search', ms: null, isError: false });
+    // The call that never got a result: both unknown, but still recorded.
+    expect(entry.toolCalls[1]).toEqual({ name: 'vault_read', ms: null, isError: null });
   });
 });

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -613,6 +613,36 @@ describe('runStep — logged text coalescing', () => {
     expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'tool_call', 'tool_result', 'text', 'done']);
   });
 
+  test('an abandoned step still leaves its buffered text in the log', async () => {
+    // The SSE layer's `cancel()` reaches this generator as `return()`, which
+    // unwinds it at the `yield` in the text branch — so nothing after the
+    // loop runs. Without the `finally` flush the deltas the user already saw
+    // would be missing from the transcript entirely.
+    const provider = streaming([
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b' },
+    ]);
+    const stalling: ModelProvider = {
+      ...provider,
+      async *run(): AsyncIterable<StepEvent> {
+        yield { type: 'text', text: 'a' };
+        yield { type: 'text', text: 'b' };
+        // The client hangs up here, mid-turn: the step is still in flight.
+        await new Promise(r => setTimeout(r, 10_000));
+        yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    const it = runStep(deps([stalling]), { threadId: id, message: 'hello' })[Symbol.asyncIterator]();
+    expect((await it.next()).value!.type).toBe('text');
+    expect((await it.next()).value!.type).toBe('text');
+    await it.return?.(undefined);
+
+    expect(await loggedText(id)).toEqual(['ab']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text']);
+  });
+
   test('text with no terminal event still reaches the log', async () => {
     const provider = streaming([
       { type: 'text', text: 'a' },

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -61,6 +61,31 @@ async function logKinds(threadId: string): Promise<string[]> {
 }
 
 describe('runStep', () => {
+  test('(z) abandoning the step closes the provider — a hand-rolled next() loop does not forward it', async () => {
+    let closed = false;
+    const provider: ModelProvider = {
+      id: 'endless/endless',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1_000_000, auth: 'local' },
+      async *run() {
+        try {
+          yield { type: 'text', text: 'first' };
+          yield { type: 'text', text: 'second' };
+          yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+        } finally {
+          closed = true;
+        }
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    const it = runStep(deps([provider]), { threadId: id, message: 'hello' })[Symbol.asyncIterator]();
+    expect((await it.next()).value!.type).toBe('text');
+    await it.return?.(undefined);
+
+    expect(closed).toBe(true);
+  });
+
   test('(a) first step appends user, step, the model events, and done; the request replays the window with no session', async () => {
     const fake = new FakeModelProvider([{ text: 'hi there' }]);
     const { id } = await store.create('default', {});

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -463,8 +463,13 @@ describe('runStep — the caller always gets a terminal event', () => {
 
     const events = await collect(runStep({ ...deps([fake]), store: flaky }, { threadId: id, message: 'hello' }));
 
-    expect(events.map(e => e.type)).toEqual(['error']);
-    expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('thread log write failed');
+    // The `text` reaches the caller before it is logged — deliberately, so a
+    // streaming client never waits on a disk write — so the failure shows up
+    // on the flush that follows it rather than in place of it. What matters
+    // is that the stream still ends on a terminal `error`.
+    expect(events.map(e => e.type)).toEqual(['text', 'error']);
+    const last = events[events.length - 1] as Extract<StepEvent, { type: 'error' }>;
+    expect(last.message).toContain('thread log write failed');
   });
 
   test('a run-log write failure does not cost the caller its done event', async () => {
@@ -527,5 +532,98 @@ describe('runStep — run-log tool call tallies', () => {
     expect(entry.toolCalls[0]).toEqual({ name: 'vault_search', ms: null, isError: false });
     // The call that never got a result: both unknown, but still recorded.
     expect(entry.toolCalls[1]).toEqual({ name: 'vault_read', ms: null, isError: null });
+  });
+});
+
+describe('runStep — the step clock', () => {
+  test('durationMs covers the whole turn, including the wait for the first event', async () => {
+    // The harness tiers produce nothing at all until the model turn is over,
+    // so a clock started after the first event measures almost nothing. This
+    // provider reproduces that shape: a 60 ms wait, then the events.
+    const slow: ModelProvider = {
+      id: 'fake/slow',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 100_000, auth: 'local' },
+      async *run(): AsyncIterable<StepEvent> {
+        await new Promise(r => setTimeout(r, 60));
+        yield { type: 'text', text: 'late' };
+        yield { type: 'done', output: null, usage: { inputTokens: 1, outputTokens: 2 } };
+      },
+    };
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([slow]), { threadId: id, message: 'hello' }));
+    const runId = events[0]!.runId;
+    const entry = JSON.parse(
+      readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${runId}.log.jsonl`), 'utf8').trim(),
+    ) as RunLogEntry;
+
+    expect(entry.durationMs).toBeGreaterThanOrEqual(50);
+  });
+});
+
+describe('runStep — logged text coalescing', () => {
+  /** The `text` events in a thread's log, in order. */
+  async function loggedText(threadId: string): Promise<string[]> {
+    const { events } = await store.get('default', threadId);
+    return events.filter(ev => 'type' in ev && ev.type === 'text').map(ev => (ev as { text: string }).text);
+  }
+
+  function streaming(script: StepEvent[]): ModelProvider {
+    return {
+      id: 'fake/streaming',
+      kind: 'direct',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 100_000, auth: 'local' },
+      async *run(): AsyncIterable<StepEvent> {
+        for (const ev of script) yield ev;
+      },
+    };
+  }
+
+  test('a run of text deltas becomes one logged text event, but still streams as three', async () => {
+    const provider = streaming([
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b' },
+      { type: 'text', text: 'c' },
+      { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } },
+    ]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([provider]), { threadId: id, message: 'hello' }));
+
+    // The caller still sees every delta as it arrives.
+    expect(events.map(e => e.type)).toEqual(['text', 'text', 'text', 'done']);
+    expect(await loggedText(id)).toEqual(['abc']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'done']);
+  });
+
+  test('a non-text event between two runs of text keeps them separate', async () => {
+    const provider = streaming([
+      { type: 'text', text: 'a' },
+      { type: 'tool_call', id: 'c1', name: 'vault_read', input: { path: 'x.md' } },
+      { type: 'tool_result', id: 'c1', name: 'vault_read', output: 'x', isError: false },
+      { type: 'text', text: 'b' },
+      { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } },
+    ]);
+    const { id } = await store.create('default', {});
+
+    await collect(runStep(deps([provider]), { threadId: id, message: 'hello' }));
+
+    expect(await loggedText(id)).toEqual(['a', 'b']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'tool_call', 'tool_result', 'text', 'done']);
+  });
+
+  test('text with no terminal event still reaches the log', async () => {
+    const provider = streaming([
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b' },
+    ]);
+    const { id } = await store.create('default', {});
+
+    const events = await collect(runStep(deps([provider]), { threadId: id, message: 'hello' }));
+
+    expect(events.map(e => e.type)).toEqual(['text', 'text', 'error']);
+    expect(await loggedText(id)).toEqual(['ab']);
+    expect(await logKinds(id)).toEqual(['user', 'step', 'text', 'error']);
   });
 });

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -364,7 +364,9 @@ async function tryPersist(write: () => Promise<void>): Promise<string | null> {
  * thread log and yielded with the run id; `session` (and `done.sessionId`)
  * updates the thread header instead. Consecutive `text` events are the one
  * exception — they reach the caller immediately but are merged into a single
- * logged `text` event. Tool-call durations are measured
+ * logged `text` event, flushed when the run of text ends, when the stream
+ * ends, or when the consumer abandons the step (the `finally`). Tool-call
+ * durations are measured
  * between a `tool_call` and the `tool_result` carrying the same id, and the
  * whole tally is written to the run log once the step completes.
  *
@@ -407,79 +409,94 @@ async function* stream(
     return tryPersist(() => store.append(tenant, opts.threadId, { type: 'text', text: merged, at: nowIso() }));
   };
 
-  for await (const ev of events) {
-    if (ev.type === 'session') {
-      const failed = await tryPersist(() => store.setSession(tenant, opts.threadId, provider.id, ev.id));
+  try {
+    for await (const ev of events) {
+      if (ev.type === 'session') {
+        const failed = await tryPersist(() => store.setSession(tenant, opts.threadId, provider.id, ev.id));
+        if (failed) {
+          yield { type: 'error', message: failed, runId };
+          return;
+        }
+        continue;
+      }
+
+      if (ev.type === 'text') {
+        textBuffer.push(ev.text);
+        yield { ...ev, runId };
+        continue;
+      }
+
+      const flushFailed = await flushText();
+      if (flushFailed) {
+        yield { type: 'error', message: flushFailed, runId };
+        return;
+      }
+
+      const failed = await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent));
       if (failed) {
+        // The store is broken, so the error event cannot be logged either —
+        // it only reaches the caller.
         yield { type: 'error', message: failed, runId };
         return;
       }
-      continue;
-    }
 
-    if (ev.type === 'text') {
-      textBuffer.push(ev.text);
-      yield { ...ev, runId };
-      continue;
-    }
-
-    const flushFailed = await flushText();
-    if (flushFailed) {
-      yield { type: 'error', message: flushFailed, runId };
-      return;
-    }
-
-    const failed = await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent));
-    if (failed) {
-      // The store is broken, so the error event cannot be logged either —
-      // it only reaches the caller.
-      yield { type: 'error', message: failed, runId };
-      return;
-    }
-
-    if (ev.type === 'tool_call') {
-      pending.set(ev.id, { name: ev.name, at: Date.now() });
-    } else if (ev.type === 'tool_result') {
-      const call = pending.get(ev.id);
-      pending.delete(ev.id);
-      // A result with no matching call (a harness that reports only the
-      // result, or an id that did not round-trip) still happened — it is
-      // logged with an unknown duration rather than a fabricated 0.
-      toolCalls.push({ name: ev.name, ms: call ? Date.now() - call.at : null, isError: ev.isError === true });
-    } else if (ev.type === 'done') {
-      sawTerminal = true;
-      if (ev.sessionId) {
-        const sessionFailed = await tryPersist(() =>
-          store.setSession(tenant, opts.threadId, provider.id, ev.sessionId as string),
-        );
-        if (sessionFailed) {
-          yield { type: 'error', message: sessionFailed, runId };
-          return;
+      if (ev.type === 'tool_call') {
+        pending.set(ev.id, { name: ev.name, at: Date.now() });
+      } else if (ev.type === 'tool_result') {
+        const call = pending.get(ev.id);
+        pending.delete(ev.id);
+        // A result with no matching call (a harness that reports only the
+        // result, or an id that did not round-trip) still happened — it is
+        // logged with an unknown duration rather than a fabricated 0.
+        toolCalls.push({ name: ev.name, ms: call ? Date.now() - call.at : null, isError: ev.isError === true });
+      } else if (ev.type === 'done') {
+        sawTerminal = true;
+        if (ev.sessionId) {
+          const sessionFailed = await tryPersist(() =>
+            store.setSession(tenant, opts.threadId, provider.id, ev.sessionId as string),
+          );
+          if (sessionFailed) {
+            yield { type: 'error', message: sessionFailed, runId };
+            return;
+          }
         }
+      } else if (ev.type === 'error') {
+        sawTerminal = true;
       }
-    } else if (ev.type === 'error') {
-      sawTerminal = true;
+
+      yield { ...ev, runId };
+
+      if (ev.type === 'done') {
+        recordRun(deps, opts, provider, runId, ev.usage, Date.now() - startedAt, finishToolCalls(toolCalls, pending));
+      }
     }
 
-    yield { ...ev, runId };
-
-    if (ev.type === 'done') {
-      recordRun(deps, opts, provider, runId, ev.usage, Date.now() - startedAt, finishToolCalls(toolCalls, pending));
+    // A stream that ends on text (no terminal event) still has to leave that
+    // text in the log.
+    const tailFailed = await flushText();
+    if (tailFailed) {
+      yield { type: 'error', message: tailFailed, runId };
+      return;
     }
-  }
 
-  // A stream that ends on text (no terminal event) still has to leave that
-  // text in the log.
-  const tailFailed = await flushText();
-  if (tailFailed) {
-    yield { type: 'error', message: tailFailed, runId };
-    return;
-  }
-
-  if (!sawTerminal) {
-    const ev: StepEvent = { type: 'error', message: `${provider.id} ended the step without a done or error event` };
-    await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() }));
-    yield { ...ev, runId };
+    if (!sawTerminal) {
+      const ev: StepEvent = { type: 'error', message: `${provider.id} ended the step without a done or error event` };
+      await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() }));
+      yield { ...ev, runId };
+    }
+  } finally {
+    // A consumer that abandons the step — an SSE client hanging up, which
+    // reaches this generator as `return()` — unwinds it at the `yield` in the
+    // text branch above, so neither the mid-loop flush nor the tail flush
+    // ever runs and the whole run of deltas is lost. The partial answer was
+    // real and the user may have seen it, so it belongs in the transcript.
+    //
+    // Nothing here may throw or yield: this runs during an unwind, where a
+    // thrown error would replace the completion that caused it and a `yield`
+    // is illegal outright. A failed flush is reported the way `recordRun`
+    // reports its own — to stderr — and the unwind continues.
+    const failed = await flushText();
+    if (failed) console.error(`counsel-loop: ${failed} (thread ${opts.threadId})`);
   }
 }
 

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import type { ZodType } from 'zod';
-import type { Message, ModelProvider, Platform, StepEvent, StepRequest, Tenant, ToolDef, VaultStore } from '../core/types';
+import type { Message, ModelProvider, Platform, StepEvent, StepRequest, Tenant, ToolDef, Usage, VaultStore } from '../core/types';
 import { currentPlatform } from '../core/types';
 import type { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent, type ThreadHeader } from '../threads/store';
@@ -36,6 +36,9 @@ const estimateTokens = (s: string): number => Math.ceil(s.length / 4);
  */
 const RESUME_FAILURE_RE = /session|thread|resume|not found/i;
 
+/** The `warning` event the fallback leaves in the transcript (spec §5). */
+export const RESUME_WARNING = 'session expired; replaying history';
+
 export interface CounselLoopDeps {
   tenant: Tenant;
   vaultRoot: string;
@@ -56,16 +59,16 @@ export interface RunStepOptions {
   outputSchema?: ZodType<unknown>;
 }
 
-/** A provider that can be re-bound to a per-thread home directory — today
- * only `CodexHarnessProvider`, whose sessions live inside `CODEX_HOME` and
- * so cannot be resumed from a different one. Duck-typed rather than an
+/** A provider that can be re-bound to one thread — today only
+ * `CodexHarnessProvider`, which runs out of process and so learns about the
+ * thread only through what this binding passes it. Duck-typed rather than an
  * `instanceof` check so this module does not pull in the Codex SDK. */
-interface HomeBindable {
-  withHome(dir: string): ModelProvider;
+interface ThreadBindable {
+  withThread(opts: { homeDir: string; threadId: string; pluginRoot: string }): ModelProvider;
 }
 
-function isHomeBindable(p: ModelProvider): p is ModelProvider & HomeBindable {
-  return typeof (p as Partial<HomeBindable>).withHome === 'function';
+function isThreadBindable(p: ModelProvider): p is ModelProvider & ThreadBindable {
+  return typeof (p as Partial<ThreadBindable>).withThread === 'function';
 }
 
 function message(err: unknown): string {
@@ -77,14 +80,23 @@ function nowIso(): string {
 }
 
 /**
- * Codex keeps a thread's state under its `CODEX_HOME`, so a registry-built
- * `codex-sub/*` provider — shared by every thread — has to be re-bound to
- * this thread's own persistent home before it can resume anything. Every
- * other provider is returned unchanged.
+ * Binds a `codex-sub/*` provider to this thread. Two things ride along, and
+ * both are needed because that harness runs the model in a separate process
+ * against an out-of-process MCP server: the thread's persistent
+ * `CODEX_HOME`, without which `resumeThread` can never find the session
+ * state a previous step left; and the thread id plus plugin root, which
+ * reach that MCP server as `COUNSEL_THREAD_ID` / `COUNSEL_PLUGIN_ROOT` and
+ * are what let it offer `propose_update` and `read_primitive` — the tools
+ * the in-process tiers get directly from `stepTools`. Every other provider
+ * is returned unchanged.
  */
-function bindToThread(provider: ModelProvider, store: ThreadStore, threadId: string): ModelProvider {
-  if (!provider.id.startsWith('codex-sub/') || !isHomeBindable(provider)) return provider;
-  return provider.withHome(store.codexHomeFor(threadId));
+function bindToThread(deps: CounselLoopDeps, provider: ModelProvider, threadId: string): ModelProvider {
+  if (!provider.id.startsWith('codex-sub/') || !isThreadBindable(provider)) return provider;
+  return provider.withThread({
+    homeDir: deps.store.codexHomeFor(threadId),
+    threadId,
+    pluginRoot: deps.pluginRoot,
+  });
 }
 
 function resolveProvider(deps: CounselLoopDeps, opts: RunStepOptions): ModelProvider {
@@ -142,23 +154,35 @@ export async function* runStep(
     return;
   }
 
-  await store.append(tenant, threadId, { t: 'user', at: nowIso(), content: opts.message });
+  const userFailed = await tryPersist(() =>
+    store.append(tenant, threadId, { t: 'user', at: nowIso(), content: opts.message }),
+  );
+  if (userFailed) {
+    yield { type: 'error', message: userFailed, runId };
+    return;
+  }
 
   let provider: ModelProvider;
   try {
-    provider = bindToThread(resolveProvider(deps, opts), store, threadId);
+    provider = bindToThread(deps, resolveProvider(deps, opts), threadId);
   } catch (err) {
     yield { type: 'error', message: message(err), runId };
     return;
   }
 
-  await store.append(tenant, threadId, {
-    t: 'step',
-    at: nowIso(),
-    runId,
-    provider: provider.id,
-    ...(opts.task ? { task: opts.task } : {}),
-  });
+  const stepFailed = await tryPersist(() =>
+    store.append(tenant, threadId, {
+      t: 'step',
+      at: nowIso(),
+      runId,
+      provider: provider.id,
+      ...(opts.task ? { task: opts.task } : {}),
+    }),
+  );
+  if (stepFailed) {
+    yield { type: 'error', message: stepFailed, runId };
+    return;
+  }
 
   // One header read serves both the system prompt (the thread's matter) and
   // the session lookup below — nothing between them can change either.
@@ -185,7 +209,16 @@ export async function* runStep(
       },
     });
 
-    budgetTokens = provider.capabilities.contextTokens - estimateTokens(system) - REPLY_RESERVE_TOKENS;
+    // An oversize system prompt is not a windowing problem — no amount of
+    // dropped history makes the request fit — so it fails the step outright
+    // rather than silently sending a request the provider will reject.
+    const systemTokens = estimateTokens(system);
+    const contextTokens = provider.capabilities.contextTokens;
+    const floor = systemTokens + REPLY_RESERVE_TOKENS;
+    if (floor > contextTokens) {
+      throw new Error(`system prompt exceeds the provider's context window (${floor} > ${contextTokens})`);
+    }
+    budgetTokens = Math.max(0, contextTokens - floor);
     base = {
       tenant,
       system,
@@ -195,7 +228,8 @@ export async function* runStep(
     };
   } catch (err) {
     const ev: StepEvent = { type: 'error', message: message(err) };
-    await store.append(tenant, threadId, { ...ev, at: nowIso() });
+    // Best-effort: the caller gets the error either way (spec §5).
+    await tryPersist(() => store.append(tenant, threadId, { ...ev, at: nowIso() }));
     yield { ...ev, runId };
     return;
   }
@@ -213,27 +247,96 @@ export async function* runStep(
     ? { ...base, messages: [{ role: 'user', content: opts.message } satisfies Message], session: { id: sessionId } }
     : await replay();
 
-  let it = provider.run(req)[Symbol.asyncIterator]();
-  let first = await it.next();
+  let attempt = await beginAttempt(provider, req);
 
   // Resume failure (spec §5): the vendor's session is gone. Drop the dead id
-  // and replay the log once for this same step — the caller never sees the
-  // failed attempt, and nothing from it reaches the thread log. Only the
-  // very first event counts: once real output has streamed, a later error
-  // is a real error, not a bad session id.
-  if (!first.done && sessionId && isResumeFailure(first.value)) {
-    await it.return?.(undefined);
+  // and replay the log once for this same step. The caller never sees the
+  // failed attempt, and the only trace it leaves is the `warning` event —
+  // in particular the user turn is NOT appended twice.
+  //
+  // The event tested is the first NON-session one: the Claude harness opens
+  // every stream with a `session` event (from `system/init`), so testing the
+  // literal first event would never see the error behind it. Session ids
+  // buffered during a failed attempt are discarded unread — persisting one
+  // would immediately re-poison the next step with a session the vendor was
+  // in the middle of rejecting.
+  if (sessionId && !attempt.first.done && isResumeFailure(attempt.first.value)) {
+    await closeQuietly(attempt.it);
     await store.clearSession(tenant, threadId, provider.id);
+    const warning: ThreadEvent = { t: 'warning', at: nowIso(), message: RESUME_WARNING };
+    const appendFailed = await tryPersist(() => store.append(tenant, threadId, warning));
+    if (appendFailed) {
+      yield { type: 'error', message: appendFailed, runId };
+      return;
+    }
     req = await replay();
-    it = provider.run(req)[Symbol.asyncIterator]();
-    first = await it.next();
+    attempt = await beginAttempt(provider, req);
   }
 
-  yield* stream(deps, opts, provider, runId, it, first);
+  yield* stream(deps, opts, provider, runId, chain(attempt));
 }
 
 function isResumeFailure(ev: StepEvent): boolean {
   return ev.type === 'error' && RESUME_FAILURE_RE.test(ev.message);
+}
+
+interface Attempt {
+  it: AsyncIterator<StepEvent>;
+  /** Leading `session` events, held back until the attempt proves real. */
+  head: StepEvent[];
+  /** The first event that is not a `session` — what resume detection tests. */
+  first: IteratorResult<StepEvent>;
+}
+
+/**
+ * Starts one provider run and reads far enough to answer "did this attempt
+ * fail to resume?" — buffering the leading `session` events (the same shape
+ * `withRetry` buffers) so the first *meaningful* event is the one examined.
+ */
+async function beginAttempt(provider: ModelProvider, req: StepRequest): Promise<Attempt> {
+  const it = provider.run(req)[Symbol.asyncIterator]();
+  const head: StepEvent[] = [];
+  let first = await it.next();
+  while (!first.done && first.value.type === 'session') {
+    head.push(first.value);
+    first = await it.next();
+  }
+  return { it, head, first };
+}
+
+/** Replays a started attempt as one flat stream: buffered head, the event
+ * that broke the buffering, then whatever the provider has left. */
+async function* chain(attempt: Attempt): AsyncIterable<StepEvent> {
+  for (const ev of attempt.head) yield ev;
+  if (attempt.first.done) return;
+  yield attempt.first.value;
+  for (let n = await attempt.it.next(); !n.done; n = await attempt.it.next()) yield n.value;
+}
+
+/** Closes an abandoned provider iterator. A throwing `return()` must not
+ * mask the fallback that is already underway. */
+async function closeQuietly(it: AsyncIterator<StepEvent>): Promise<void> {
+  try {
+    await it.return?.(undefined);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * Runs one thread-store write, returning a caller-facing message instead of
+ * throwing. A failed write means the transcript is now incomplete, so the
+ * step has to stop — but it must stop with a terminal `error` the caller
+ * actually receives (spec §5), not with an exception thrown out of the
+ * async generator mid-stream.
+ */
+async function tryPersist(write: () => Promise<void>): Promise<string | null> {
+  try {
+    await write();
+    return null;
+  } catch (err) {
+    return `thread log write failed: ${message(err)}`;
+  }
 }
 
 /**
@@ -241,7 +344,13 @@ function isResumeFailure(ev: StepEvent): boolean {
  * thread log and yielded with the run id; `session` (and `done.sessionId`)
  * updates the thread header instead. Tool-call durations are measured
  * between a `tool_call` and the `tool_result` carrying the same id, and the
- * whole tally is written to the run log when the step completes.
+ * whole tally is written to the run log once the step completes.
+ *
+ * Two things are deliberately ordered around the yield. The run log is
+ * written AFTER the `done` reaches the caller, and a failure to write it is
+ * swallowed to stderr: telemetry must never cost the caller its terminal
+ * event. A failed thread-log write, by contrast, stops the step — but as a
+ * yielded `error`, never as a thrown exception.
  *
  * A provider that ends its stream without a `done` or `error` gets one
  * synthesized here: spec §5 promises the caller never sees a stream close
@@ -253,58 +362,105 @@ async function* stream(
   opts: RunStepOptions,
   provider: ModelProvider,
   runId: string,
-  it: AsyncIterator<StepEvent>,
-  first: IteratorResult<StepEvent>,
+  events: AsyncIterable<StepEvent>,
 ): AsyncIterable<StepEvent & { runId: string }> {
   const { tenant, store } = deps;
   const startedAt = Date.now();
-  const pending = new Map<string, number>();
+  const pending = new Map<string, { name: string; at: number }>();
   const toolCalls: ToolCallLog[] = [];
   let sawTerminal = false;
 
-  let res = first;
-  while (!res.done) {
-    const ev = res.value;
-
+  for await (const ev of events) {
     if (ev.type === 'session') {
-      await store.setSession(tenant, opts.threadId, provider.id, ev.id);
-      res = await it.next();
+      const failed = await tryPersist(() => store.setSession(tenant, opts.threadId, provider.id, ev.id));
+      if (failed) {
+        yield { type: 'error', message: failed, runId };
+        return;
+      }
       continue;
     }
 
-    await store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent);
+    const failed = await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent));
+    if (failed) {
+      // The store is broken, so the error event cannot be logged either —
+      // it only reaches the caller.
+      yield { type: 'error', message: failed, runId };
+      return;
+    }
 
     if (ev.type === 'tool_call') {
-      pending.set(ev.id, Date.now());
+      pending.set(ev.id, { name: ev.name, at: Date.now() });
     } else if (ev.type === 'tool_result') {
-      const at = pending.get(ev.id);
+      const call = pending.get(ev.id);
       pending.delete(ev.id);
-      toolCalls.push({ name: ev.name, ms: at === undefined ? 0 : Date.now() - at, isError: ev.isError === true });
+      // A result with no matching call (a harness that reports only the
+      // result, or an id that did not round-trip) still happened — it is
+      // logged with an unknown duration rather than a fabricated 0.
+      toolCalls.push({ name: ev.name, ms: call ? Date.now() - call.at : null, isError: ev.isError === true });
     } else if (ev.type === 'done') {
       sawTerminal = true;
-      if (ev.sessionId) await store.setSession(tenant, opts.threadId, provider.id, ev.sessionId);
-      const entry: RunLogEntry = {
-        at: nowIso(),
-        provider: provider.id,
-        ...(opts.task ? { task: opts.task } : {}),
-        inputTokens: ev.usage.inputTokens,
-        outputTokens: ev.usage.outputTokens,
-        ...(ev.usage.costUsd === undefined ? {} : { costUsd: ev.usage.costUsd }),
-        durationMs: Date.now() - startedAt,
-        toolCalls,
-      };
-      writeRunLog(deps.vaultRoot, tenant, runId, [entry]);
+      if (ev.sessionId) {
+        const sessionFailed = await tryPersist(() =>
+          store.setSession(tenant, opts.threadId, provider.id, ev.sessionId as string),
+        );
+        if (sessionFailed) {
+          yield { type: 'error', message: sessionFailed, runId };
+          return;
+        }
+      }
     } else if (ev.type === 'error') {
       sawTerminal = true;
     }
 
     yield { ...ev, runId };
-    res = await it.next();
+
+    if (ev.type === 'done') {
+      recordRun(deps, opts, provider, runId, ev.usage, Date.now() - startedAt, finishToolCalls(toolCalls, pending));
+    }
   }
 
   if (!sawTerminal) {
     const ev: StepEvent = { type: 'error', message: `${provider.id} ended the step without a done or error event` };
-    await store.append(tenant, opts.threadId, { ...ev, at: nowIso() });
+    await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() }));
     yield { ...ev, runId };
+  }
+}
+
+/**
+ * Closes out the run's tool tally. A `tool_call` still pending when the step
+ * ended never got a result — the step was cut short, or the harness dropped
+ * it — so it is logged with both its duration and its outcome unknown
+ * rather than omitted: a call the model made and never heard back from is
+ * exactly what a run log should show.
+ */
+function finishToolCalls(done: ToolCallLog[], pending: Map<string, { name: string; at: number }>): ToolCallLog[] {
+  const unmatched = [...pending.values()].map(c => ({ name: c.name, ms: null, isError: null }));
+  return [...done, ...unmatched];
+}
+
+/** Writes the run log, swallowing failures to stderr — see `stream`. */
+function recordRun(
+  deps: CounselLoopDeps,
+  opts: RunStepOptions,
+  provider: ModelProvider,
+  runId: string,
+  usage: Usage,
+  durationMs: number,
+  toolCalls: ToolCallLog[],
+): void {
+  const entry: RunLogEntry = {
+    at: nowIso(),
+    provider: provider.id,
+    ...(opts.task ? { task: opts.task } : {}),
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    ...(usage.costUsd === undefined ? {} : { costUsd: usage.costUsd }),
+    durationMs,
+    toolCalls,
+  };
+  try {
+    writeRunLog(deps.vaultRoot, deps.tenant, runId, [entry]);
+  } catch (err) {
+    console.error(`counsel-loop: run log write failed for ${runId}: ${message(err)}`);
   }
 }

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -304,13 +304,26 @@ async function beginAttempt(provider: ModelProvider, req: StepRequest): Promise<
   return { it, head, first };
 }
 
-/** Replays a started attempt as one flat stream: buffered head, the event
- * that broke the buffering, then whatever the provider has left. */
+/**
+ * Replays a started attempt as one flat stream: buffered head, the event
+ * that broke the buffering, then whatever the provider has left.
+ *
+ * The provider's iterator is closed on the way out, however the way out
+ * comes. A hand-rolled `next()` loop — unlike `for await` or `yield*` — does
+ * not forward abandonment to what it is reading, so without this a consumer
+ * that stops early (an HTTP client hanging up mid-step) would leave the
+ * provider running: a harness subprocess with nobody reading it, or a direct
+ * provider holding an open HTTP response.
+ */
 async function* chain(attempt: Attempt): AsyncIterable<StepEvent> {
-  for (const ev of attempt.head) yield ev;
-  if (attempt.first.done) return;
-  yield attempt.first.value;
-  for (let n = await attempt.it.next(); !n.done; n = await attempt.it.next()) yield n.value;
+  try {
+    for (const ev of attempt.head) yield ev;
+    if (attempt.first.done) return;
+    yield attempt.first.value;
+    for (let n = await attempt.it.next(); !n.done; n = await attempt.it.next()) yield n.value;
+  } finally {
+    await closeQuietly(attempt.it);
+  }
 }
 
 /** Closes an abandoned provider iterator. A throwing `return()` must not

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -130,8 +130,10 @@ function stepTools(deps: CounselLoopDeps, threadId: string, cfg: VaultConfig, sc
  *
  * Yields every `StepEvent` the provider produced, tagged with this step's
  * `runId` — except `session`, which is consumed (stored on the thread
- * header) rather than surfaced. `text` events pass through exactly as the
- * provider emitted them; coalescing them for a UI is the server's job.
+ * header) rather than surfaced. `text` events pass through to the caller
+ * exactly as the provider emitted them; coalescing them for a UI is the
+ * server's job. The thread LOG stores one `text` event per run of text (see
+ * `stream`), which is a different question from what the caller streams.
  *
  * Failures are events, never exceptions: an unknown thread, an unresolvable
  * provider, or a broken prompt assembly each end the stream with a single
@@ -143,6 +145,11 @@ export async function* runStep(
   deps: CounselLoopDeps,
   opts: RunStepOptions,
 ): AsyncIterable<StepEvent & { runId: string }> {
+  // The step's clock starts HERE, not inside `stream`. `beginAttempt` already
+  // awaits the provider's first non-`session` event, which on both harness
+  // tiers is the entire model turn — a clock started after it measured
+  // single-digit milliseconds for three-second steps.
+  const startedAt = Date.now();
   const runId = randomUUID();
   const { tenant, store } = deps;
   const { threadId } = opts;
@@ -273,7 +280,7 @@ export async function* runStep(
     attempt = await beginAttempt(provider, req);
   }
 
-  yield* stream(deps, opts, provider, runId, chain(attempt));
+  yield* stream(deps, opts, provider, runId, chain(attempt), startedAt);
 }
 
 function isResumeFailure(ev: StepEvent): boolean {
@@ -355,7 +362,9 @@ async function tryPersist(write: () => Promise<void>): Promise<string | null> {
 /**
  * Drains the provider's stream: every event but `session` is appended to the
  * thread log and yielded with the run id; `session` (and `done.sessionId`)
- * updates the thread header instead. Tool-call durations are measured
+ * updates the thread header instead. Consecutive `text` events are the one
+ * exception — they reach the caller immediately but are merged into a single
+ * logged `text` event. Tool-call durations are measured
  * between a `tool_call` and the `tool_result` carrying the same id, and the
  * whole tally is written to the run log once the step completes.
  *
@@ -376,12 +385,27 @@ async function* stream(
   provider: ModelProvider,
   runId: string,
   events: AsyncIterable<StepEvent>,
+  startedAt: number,
 ): AsyncIterable<StepEvent & { runId: string }> {
   const { tenant, store } = deps;
-  const startedAt = Date.now();
   const pending = new Map<string, { name: string; at: number }>();
   const toolCalls: ToolCallLog[] = [];
   let sawTerminal = false;
+
+  // `text` deltas are yielded the instant they arrive — a caller streaming to
+  // a user must not wait on the next non-text event — but they are held back
+  // from the LOG until the run of text ends. The local tier emits one delta
+  // per token, which wrote 177 events / 13 KB of JSONL for a single ~800
+  // character answer, and left every reader of `GET /threads/:id` to redo the
+  // coalescing the SSE layer already does. One run of text is one `text`
+  // event in the log; a `tool_call` between two runs still splits them.
+  let textBuffer: string[] = [];
+  const flushText = async (): Promise<string | null> => {
+    if (textBuffer.length === 0) return null;
+    const merged = textBuffer.join('');
+    textBuffer = [];
+    return tryPersist(() => store.append(tenant, opts.threadId, { type: 'text', text: merged, at: nowIso() }));
+  };
 
   for await (const ev of events) {
     if (ev.type === 'session') {
@@ -391,6 +415,18 @@ async function* stream(
         return;
       }
       continue;
+    }
+
+    if (ev.type === 'text') {
+      textBuffer.push(ev.text);
+      yield { ...ev, runId };
+      continue;
+    }
+
+    const flushFailed = await flushText();
+    if (flushFailed) {
+      yield { type: 'error', message: flushFailed, runId };
+      return;
     }
 
     const failed = await tryPersist(() => store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent));
@@ -430,6 +466,14 @@ async function* stream(
     if (ev.type === 'done') {
       recordRun(deps, opts, provider, runId, ev.usage, Date.now() - startedAt, finishToolCalls(toolCalls, pending));
     }
+  }
+
+  // A stream that ends on text (no terminal event) still has to leave that
+  // text in the log.
+  const tailFailed = await flushText();
+  if (tailFailed) {
+    yield { type: 'error', message: tailFailed, runId };
+    return;
   }
 
   if (!sawTerminal) {

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -1,0 +1,310 @@
+import { randomUUID } from 'node:crypto';
+import type { ZodType } from 'zod';
+import type { Message, ModelProvider, Platform, StepEvent, StepRequest, Tenant, ToolDef, VaultStore } from '../core/types';
+import { currentPlatform } from '../core/types';
+import type { Router } from '../router/router';
+import { ThreadStore, type ThreadEvent, type ThreadHeader } from '../threads/store';
+import { window } from '../threads/window';
+import { readVaultConfig, type VaultConfig } from '../vault/resolve-root';
+import { guardedVaultTools } from '../vault/vault-tools';
+import { builtinTools } from '../tools/builtin';
+import { ToolRegistry } from '../tools/registry';
+import { assembleSystemPrompt } from './prompt';
+import { readPrimitiveTool } from './primitives';
+import { proposeUpdateTool } from './proposals';
+import { writeRunLog, type RunLogEntry, type ToolCallLog } from './run-log';
+
+/**
+ * Headroom left in the context window for the model's own reply and for the
+ * slack between our 4-chars-per-token estimate and the vendor's real
+ * tokenizer. Deliberately generous: overshooting the window is a hard
+ * provider error, while undershooting only drops the oldest turns.
+ */
+const REPLY_RESERVE_TOKENS = 2000;
+
+/** The same cheap estimator `window()` defaults to, applied to the system
+ * prompt as well so both halves of the budget are measured the same way. */
+const estimateTokens = (s: string): number => Math.ceil(s.length / 4);
+
+/**
+ * A vendor session that no longer exists reads differently on every harness
+ * ("session not found", "thread ... has expired", "cannot resume"), so the
+ * fallback matches on shape rather than on an exact string. False positives
+ * are cheap — the worst case is one wasted replay of a step that would have
+ * failed anyway — and the match only ever applies to a step that actually
+ * sent a `session`, and only to its very first event.
+ */
+const RESUME_FAILURE_RE = /session|thread|resume|not found/i;
+
+export interface CounselLoopDeps {
+  tenant: Tenant;
+  vaultRoot: string;
+  /** The Counsel OS plugin/repo root: `skills/`, `primitives/`, `scripts/`. */
+  pluginRoot: string;
+  vault: VaultStore;
+  store: ThreadStore;
+  providers: ModelProvider[];
+  router: Router;
+  platform?: Platform;
+}
+
+export interface RunStepOptions {
+  threadId: string;
+  message: string;
+  task?: string;
+  providerId?: string;
+  outputSchema?: ZodType<unknown>;
+}
+
+/** A provider that can be re-bound to a per-thread home directory — today
+ * only `CodexHarnessProvider`, whose sessions live inside `CODEX_HOME` and
+ * so cannot be resumed from a different one. Duck-typed rather than an
+ * `instanceof` check so this module does not pull in the Codex SDK. */
+interface HomeBindable {
+  withHome(dir: string): ModelProvider;
+}
+
+function isHomeBindable(p: ModelProvider): p is ModelProvider & HomeBindable {
+  return typeof (p as Partial<HomeBindable>).withHome === 'function';
+}
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+/**
+ * Codex keeps a thread's state under its `CODEX_HOME`, so a registry-built
+ * `codex-sub/*` provider — shared by every thread — has to be re-bound to
+ * this thread's own persistent home before it can resume anything. Every
+ * other provider is returned unchanged.
+ */
+function bindToThread(provider: ModelProvider, store: ThreadStore, threadId: string): ModelProvider {
+  if (!provider.id.startsWith('codex-sub/') || !isHomeBindable(provider)) return provider;
+  return provider.withHome(store.codexHomeFor(threadId));
+}
+
+function resolveProvider(deps: CounselLoopDeps, opts: RunStepOptions): ModelProvider {
+  if (opts.providerId) {
+    const found = deps.providers.find(p => p.id === opts.providerId);
+    if (!found) throw new Error(`unknown provider: ${opts.providerId}`);
+    return found;
+  }
+  return deps.router.resolve(opts.task);
+}
+
+/**
+ * The tools a counsel step gets: the vault tools with the `remember` gate
+ * closed (`guardedVaultTools` — knowledge paths refuse `vault_write`),
+ * `propose_update` as the way through that gate, `read_primitive` for the
+ * methodology's on-demand sections, and the platform's script tools.
+ */
+function stepTools(deps: CounselLoopDeps, threadId: string, cfg: VaultConfig, scriptTools: ToolDef[]): ToolDef[] {
+  return [
+    ...guardedVaultTools(deps.vault, cfg),
+    proposeUpdateTool(deps.store, deps.vault, threadId, deps.tenant) as ToolDef,
+    readPrimitiveTool(deps.pluginRoot) as ToolDef,
+    ...scriptTools,
+  ];
+}
+
+/**
+ * One counsel step: append the user turn, resolve a provider, assemble the
+ * system prompt and tools, stream the model to completion, and record
+ * everything (thread log, vendor session, run log) as it goes.
+ *
+ * Yields every `StepEvent` the provider produced, tagged with this step's
+ * `runId` — except `session`, which is consumed (stored on the thread
+ * header) rather than surfaced. `text` events pass through exactly as the
+ * provider emitted them; coalescing them for a UI is the server's job.
+ *
+ * Failures are events, never exceptions: an unknown thread, an unresolvable
+ * provider, or a broken prompt assembly each end the stream with a single
+ * `error`. An unknown thread appends nothing (there is nothing to append
+ * to); the other two leave only the `user` event behind, so the request is
+ * still visible in the thread.
+ */
+export async function* runStep(
+  deps: CounselLoopDeps,
+  opts: RunStepOptions,
+): AsyncIterable<StepEvent & { runId: string }> {
+  const runId = randomUUID();
+  const { tenant, store } = deps;
+  const { threadId } = opts;
+
+  try {
+    await store.get(tenant, threadId);
+  } catch {
+    yield { type: 'error', message: `unknown thread: ${threadId}`, runId };
+    return;
+  }
+
+  await store.append(tenant, threadId, { t: 'user', at: nowIso(), content: opts.message });
+
+  let provider: ModelProvider;
+  try {
+    provider = bindToThread(resolveProvider(deps, opts), store, threadId);
+  } catch (err) {
+    yield { type: 'error', message: message(err), runId };
+    return;
+  }
+
+  await store.append(tenant, threadId, {
+    t: 'step',
+    at: nowIso(),
+    runId,
+    provider: provider.id,
+    ...(opts.task ? { task: opts.task } : {}),
+  });
+
+  // One header read serves both the system prompt (the thread's matter) and
+  // the session lookup below — nothing between them can change either.
+  let header: ThreadHeader;
+  let base: StepRequest;
+  let budgetTokens: number;
+  try {
+    ({ header } = await store.get(tenant, threadId));
+    const cfg = readVaultConfig(deps.vaultRoot);
+    const platform = deps.platform ?? currentPlatform();
+    const registry = new ToolRegistry();
+    for (const t of builtinTools({ vaultRoot: deps.vaultRoot, repoRoot: deps.pluginRoot })) registry.register(t);
+    const scriptTools = registry.available(platform);
+
+    const system = assembleSystemPrompt({
+      pluginRoot: deps.pluginRoot,
+      vaultRoot: deps.vaultRoot,
+      ...(header.matter ? { matterPath: header.matter } : {}),
+      platform,
+      cfg,
+      tools: {
+        available: scriptTools.map(t => t.name),
+        unavailable: registry.unavailable(platform),
+      },
+    });
+
+    budgetTokens = provider.capabilities.contextTokens - estimateTokens(system) - REPLY_RESERVE_TOKENS;
+    base = {
+      tenant,
+      system,
+      messages: [],
+      tools: stepTools(deps, threadId, cfg, scriptTools),
+      ...(opts.outputSchema ? { outputSchema: opts.outputSchema } : {}),
+    };
+  } catch (err) {
+    const ev: StepEvent = { type: 'error', message: message(err) };
+    await store.append(tenant, threadId, { ...ev, at: nowIso() });
+    yield { ...ev, runId };
+    return;
+  }
+
+  const replay = async (): Promise<StepRequest> => {
+    const { events } = await store.get(tenant, threadId);
+    return { ...base, messages: window(events, budgetTokens, estimateTokens) };
+  };
+
+  // A provider that already holds a session for this thread gets only the
+  // new turn plus the session id — its own side keeps the history, and
+  // re-sending ours would double it. Everyone else replays the window.
+  const sessionId = header.sessions[provider.id];
+  let req: StepRequest = sessionId
+    ? { ...base, messages: [{ role: 'user', content: opts.message } satisfies Message], session: { id: sessionId } }
+    : await replay();
+
+  let it = provider.run(req)[Symbol.asyncIterator]();
+  let first = await it.next();
+
+  // Resume failure (spec §5): the vendor's session is gone. Drop the dead id
+  // and replay the log once for this same step — the caller never sees the
+  // failed attempt, and nothing from it reaches the thread log. Only the
+  // very first event counts: once real output has streamed, a later error
+  // is a real error, not a bad session id.
+  if (!first.done && sessionId && isResumeFailure(first.value)) {
+    await it.return?.(undefined);
+    await store.clearSession(tenant, threadId, provider.id);
+    req = await replay();
+    it = provider.run(req)[Symbol.asyncIterator]();
+    first = await it.next();
+  }
+
+  yield* stream(deps, opts, provider, runId, it, first);
+}
+
+function isResumeFailure(ev: StepEvent): boolean {
+  return ev.type === 'error' && RESUME_FAILURE_RE.test(ev.message);
+}
+
+/**
+ * Drains the provider's stream: every event but `session` is appended to the
+ * thread log and yielded with the run id; `session` (and `done.sessionId`)
+ * updates the thread header instead. Tool-call durations are measured
+ * between a `tool_call` and the `tool_result` carrying the same id, and the
+ * whole tally is written to the run log when the step completes.
+ *
+ * A provider that ends its stream without a `done` or `error` gets one
+ * synthesized here: spec §5 promises the caller never sees a stream close
+ * without a terminal event, and a server turning these into SSE has no
+ * other way to tell "finished" from "the connection died".
+ */
+async function* stream(
+  deps: CounselLoopDeps,
+  opts: RunStepOptions,
+  provider: ModelProvider,
+  runId: string,
+  it: AsyncIterator<StepEvent>,
+  first: IteratorResult<StepEvent>,
+): AsyncIterable<StepEvent & { runId: string }> {
+  const { tenant, store } = deps;
+  const startedAt = Date.now();
+  const pending = new Map<string, number>();
+  const toolCalls: ToolCallLog[] = [];
+  let sawTerminal = false;
+
+  let res = first;
+  while (!res.done) {
+    const ev = res.value;
+
+    if (ev.type === 'session') {
+      await store.setSession(tenant, opts.threadId, provider.id, ev.id);
+      res = await it.next();
+      continue;
+    }
+
+    await store.append(tenant, opts.threadId, { ...ev, at: nowIso() } as ThreadEvent);
+
+    if (ev.type === 'tool_call') {
+      pending.set(ev.id, Date.now());
+    } else if (ev.type === 'tool_result') {
+      const at = pending.get(ev.id);
+      pending.delete(ev.id);
+      toolCalls.push({ name: ev.name, ms: at === undefined ? 0 : Date.now() - at, isError: ev.isError === true });
+    } else if (ev.type === 'done') {
+      sawTerminal = true;
+      if (ev.sessionId) await store.setSession(tenant, opts.threadId, provider.id, ev.sessionId);
+      const entry: RunLogEntry = {
+        at: nowIso(),
+        provider: provider.id,
+        ...(opts.task ? { task: opts.task } : {}),
+        inputTokens: ev.usage.inputTokens,
+        outputTokens: ev.usage.outputTokens,
+        ...(ev.usage.costUsd === undefined ? {} : { costUsd: ev.usage.costUsd }),
+        durationMs: Date.now() - startedAt,
+        toolCalls,
+      };
+      writeRunLog(deps.vaultRoot, tenant, runId, [entry]);
+    } else if (ev.type === 'error') {
+      sawTerminal = true;
+    }
+
+    yield { ...ev, runId };
+    res = await it.next();
+  }
+
+  if (!sawTerminal) {
+    const ev: StepEvent = { type: 'error', message: `${provider.id} ended the step without a done or error event` };
+    await store.append(tenant, opts.threadId, { ...ev, at: nowIso() });
+    yield { ...ev, runId };
+  }
+}

--- a/runtime/src/loop/primitives.ts
+++ b/runtime/src/loop/primitives.ts
@@ -1,0 +1,39 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod';
+import type { ToolDef } from '../core/types';
+
+/** Primitive names available under `<pluginRoot>/primitives/`, without the
+ * `.md` extension — e.g. `draft`, `evaluate`, `read`, `remember`, `research`. */
+function listPrimitiveNames(pluginRoot: string): string[] {
+  const dir = join(pluginRoot, 'primitives');
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  return entries.filter(name => name.endsWith('.md')).map(name => name.slice(0, -'.md'.length));
+}
+
+/**
+ * `read_primitive {name}` — the runtime's stand-in for "read
+ * `primitives/{name}.md`" in the methodology (see `HOST_PREAMBLE`). The
+ * allowlist is the actual set of `.md` files under `<pluginRoot>/primitives/`
+ * at call time, so an unknown or path-traversal name (`../../etc/passwd`,
+ * `draft/../../../x`) is rejected rather than joined onto a filesystem path.
+ */
+export function readPrimitiveTool(pluginRoot: string): ToolDef<{ name: string }, string> {
+  return {
+    name: 'read_primitive',
+    description: 'Read a primitive\'s detailed instructions by name (e.g. "draft", "evaluate", "read", "redline-output", "remember", "research").',
+    inputSchema: z.object({ name: z.string().describe('The primitive name, without the .md extension.') }),
+    execute: async ({ name }) => {
+      const allowed = listPrimitiveNames(pluginRoot);
+      if (!allowed.includes(name)) {
+        throw new Error(`unknown primitive: ${name}. Available: ${allowed.join(', ') || '(none)'}`);
+      }
+      return readFileSync(join(pluginRoot, 'primitives', `${name}.md`), 'utf8');
+    },
+  };
+}

--- a/runtime/src/loop/prompt.test.ts
+++ b/runtime/src/loop/prompt.test.ts
@@ -3,8 +3,21 @@ import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { assembleSystemPrompt, HOST_PREAMBLE } from './prompt';
+import type { AvailableTools } from './prompt';
 import { readPrimitiveTool } from './primitives';
 import { runToolDef } from '../core/fake-provider';
+import type { VaultConfig } from '../vault/resolve-root';
+
+const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+
+const allTools: AvailableTools = {
+  available: [
+    'vault_read', 'vault_write', 'vault_list', 'vault_search',
+    'propose_update', 'read_primitive',
+    'docket_sweep', 'extract_redlines', 'check_document', 'clean_format', 'apply_redlines', 'word_compare',
+  ],
+  unavailable: [],
+};
 
 function makeFixturePluginRoot(): string {
   const root = mkdtempSync(join(tmpdir(), 'plugin-'));
@@ -38,7 +51,17 @@ describe('assembleSystemPrompt', () => {
       vaultRoot,
       matterPath: 'matters/acme-nda.md',
       platform: 'macos',
-      toolNames: ['vault_read', 'vault_write', 'vault_list', 'vault_search', 'propose_update', 'read_primitive', 'docket_sweep'],
+      tools: {
+        available: ['vault_read', 'vault_write', 'vault_list', 'vault_search', 'propose_update', 'read_primitive', 'docket_sweep'],
+        unavailable: [
+          { name: 'extract_redlines', needs: ['macos', 'linux', 'windows', 'hosted'] },
+          { name: 'check_document', needs: ['macos', 'linux', 'windows', 'hosted'] },
+          { name: 'clean_format', needs: ['macos', 'linux', 'windows', 'hosted'] },
+          { name: 'apply_redlines', needs: ['macos', 'linux', 'windows', 'hosted'] },
+          { name: 'word_compare', needs: ['macos'] },
+        ],
+      },
+      cfg: defaultCfg,
     });
 
     // Frontmatter is gone; body content is present.
@@ -70,7 +93,8 @@ describe('assembleSystemPrompt', () => {
       vaultRoot,
       matterPath: 'matters/acme-nda.md',
       platform: 'macos' as const,
-      toolNames: ['vault_read', 'vault_write', 'read_primitive'],
+      tools: { available: ['vault_read', 'vault_write', 'read_primitive'], unavailable: [] },
+      cfg: defaultCfg,
     };
 
     const before = assembleSystemPrompt(opts);
@@ -89,7 +113,8 @@ describe('assembleSystemPrompt', () => {
       pluginRoot,
       vaultRoot,
       platform: 'linux',
-      toolNames: ['vault_read'],
+      tools: { available: ['vault_read'], unavailable: [] },
+      cfg: defaultCfg,
     });
 
     expect(prompt).not.toContain('## Practice profile');
@@ -106,7 +131,13 @@ describe('assembleSystemPrompt', () => {
     };
 
     const prompt = assembleSystemPrompt(
-      { pluginRoot: '/fake/plugin', vaultRoot: '/fake/vault', platform: 'hosted', toolNames: [] },
+      {
+        pluginRoot: '/fake/plugin',
+        vaultRoot: '/fake/vault',
+        platform: 'hosted',
+        tools: { available: [], unavailable: [] },
+        cfg: defaultCfg,
+      },
       readFile,
     );
 
@@ -114,26 +145,94 @@ describe('assembleSystemPrompt', () => {
     expect(prompt).not.toContain('name: counsel');
     expect(calls.some(p => p.includes('SKILL.md'))).toBe(true);
   });
+
+  test('a non-ENOENT readFile error propagates instead of being treated as "file absent"', () => {
+    const fakeSkill = '---\nname: counsel\n---\nBODY\n';
+    const readFile = (path: string) => {
+      if (path.endsWith('SKILL.md')) return fakeSkill;
+      if (path.endsWith('profile.md')) throw Object.assign(new Error('permission denied'), { code: 'EACCES' });
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    };
+
+    expect(() =>
+      assembleSystemPrompt(
+        {
+          pluginRoot: '/fake/plugin',
+          vaultRoot: '/fake/vault',
+          platform: 'hosted',
+          tools: { available: [], unavailable: [] },
+          cfg: defaultCfg,
+        },
+        readFile,
+      ),
+    ).toThrow(/permission denied/);
+  });
+
+  test('prints the configured mattersPath and does not leak the default "matters/" when overridden', () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const vaultRoot = makeFixtureVaultRoot();
+
+    const prompt = assembleSystemPrompt({
+      pluginRoot,
+      vaultRoot,
+      platform: 'macos',
+      tools: { available: ['vault_read', 'vault_write'], unavailable: [] },
+      cfg: { entitiesPath: 'clients', mattersPath: 'cases' },
+    });
+
+    expect(prompt).toContain('cases/');
+    expect(prompt).toContain('clients/');
+    expect(prompt).not.toContain('matters/');
+    expect(prompt).not.toContain('entities/');
+  });
 });
 
 describe('HOST_PREAMBLE', () => {
-  test('lists available tools and unavailable script tools with a reason', () => {
-    const preamble = HOST_PREAMBLE(['vault_read', 'read_primitive', 'docket_sweep'], 'linux');
+  test('lists available tools and unavailable tools with what platform they need', () => {
+    const tools: AvailableTools = {
+      available: ['vault_read', 'read_primitive', 'docket_sweep'],
+      unavailable: [{ name: 'word_compare', needs: ['macos'] }],
+    };
+    const preamble = HOST_PREAMBLE(tools, 'linux', defaultCfg);
     expect(preamble).toContain('vault_read');
     expect(preamble).toContain('word_compare');
-    expect(preamble).toContain('requires Microsoft Word for Mac');
+    expect(preamble).toContain('needs macos');
   });
 
   test('says every tool is available when nothing is missing', () => {
-    const all = ['docket_sweep', 'extract_redlines', 'check_document', 'clean_format', 'apply_redlines', 'word_compare'];
-    const preamble = HOST_PREAMBLE(all, 'macos');
+    const preamble = HOST_PREAMBLE(allTools, 'macos', defaultCfg);
     expect(preamble).toContain('every tool listed above is available on this platform');
   });
 
   test('tells the model not to run resolve_legal_root.sh', () => {
-    const preamble = HOST_PREAMBLE([], 'macos');
+    const preamble = HOST_PREAMBLE({ available: [], unavailable: [] }, 'macos', defaultCfg);
     expect(preamble).toContain('resolve_legal_root.sh');
     expect(preamble).toMatch(/[Dd]o not run/);
+  });
+
+  test('translates {legal_root}/x/y.md paths and states matters/entities live at the configured dirs', () => {
+    const preamble = HOST_PREAMBLE(allTools, 'macos', { entitiesPath: 'clients', mattersPath: 'cases' });
+    expect(preamble).toContain('{legal_root}/x/y.md');
+    expect(preamble.toLowerCase()).toContain('drop');
+    expect(preamble).toContain('cases/');
+    expect(preamble).toContain('clients/');
+  });
+
+  test('tells the model not to improvise when no tool covers a methodology step', () => {
+    const preamble = HOST_PREAMBLE(allTools, 'macos', defaultCfg);
+    expect(preamble).toMatch(/do not improvise/i);
+    expect(preamble).toMatch(/tell the user what you cannot do/i);
+  });
+
+  test('the apply_redlines mapping row matches the script\'s own usage text', () => {
+    const preamble = HOST_PREAMBLE(allTools, 'macos', defaultCfg);
+    expect(preamble).toContain('<redlines.json>');
+  });
+
+  test('the check_document mapping row reflects the file field and --json', () => {
+    const preamble = HOST_PREAMBLE(allTools, 'macos', defaultCfg);
+    expect(preamble).toContain('`file`');
+    expect(preamble).toContain('--json');
   });
 });
 

--- a/runtime/src/loop/prompt.test.ts
+++ b/runtime/src/loop/prompt.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { assembleSystemPrompt, HOST_PREAMBLE } from './prompt';
+import { readPrimitiveTool } from './primitives';
+import { runToolDef } from '../core/fake-provider';
+
+function makeFixturePluginRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'plugin-'));
+  mkdirSync(join(root, 'skills', 'counsel'), { recursive: true });
+  writeFileSync(
+    join(root, 'skills', 'counsel', 'SKILL.md'),
+    '---\nname: counsel\ndescription: "test skill"\n---\n\n# Counsel OS\n\nBody text goes here.\n',
+    'utf8',
+  );
+  mkdirSync(join(root, 'primitives'), { recursive: true });
+  writeFileSync(join(root, 'primitives', 'draft.md'), '# draft\n\noriginal primitive content\n', 'utf8');
+  return root;
+}
+
+function makeFixtureVaultRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), 'vault-'));
+  mkdirSync(join(root, 'practice'), { recursive: true });
+  writeFileSync(join(root, 'practice', 'profile.md'), 'Firm: Acme Legal\nAttorney: Jane Doe\n', 'utf8');
+  mkdirSync(join(root, 'matters'), { recursive: true });
+  writeFileSync(join(root, 'matters', 'acme-nda.md'), 'Matter: Acme NDA\nStatus: active\n', 'utf8');
+  return root;
+}
+
+describe('assembleSystemPrompt', () => {
+  test('assembles preamble + SKILL.md body (frontmatter stripped) + profile + matter', () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const vaultRoot = makeFixtureVaultRoot();
+
+    const prompt = assembleSystemPrompt({
+      pluginRoot,
+      vaultRoot,
+      matterPath: 'matters/acme-nda.md',
+      platform: 'macos',
+      toolNames: ['vault_read', 'vault_write', 'vault_list', 'vault_search', 'propose_update', 'read_primitive', 'docket_sweep'],
+    });
+
+    // Frontmatter is gone; body content is present.
+    expect(prompt).not.toContain('counsel-os-config');
+    expect(prompt).not.toContain('name: counsel');
+    expect(prompt).not.toContain('description: "test skill"');
+    expect(prompt).toContain('# Counsel OS');
+    expect(prompt).toContain('Body text goes here.');
+
+    // The host preamble is present.
+    expect(prompt).toContain('Host: Counsel OS runtime');
+    expect(prompt).toContain('read_primitive');
+    expect(prompt).toContain('propose_update');
+
+    // Profile and matter sections are present, each under its own heading.
+    expect(prompt).toContain('## Practice profile');
+    expect(prompt).toContain('Firm: Acme Legal');
+    expect(prompt).toContain('## Current matter');
+    expect(prompt).toContain('Matter: Acme NDA');
+
+    expect(prompt).toMatchSnapshot();
+  });
+
+  test('changing the fixture primitive does not change the output — primitives load lazily via read_primitive', () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const vaultRoot = makeFixtureVaultRoot();
+    const opts = {
+      pluginRoot,
+      vaultRoot,
+      matterPath: 'matters/acme-nda.md',
+      platform: 'macos' as const,
+      toolNames: ['vault_read', 'vault_write', 'read_primitive'],
+    };
+
+    const before = assembleSystemPrompt(opts);
+    writeFileSync(join(pluginRoot, 'primitives', 'draft.md'), '# draft\n\nCOMPLETELY DIFFERENT CONTENT\n', 'utf8');
+    const after = assembleSystemPrompt(opts);
+
+    expect(after).toBe(before);
+    expect(after).not.toContain('COMPLETELY DIFFERENT CONTENT');
+  });
+
+  test('omits the profile/matter sections when the files are absent', () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const vaultRoot = mkdtempSync(join(tmpdir(), 'vault-empty-'));
+
+    const prompt = assembleSystemPrompt({
+      pluginRoot,
+      vaultRoot,
+      platform: 'linux',
+      toolNames: ['vault_read'],
+    });
+
+    expect(prompt).not.toContain('## Practice profile');
+    expect(prompt).not.toContain('## Current matter');
+  });
+
+  test('is pure — reads only through the injected readFile', () => {
+    const calls: string[] = [];
+    const fakeSkill = '---\nname: counsel\n---\nFAKE BODY\n';
+    const readFile = (path: string) => {
+      calls.push(path);
+      if (path.endsWith('SKILL.md')) return fakeSkill;
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    };
+
+    const prompt = assembleSystemPrompt(
+      { pluginRoot: '/fake/plugin', vaultRoot: '/fake/vault', platform: 'hosted', toolNames: [] },
+      readFile,
+    );
+
+    expect(prompt).toContain('FAKE BODY');
+    expect(prompt).not.toContain('name: counsel');
+    expect(calls.some(p => p.includes('SKILL.md'))).toBe(true);
+  });
+});
+
+describe('HOST_PREAMBLE', () => {
+  test('lists available tools and unavailable script tools with a reason', () => {
+    const preamble = HOST_PREAMBLE(['vault_read', 'read_primitive', 'docket_sweep'], 'linux');
+    expect(preamble).toContain('vault_read');
+    expect(preamble).toContain('word_compare');
+    expect(preamble).toContain('requires Microsoft Word for Mac');
+  });
+
+  test('says every tool is available when nothing is missing', () => {
+    const all = ['docket_sweep', 'extract_redlines', 'check_document', 'clean_format', 'apply_redlines', 'word_compare'];
+    const preamble = HOST_PREAMBLE(all, 'macos');
+    expect(preamble).toContain('every tool listed above is available on this platform');
+  });
+
+  test('tells the model not to run resolve_legal_root.sh', () => {
+    const preamble = HOST_PREAMBLE([], 'macos');
+    expect(preamble).toContain('resolve_legal_root.sh');
+    expect(preamble).toMatch(/[Dd]o not run/);
+  });
+});
+
+describe('readPrimitiveTool', () => {
+  test('a known primitive name returns its file content', async () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const tool = readPrimitiveTool(pluginRoot);
+    const r = await runToolDef([tool], 'read_primitive', { name: 'draft' }, 'default');
+    expect(r.isError).toBe(false);
+    expect(r.output).toContain('original primitive content');
+  });
+
+  test('an unknown primitive name errors instead of reading arbitrary paths', async () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const tool = readPrimitiveTool(pluginRoot);
+    const r = await runToolDef([tool], 'read_primitive', { name: 'nonexistent' }, 'default');
+    expect(r.isError).toBe(true);
+    expect(String(r.output)).toMatch(/unknown primitive/);
+  });
+
+  test('path traversal is rejected, not resolved', async () => {
+    const pluginRoot = makeFixturePluginRoot();
+    const tool = readPrimitiveTool(pluginRoot);
+    const r = await runToolDef([tool], 'read_primitive', { name: '../../../etc/passwd' }, 'default');
+    expect(r.isError).toBe(true);
+  });
+});

--- a/runtime/src/loop/prompt.ts
+++ b/runtime/src/loop/prompt.ts
@@ -1,0 +1,193 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Platform } from '../core/types';
+
+/**
+ * A script tool the methodology may reference, and the fields the matching
+ * runtime tool takes. Used by `HOST_PREAMBLE` to build the script-mapping
+ * table and to compute which tools are unavailable on a given platform. Keep
+ * this list in lockstep with `tools/builtin.ts`'s `builtinTools()` — the
+ * field names here must match that file's `inputSchema`s exactly, or the
+ * preamble will teach the model to call tools with the wrong arguments.
+ */
+interface KnownScriptTool {
+  name: string;
+  invocation: string;
+  fields: string;
+  platforms: Platform[];
+  unavailableReason: string;
+}
+
+const ALL_PLATFORMS: Platform[] = ['macos', 'linux', 'windows', 'hosted'];
+
+const KNOWN_SCRIPT_TOOLS: KnownScriptTool[] = [
+  {
+    name: 'docket_sweep',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/docket_sweep.py" <matters_dir> --window <days> --format json',
+    fields: '`days` (optional, default 60)',
+    platforms: ALL_PLATFORMS,
+    unavailableReason: 'not available on this platform',
+  },
+  {
+    name: 'extract_redlines',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <input.docx>',
+    fields: '`docx`',
+    platforms: ALL_PLATFORMS,
+    unavailableReason: 'not available on this platform',
+  },
+  {
+    name: 'check_document',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <input>',
+    fields: '`docx`',
+    platforms: ALL_PLATFORMS,
+    unavailableReason: 'not available on this platform',
+  },
+  {
+    name: 'clean_format',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/clean_format.py" <input.docx> <output.docx>',
+    fields: '`input`, `output`',
+    platforms: ALL_PLATFORMS,
+    unavailableReason: 'not available on this platform',
+  },
+  {
+    name: 'apply_redlines',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <edits.json> <output.docx>',
+    fields: '`original`, `edits`, `output`, `track` (optional)',
+    platforms: ALL_PLATFORMS,
+    unavailableReason: 'not available on this platform',
+  },
+  {
+    name: 'word_compare',
+    invocation: '"${CLAUDE_PLUGIN_ROOT}/scripts/word_compare.sh" <original.docx> <modified.docx> <author> <output.docx>',
+    fields: '`original`, `modified`, `author`, `output`',
+    platforms: ['macos'],
+    unavailableReason: 'requires Microsoft Word for Mac',
+  },
+];
+
+/**
+ * The host-specific header prepended to the methodology body. Written for the
+ * model, not the user: it maps every "run this script" / "read this file"
+ * step in `SKILL.md` and the primitives onto the tool calls this runtime
+ * actually exposes, states what the propose-then-approve write gate is, and
+ * lists which tools exist on this run's platform.
+ */
+export function HOST_PREAMBLE(toolNames: string[], platform: Platform): string {
+  const scriptTable = KNOWN_SCRIPT_TOOLS
+    .map(t => `| \`${t.invocation}\` | \`${t.name}\` | ${t.fields} |`)
+    .join('\n');
+
+  const available = [...toolNames].sort().map(n => `\`${n}\``).join(', ');
+
+  const unavailable = KNOWN_SCRIPT_TOOLS.filter(t => !toolNames.includes(t.name));
+  const unavailableList = unavailable.length === 0
+    ? 'none — every tool listed above is available on this platform.'
+    : unavailable.map(t => `\`${t.name}\` (${t.unavailableReason})`).join(', ');
+
+  return `# Host: Counsel OS runtime
+
+You run inside the Counsel OS runtime, not inside Claude Code. Some steps in
+the methodology below do not apply here. Use this section to translate them.
+
+## The legal root is already resolved
+
+The runtime resolved \`{legal_root}\` before this session started. Do not run
+\`scripts/resolve_legal_root.sh\`. Do not ask the user for the legal root.
+Treat every vault path in the methodology as already resolved.
+
+## Scripts are tools
+
+The methodology tells you to run scripts directly, for example
+\`python3 "\${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" ...\`. In this
+runtime, call the matching tool instead. Do not run \`python3\` or \`bash\`
+yourself. Pass the tool's arguments as named fields, not as a command line.
+
+| Script call in the methodology | Tool | Fields |
+|---|---|---|
+${scriptTable}
+
+## Primitives are a tool call
+
+The methodology tells you to read \`primitives/{name}.md\` for the detailed
+steps of a mode. In this runtime, call \`read_primitive\` with that name
+instead of reading the file yourself. For example, call
+\`read_primitive {"name": "draft"}\` to load \`primitives/draft.md\`.
+
+## Writes go through two paths
+
+Matter files stay under direct control. Call \`vault_write\` for any path
+under \`matters/\`.
+
+Knowledge-system files do not write directly. This covers \`practice/\`,
+\`memory/\`, \`law/\`, and the entities directory. Call \`propose_update\` for
+these paths instead. \`propose_update\` does not write the file — it records
+a proposed change for the user to approve or reject. Tell the user what you
+proposed and why.
+
+## Tools on this platform (${platform})
+
+Available: ${available || 'none'}.
+
+Unavailable: ${unavailableList}`;
+}
+
+/** Strips a leading `--- ... ---` YAML frontmatter block, if present. */
+function stripFrontmatter(text: string): string {
+  if (!text.startsWith('---')) return text;
+  const closeIdx = text.indexOf('\n---', 3);
+  if (closeIdx === -1) return text;
+  const afterClose = text.indexOf('\n', closeIdx + 1);
+  const body = afterClose === -1 ? '' : text.slice(afterClose + 1);
+  return body.replace(/^\n+/, '');
+}
+
+/** Reads `path` with `readFile`, returning `null` instead of throwing when
+ * the file does not exist (or any other read error occurs). */
+function readIfPresent(readFile: (path: string) => string, path: string): string | null {
+  try {
+    return readFile(path);
+  } catch {
+    return null;
+  }
+}
+
+export interface AssembleSystemPromptOptions {
+  pluginRoot: string;
+  vaultRoot: string;
+  matterPath?: string;
+  platform: Platform;
+  toolNames: string[];
+}
+
+/**
+ * Builds the system prompt for a counsel-loop step: the host preamble, the
+ * body of `skills/counsel/SKILL.md` (frontmatter stripped), the practice
+ * profile if present, and the current matter file if present. Pure — every
+ * file is read through the injected `readFile` (default `readFileSync`), so
+ * a fake `readFile` makes this fully testable without touching disk. Never
+ * reads `primitives/*.md`: those load lazily via the `read_primitive` tool,
+ * so editing a primitive does not change the system prompt.
+ */
+export function assembleSystemPrompt(
+  opts: AssembleSystemPromptOptions,
+  readFile: (path: string) => string = path => readFileSync(path, 'utf8'),
+): string {
+  const skillPath = join(opts.pluginRoot, 'skills', 'counsel', 'SKILL.md');
+  const skillBody = stripFrontmatter(readFile(skillPath));
+
+  let prompt = HOST_PREAMBLE(opts.toolNames, opts.platform) + '\n\n' + skillBody;
+
+  const profile = readIfPresent(readFile, join(opts.vaultRoot, 'practice', 'profile.md'));
+  if (profile !== null) {
+    prompt += '\n\n## Practice profile\n' + profile;
+  }
+
+  if (opts.matterPath) {
+    const matter = readIfPresent(readFile, join(opts.vaultRoot, opts.matterPath));
+    if (matter !== null) {
+      prompt += '\n\n## Current matter\n' + matter;
+    }
+  }
+
+  return prompt;
+}

--- a/runtime/src/loop/prompt.ts
+++ b/runtime/src/loop/prompt.ts
@@ -1,88 +1,85 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { Platform } from '../core/types';
+import type { VaultConfig } from '../vault/resolve-root';
 
 /**
- * A script tool the methodology may reference, and the fields the matching
- * runtime tool takes. Used by `HOST_PREAMBLE` to build the script-mapping
- * table and to compute which tools are unavailable on a given platform. Keep
- * this list in lockstep with `tools/builtin.ts`'s `builtinTools()` — the
- * field names here must match that file's `inputSchema`s exactly, or the
- * preamble will teach the model to call tools with the wrong arguments.
+ * A script call the methodology may reference, and the tool + fields it maps
+ * to. Purely the mapping-table content for `HOST_PREAMBLE` — which tools are
+ * actually available on a given platform is supplied by the caller (see
+ * `AvailableTools`), not looked up here. Keep this list in lockstep with
+ * `tools/builtin.ts`'s `builtinTools()` — the field names here must match
+ * that file's `inputSchema`s exactly, or the preamble will teach the model
+ * to call tools with the wrong arguments.
  */
-interface KnownScriptTool {
+interface ScriptToolMapping {
   name: string;
   invocation: string;
   fields: string;
-  platforms: Platform[];
-  unavailableReason: string;
 }
 
-const ALL_PLATFORMS: Platform[] = ['macos', 'linux', 'windows', 'hosted'];
-
-const KNOWN_SCRIPT_TOOLS: KnownScriptTool[] = [
+const SCRIPT_TOOL_MAPPINGS: ScriptToolMapping[] = [
   {
     name: 'docket_sweep',
     invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/docket_sweep.py" <matters_dir> --window <days> --format json',
     fields: '`days` (optional, default 60)',
-    platforms: ALL_PLATFORMS,
-    unavailableReason: 'not available on this platform',
   },
   {
     name: 'extract_redlines',
-    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <input.docx>',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/extract_redlines.py" <file> --format json',
     fields: '`docx`',
-    platforms: ALL_PLATFORMS,
-    unavailableReason: 'not available on this platform',
   },
   {
     name: 'check_document',
-    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <input>',
-    fields: '`docx`',
-    platforms: ALL_PLATFORMS,
-    unavailableReason: 'not available on this platform',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/check_document.py" <file> --json',
+    fields: '`file` — accepts .docx, .md, or .txt; always run with --json',
   },
   {
     name: 'clean_format',
     invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/clean_format.py" <input.docx> <output.docx>',
     fields: '`input`, `output`',
-    platforms: ALL_PLATFORMS,
-    unavailableReason: 'not available on this platform',
   },
   {
     name: 'apply_redlines',
-    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <edits.json> <output.docx>',
+    invocation: 'python3 "${CLAUDE_PLUGIN_ROOT}/scripts/apply_redlines.py" [--track] <original.docx> <redlines.json> <output.docx>',
     fields: '`original`, `edits`, `output`, `track` (optional)',
-    platforms: ALL_PLATFORMS,
-    unavailableReason: 'not available on this platform',
   },
   {
     name: 'word_compare',
     invocation: '"${CLAUDE_PLUGIN_ROOT}/scripts/word_compare.sh" <original.docx> <modified.docx> <author> <output.docx>',
     fields: '`original`, `modified`, `author`, `output`',
-    platforms: ['macos'],
-    unavailableReason: 'requires Microsoft Word for Mac',
   },
 ];
 
 /**
- * The host-specific header prepended to the methodology body. Written for the
- * model, not the user: it maps every "run this script" / "read this file"
- * step in `SKILL.md` and the primitives onto the tool calls this runtime
- * actually exposes, states what the propose-then-approve write gate is, and
- * lists which tools exist on this run's platform.
+ * The tool availability this run's caller already computed — typically from
+ * a `ToolRegistry` built with every builtin tool registered:
+ * `{ available: registry.available(platform).map(t => t.name), unavailable: registry.unavailable(platform) }`.
+ * `HOST_PREAMBLE` only renders this; it does not decide platform gating.
  */
-export function HOST_PREAMBLE(toolNames: string[], platform: Platform): string {
-  const scriptTable = KNOWN_SCRIPT_TOOLS
+export interface AvailableTools {
+  available: string[];
+  unavailable: Array<{ name: string; needs: Platform[] }>;
+}
+
+/**
+ * The host-specific header prepended to the methodology body. Written for the
+ * model, not the user: it maps every "run this script" / "read this file" /
+ * "{legal_root}/..." step in `SKILL.md` and the primitives onto the tool
+ * calls and vault-relative paths this runtime actually uses, states what the
+ * propose-then-approve write gate is, says what to do when no tool covers a
+ * step, and lists which tools exist on this run's platform.
+ */
+export function HOST_PREAMBLE(tools: AvailableTools, platform: Platform, cfg: VaultConfig): string {
+  const scriptTable = SCRIPT_TOOL_MAPPINGS
     .map(t => `| \`${t.invocation}\` | \`${t.name}\` | ${t.fields} |`)
     .join('\n');
 
-  const available = [...toolNames].sort().map(n => `\`${n}\``).join(', ');
+  const available = [...tools.available].sort().map(n => `\`${n}\``).join(', ');
 
-  const unavailable = KNOWN_SCRIPT_TOOLS.filter(t => !toolNames.includes(t.name));
-  const unavailableList = unavailable.length === 0
+  const unavailableList = tools.unavailable.length === 0
     ? 'none — every tool listed above is available on this platform.'
-    : unavailable.map(t => `\`${t.name}\` (${t.unavailableReason})`).join(', ');
+    : tools.unavailable.map(t => `\`${t.name}\` (needs ${t.needs.join(', ')})`).join(', ');
 
   return `# Host: Counsel OS runtime
 
@@ -95,6 +92,15 @@ The runtime resolved \`{legal_root}\` before this session started. Do not run
 \`scripts/resolve_legal_root.sh\`. Do not ask the user for the legal root.
 Treat every vault path in the methodology as already resolved.
 
+## Vault paths
+
+The methodology writes vault paths as \`{legal_root}/x/y.md\`. Vault tools do
+not take that prefix. Drop \`{legal_root}/\`. Pass \`x/y.md\` instead. Never
+pass an absolute path.
+
+Matter files live under \`${cfg.mattersPath}/\`. Entity files live under
+\`${cfg.entitiesPath}/\`.
+
 ## Scripts are tools
 
 The methodology tells you to run scripts directly, for example
@@ -106,6 +112,10 @@ yourself. Pass the tool's arguments as named fields, not as a command line.
 |---|---|---|
 ${scriptTable}
 
+If a methodology step calls for a script or shell command with no tool
+listed above, do not improvise. Tell the user what you cannot do. Continue
+with the rest of the request.
+
 ## Primitives are a tool call
 
 The methodology tells you to read \`primitives/{name}.md\` for the detailed
@@ -116,10 +126,10 @@ instead of reading the file yourself. For example, call
 ## Writes go through two paths
 
 Matter files stay under direct control. Call \`vault_write\` for any path
-under \`matters/\`.
+under \`${cfg.mattersPath}/\`.
 
 Knowledge-system files do not write directly. This covers \`practice/\`,
-\`memory/\`, \`law/\`, and the entities directory. Call \`propose_update\` for
+\`memory/\`, \`law/\`, and \`${cfg.entitiesPath}/\`. Call \`propose_update\` for
 these paths instead. \`propose_update\` does not write the file — it records
 a proposed change for the user to approve or reject. Tell the user what you
 proposed and why.
@@ -141,13 +151,18 @@ function stripFrontmatter(text: string): string {
   return body.replace(/^\n+/, '');
 }
 
-/** Reads `path` with `readFile`, returning `null` instead of throwing when
- * the file does not exist (or any other read error occurs). */
+/** Reads `path` with `readFile`, returning `null` when the file does not
+ * exist (`ENOENT`) — the only expected reason `practice/profile.md` or a
+ * matter file might be absent. Any other error (permissions, a directory
+ * where a file was expected, a broken injected `readFile`) is a real
+ * failure and is left to propagate rather than silently rendered as
+ * "absent". */
 function readIfPresent(readFile: (path: string) => string, path: string): string | null {
   try {
     return readFile(path);
-  } catch {
-    return null;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') return null;
+    throw err;
   }
 }
 
@@ -156,7 +171,8 @@ export interface AssembleSystemPromptOptions {
   vaultRoot: string;
   matterPath?: string;
   platform: Platform;
-  toolNames: string[];
+  tools: AvailableTools;
+  cfg: VaultConfig;
 }
 
 /**
@@ -175,7 +191,7 @@ export function assembleSystemPrompt(
   const skillPath = join(opts.pluginRoot, 'skills', 'counsel', 'SKILL.md');
   const skillBody = stripFrontmatter(readFile(skillPath));
 
-  let prompt = HOST_PREAMBLE(opts.toolNames, opts.platform) + '\n\n' + skillBody;
+  let prompt = HOST_PREAMBLE(opts.tools, opts.platform, opts.cfg) + '\n\n' + skillBody;
 
   const profile = readIfPresent(readFile, join(opts.vaultRoot, 'practice', 'profile.md'));
   if (profile !== null) {

--- a/runtime/src/loop/proposals.test.ts
+++ b/runtime/src/loop/proposals.test.ts
@@ -50,6 +50,39 @@ describe('proposeUpdateTool', () => {
     expect(await vault.read('default', 'practice/standards/indemnification.md')).toBe('old content');
   });
 
+  test('the recorded path is normalized, not the spelling the model used', async () => {
+    // `isKnowledgePath` already normalizes, so this reaches propose_update
+    // rather than vault_write. What lands in the event is what a reviewer
+    // reads and what applyProposal writes to, so it must be the real path.
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const r = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'matters/../practice/x.md', content: 'body', rationale: 'why' },
+      'default',
+    );
+    expect(r.isError).toBe(false);
+
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.path).toBe('practice/x.md');
+  });
+
+  test('a path that normalizes out of the vault is an error result, not a proposal', async () => {
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const r = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: '../escape.md', content: 'body', rationale: 'why' },
+      'default',
+    );
+    expect(r.isError).toBe(true);
+    expect(String(r.output)).toContain('path outside vault');
+
+    const { events } = await store.get('default', threadId);
+    expect(events.some(ev => 't' in ev && ev.t === 'proposal')).toBe(false);
+  });
+
   test('a proposal for a path that does not exist yet records a null expectedVersion', async () => {
     const tool = proposeUpdateTool(store, vault, threadId, 'default');
     await runToolDef(

--- a/runtime/src/loop/proposals.test.ts
+++ b/runtime/src/loop/proposals.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { applyProposal, proposeUpdateTool } from './proposals';
+import { FsVaultStore } from '../vault/fs-store';
+import { ThreadStore } from '../threads/store';
+import { runToolDef } from '../core/fake-provider';
+
+let vault: FsVaultStore;
+let store: ThreadStore;
+let threadId: string;
+
+beforeEach(async () => {
+  vault = new FsVaultStore(mkdtempSync(join(tmpdir(), 'proposals-vault-')));
+  store = new ThreadStore(mkdtempSync(join(tmpdir(), 'proposals-threads-')), {
+    codexHomeRoot: mkdtempSync(join(tmpdir(), 'proposals-codex-')),
+  });
+  const header = await store.create('default', { title: 'test thread' });
+  threadId = header.id;
+});
+
+describe('proposeUpdateTool', () => {
+  test('appends a proposal event carrying the path\'s current version', async () => {
+    await vault.write('default', 'practice/standards/indemnification.md', 'old content');
+    const expectedVersion = await vault.version('default', 'practice/standards/indemnification.md');
+
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const r = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/indemnification.md', content: 'new content', rationale: 'tighten the cap' },
+      'default',
+    );
+    expect(r.isError).toBe(false);
+    const proposalId = (r.output as { proposalId: string }).proposalId;
+    expect(proposalId).toBeTruthy();
+
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal).toBeDefined();
+    expect(proposal.id).toBe(proposalId);
+    expect(proposal.path).toBe('practice/standards/indemnification.md');
+    expect(proposal.content).toBe('new content');
+    expect(proposal.rationale).toBe('tighten the cap');
+    expect(proposal.status).toBe('pending');
+    expect(proposal.expectedVersion).toBe(expectedVersion);
+
+    // The vault itself is untouched — propose_update never writes.
+    expect(await vault.read('default', 'practice/standards/indemnification.md')).toBe('old content');
+  });
+
+  test('a proposal for a path that does not exist yet records a null expectedVersion', async () => {
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/new.md', content: 'brand new', rationale: 'new standard' },
+      'default',
+    );
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.expectedVersion).toBeNull();
+  });
+});
+
+describe('applyProposal', () => {
+  test('approve writes the content at the recorded version and returns the new version', async () => {
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const propose = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/x.md', content: 'proposed content', rationale: 'r' },
+      'default',
+    );
+    const proposalId = (propose.output as { proposalId: string }).proposalId;
+
+    const result = await applyProposal(store, vault, 'default', threadId, proposalId, 'approve');
+    expect(result.status).toBe('approved');
+    expect((result as any).version).toBe(await vault.version('default', 'practice/standards/x.md'));
+    expect(await vault.read('default', 'practice/standards/x.md')).toBe('proposed content');
+
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.status).toBe('approved');
+  });
+
+  test('approve after an external edit conflicts and leaves the proposal pending', async () => {
+    const originalVersion = await vault.write('default', 'practice/standards/x.md', 'original');
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const propose = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/x.md', content: 'proposed content', rationale: 'r' },
+      'default',
+    );
+    const proposalId = (propose.output as { proposalId: string }).proposalId;
+
+    // Someone else edits the file after the proposal was made, before approval.
+    const editedVersion = await vault.write('default', 'practice/standards/x.md', 'edited out from under the proposal');
+
+    const result = await applyProposal(store, vault, 'default', threadId, proposalId, 'approve');
+    expect(result.status).toBe('conflict');
+    const conflict = (result as any).conflict;
+    expect(conflict.expected).toBe(originalVersion);
+    expect(conflict.actual).toBe(editedVersion);
+
+    // Nothing further was written, and the proposal is still pending.
+    expect(await vault.read('default', 'practice/standards/x.md')).toBe('edited out from under the proposal');
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.status).toBe('pending');
+  });
+
+  test('reject marks the proposal rejected and writes nothing', async () => {
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const propose = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/y.md', content: 'proposed content', rationale: 'r' },
+      'default',
+    );
+    const proposalId = (propose.output as { proposalId: string }).proposalId;
+
+    const result = await applyProposal(store, vault, 'default', threadId, proposalId, 'reject');
+    expect(result.status).toBe('rejected');
+    expect(await vault.version('default', 'practice/standards/y.md')).toBeNull();
+
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.status).toBe('rejected');
+  });
+
+  test('an unknown proposal id throws', async () => {
+    await expect(applyProposal(store, vault, 'default', threadId, 'nonexistent', 'approve')).rejects.toThrow(/unknown proposal/);
+  });
+});

--- a/runtime/src/loop/proposals.test.ts
+++ b/runtime/src/loop/proposals.test.ts
@@ -131,6 +131,55 @@ describe('applyProposal', () => {
     expect(proposal.status).toBe('rejected');
   });
 
+  test('approve after a prior reject is a no-op — the earlier decision stands and nothing is written', async () => {
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const propose = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/z.md', content: 'proposed content', rationale: 'r' },
+      'default',
+    );
+    const proposalId = (propose.output as { proposalId: string }).proposalId;
+
+    const rejected = await applyProposal(store, vault, 'default', threadId, proposalId, 'reject');
+    expect(rejected.status).toBe('rejected');
+
+    const second = await applyProposal(store, vault, 'default', threadId, proposalId, 'approve');
+    expect(second.status).toBe('rejected');
+    expect((second as any).error).toMatch(/not pending/);
+
+    expect(await vault.version('default', 'practice/standards/z.md')).toBeNull();
+    const { events } = await store.get('default', threadId);
+    const proposal = events.find(ev => 't' in ev && ev.t === 'proposal') as any;
+    expect(proposal.status).toBe('rejected');
+  });
+
+  test('approving an already-approved proposal is a no-op and does not re-write', async () => {
+    await vault.write('default', 'practice/standards/w.md', 'initial');
+    const tool = proposeUpdateTool(store, vault, threadId, 'default');
+    const propose = await runToolDef(
+      [tool],
+      'propose_update',
+      { path: 'practice/standards/w.md', content: 'first approval', rationale: 'r' },
+      'default',
+    );
+    const proposalId = (propose.output as { proposalId: string }).proposalId;
+
+    const first = await applyProposal(store, vault, 'default', threadId, proposalId, 'approve');
+    expect(first.status).toBe('approved');
+
+    // Someone edits the file again after the first approval.
+    await vault.write('default', 'practice/standards/w.md', 'edited after approval');
+
+    const second = await applyProposal(store, vault, 'default', threadId, proposalId, 'approve');
+    expect(second.status).toBe('approved');
+    expect((second as any).error).toMatch(/not pending/);
+    expect((second as any).version).toBeUndefined();
+
+    // The second call didn't touch the vault — the post-approval edit stands.
+    expect(await vault.read('default', 'practice/standards/w.md')).toBe('edited after approval');
+  });
+
   test('an unknown proposal id throws', async () => {
     await expect(applyProposal(store, vault, 'default', threadId, 'nonexistent', 'approve')).rejects.toThrow(/unknown proposal/);
   });

--- a/runtime/src/loop/proposals.ts
+++ b/runtime/src/loop/proposals.ts
@@ -1,0 +1,98 @@
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import type { Tenant, ToolDef, VaultStore, Version } from '../core/types';
+import { VaultConflictError } from '../core/types';
+import type { ThreadEvent, ThreadStore } from '../threads/store';
+
+export interface ProposeUpdateInput {
+  path: string;
+  content: string;
+  rationale: string;
+}
+
+/**
+ * `propose_update` — the only way a model writes a knowledge-system path
+ * (see `guardedVaultTools`). It never writes the vault itself: it appends a
+ * `proposal` event, carrying the path's version at proposal time, and hands
+ * the model back the proposal id to reference when telling the user what it
+ * proposed. `applyProposal` is what actually writes, on approval.
+ */
+export function proposeUpdateTool(
+  store: ThreadStore,
+  vault: VaultStore,
+  threadId: string,
+  tenant: Tenant,
+): ToolDef<ProposeUpdateInput, { proposalId: string }> {
+  return {
+    name: 'propose_update',
+    description:
+      'Propose a write to a knowledge-system path (practice/, memory/, law/, or the entities directory). '
+      + 'Does not write immediately — the user approves or rejects it. Matter paths use vault_write directly.',
+    inputSchema: z.object({
+      path: z.string().describe('Vault-relative path to write, e.g. practice/standards/indemnification.md.'),
+      content: z.string().describe('The full new content of the file.'),
+      rationale: z.string().describe('Why this update is proposed, for the user to review.'),
+    }),
+    execute: async ({ path, content, rationale }) => {
+      const proposalId = randomUUID();
+      const expectedVersion = await vault.version(tenant, path);
+      await store.append(tenant, threadId, {
+        t: 'proposal',
+        at: new Date().toISOString(),
+        id: proposalId,
+        path,
+        content,
+        rationale,
+        status: 'pending',
+        expectedVersion,
+      });
+      return { proposalId };
+    },
+  };
+}
+
+export type ApplyProposalResult =
+  | { status: 'approved'; version: Version }
+  | { status: 'rejected' }
+  | { status: 'conflict'; conflict: { expected: Version; actual: Version } };
+
+/**
+ * Applies a founder/user decision on a pending proposal. `reject` marks the
+ * event rejected and writes nothing. `approve` writes `proposal.content` to
+ * `proposal.path` with the proposal's recorded `expectedVersion` — if the
+ * path changed since the proposal was made, the write conflicts and the
+ * proposal is left `pending` so the model can re-propose against the current
+ * content instead of silently clobbering the intervening edit.
+ */
+export async function applyProposal(
+  store: ThreadStore,
+  vault: VaultStore,
+  tenant: Tenant,
+  threadId: string,
+  proposalId: string,
+  decision: 'approve' | 'reject',
+): Promise<ApplyProposalResult> {
+  const { events } = await store.get(tenant, threadId);
+  const proposal = events.find(
+    (ev): ev is Extract<ThreadEvent, { t: 'proposal' }> => 't' in ev && ev.t === 'proposal' && ev.id === proposalId,
+  );
+  if (!proposal) throw new Error(`unknown proposal: ${proposalId}`);
+
+  if (decision === 'reject') {
+    await store.updateProposal(tenant, threadId, proposalId, 'rejected');
+    return { status: 'rejected' };
+  }
+
+  try {
+    const version = await vault.write(tenant, proposal.path, proposal.content, {
+      expectedVersion: proposal.expectedVersion ?? undefined,
+    });
+    await store.updateProposal(tenant, threadId, proposalId, 'approved');
+    return { status: 'approved', version };
+  } catch (err) {
+    if (err instanceof VaultConflictError) {
+      return { status: 'conflict', conflict: { expected: err.expected, actual: err.actual } };
+    }
+    throw err;
+  }
+}

--- a/runtime/src/loop/proposals.ts
+++ b/runtime/src/loop/proposals.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type { Tenant, ToolDef, VaultStore, Version } from '../core/types';
 import { VaultConflictError } from '../core/types';
 import type { ThreadEvent, ThreadStore } from '../threads/store';
+import { normalizeVaultPath } from '../vault/knowledge-paths';
 
 export interface ProposeUpdateInput {
   path: string;
@@ -16,6 +17,15 @@ export interface ProposeUpdateInput {
  * `proposal` event, carrying the path's version at proposal time, and hands
  * the model back the proposal id to reference when telling the user what it
  * proposed. `applyProposal` is what actually writes, on approval.
+ *
+ * The path is normalized before it is recorded. `isKnowledgePath` already
+ * normalizes for its gate decision, so `matters/../practice/x.md` is
+ * correctly treated as a knowledge path — but the raw spelling is what used
+ * to land in the proposal event, and that is what a reviewer reads, what a
+ * UI groups by, and what `applyProposal` writes to. Two spellings of one
+ * file must not read as two different proposals. A path that normalizes out
+ * of the vault throws, which `runToolDef` turns into an error result the
+ * model can see, rather than recording an unapprovable proposal.
  */
 export function proposeUpdateTool(
   store: ThreadStore,
@@ -34,13 +44,14 @@ export function proposeUpdateTool(
       rationale: z.string().describe('Why this update is proposed, for the user to review.'),
     }),
     execute: async ({ path, content, rationale }) => {
+      const vaultPath = normalizeVaultPath(path);
       const proposalId = randomUUID();
-      const expectedVersion = await vault.version(tenant, path);
+      const expectedVersion = await vault.version(tenant, vaultPath);
       await store.append(tenant, threadId, {
         t: 'proposal',
         at: new Date().toISOString(),
         id: proposalId,
-        path,
+        path: vaultPath,
         content,
         rationale,
         status: 'pending',

--- a/runtime/src/loop/proposals.ts
+++ b/runtime/src/loop/proposals.ts
@@ -54,15 +54,24 @@ export function proposeUpdateTool(
 export type ApplyProposalResult =
   | { status: 'approved'; version: Version }
   | { status: 'rejected' }
-  | { status: 'conflict'; conflict: { expected: Version; actual: Version } };
+  | { status: 'conflict'; conflict: { expected: Version; actual: Version } }
+  // The proposal was already decided (by an earlier approve/reject) before
+  // this call — no write happens, and the earlier decision is not disturbed.
+  | { status: 'approved' | 'rejected'; error: string };
 
 /**
- * Applies a founder/user decision on a pending proposal. `reject` marks the
- * event rejected and writes nothing. `approve` writes `proposal.content` to
- * `proposal.path` with the proposal's recorded `expectedVersion` — if the
- * path changed since the proposal was made, the write conflicts and the
- * proposal is left `pending` so the model can re-propose against the current
- * content instead of silently clobbering the intervening edit.
+ * Applies a founder/user decision on a pending proposal. A proposal that is
+ * no longer `pending` (already approved or rejected) is a no-op: its past
+ * status is returned with an error, and nothing is written — `decision` is
+ * not consulted before that check, so `approve` can't re-run a write behind
+ * an already-rejected proposal's back. Otherwise `reject` marks the event
+ * rejected and writes nothing. `approve` writes `proposal.content` to
+ * `proposal.path` with the proposal's recorded `expectedVersion` (`null`
+ * when the path didn't exist at proposal time — that still conflicts if the
+ * path was created in the meantime, see `FsVaultStore.write`) — if the path
+ * changed since the proposal was made, the write conflicts and the proposal
+ * is left `pending` so the model can re-propose against the current content
+ * instead of silently clobbering the intervening edit.
  */
 export async function applyProposal(
   store: ThreadStore,
@@ -78,6 +87,10 @@ export async function applyProposal(
   );
   if (!proposal) throw new Error(`unknown proposal: ${proposalId}`);
 
+  if (proposal.status !== 'pending') {
+    return { status: proposal.status, error: 'proposal is not pending' };
+  }
+
   if (decision === 'reject') {
     await store.updateProposal(tenant, threadId, proposalId, 'rejected');
     return { status: 'rejected' };
@@ -85,7 +98,7 @@ export async function applyProposal(
 
   try {
     const version = await vault.write(tenant, proposal.path, proposal.content, {
-      expectedVersion: proposal.expectedVersion ?? undefined,
+      expectedVersion: proposal.expectedVersion,
     });
     await store.updateProposal(tenant, threadId, proposalId, 'approved');
     return { status: 'approved', version };

--- a/runtime/src/loop/run-log.ts
+++ b/runtime/src/loop/run-log.ts
@@ -18,9 +18,12 @@ const TENANT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
 
 export interface ToolCallLog {
   name: string;
-  /** Wall-clock ms between the `tool_call` and its matching `tool_result`. */
-  ms: number;
-  isError: boolean;
+  /** Wall-clock ms between the `tool_call` and its matching `tool_result`;
+   * `null` when the two never paired up, so an unknown duration is never
+   * reported as a real measurement of 0. */
+  ms: number | null;
+  /** `null` for a call that never produced a result — outcome unknown. */
+  isError: boolean | null;
 }
 
 export interface RunLogEntry {

--- a/runtime/src/loop/run-log.ts
+++ b/runtime/src/loop/run-log.ts
@@ -1,0 +1,53 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { Tenant } from '../core/types';
+
+/**
+ * Run logs live at `<vaultRoot>/.counsel/runs/<tenant>/<runId>.log.jsonl`
+ * (spec §4.3). Like `ThreadStore`, this writes `.counsel/` through `node:fs`
+ * rather than `VaultStore` — `FsVaultStore` deliberately refuses that prefix
+ * so no model-reachable tool can reach the runtime's own bookkeeping.
+ */
+const RUNS_DIR = join('.counsel', 'runs');
+
+// `tenant` and `runId` both land in a filesystem path. Same rule, and the
+// same regexes, as `ThreadStore`: a value like `../../etc` would otherwise
+// escape the runs directory.
+const RUN_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const TENANT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
+export interface ToolCallLog {
+  name: string;
+  /** Wall-clock ms between the `tool_call` and its matching `tool_result`. */
+  ms: number;
+  isError: boolean;
+}
+
+export interface RunLogEntry {
+  at: string;
+  provider: string;
+  task?: string;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd?: number;
+  durationMs: number;
+  toolCalls: ToolCallLog[];
+}
+
+export function runLogPath(vaultRoot: string, tenant: Tenant, runId: string): string {
+  if (!TENANT_RE.test(tenant)) throw new Error('invalid tenant');
+  if (!RUN_ID_RE.test(runId)) throw new Error('invalid run id');
+  return join(vaultRoot, RUNS_DIR, tenant, `${runId}.log.jsonl`);
+}
+
+/**
+ * Appends one JSON line per entry. Append rather than overwrite: a run id
+ * names a whole run, and a run that grows into several steps (the flow
+ * engine, later) must accumulate rather than lose everything but the last.
+ */
+export function writeRunLog(vaultRoot: string, tenant: Tenant, runId: string, entries: RunLogEntry[]): void {
+  if (entries.length === 0) return;
+  const path = runLogPath(vaultRoot, tenant, runId);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, entries.map(e => JSON.stringify(e) + '\n').join(''), { flag: 'a' });
+}

--- a/runtime/src/mcp/stdio.ts
+++ b/runtime/src/mcp/stdio.ts
@@ -1,6 +1,18 @@
 #!/usr/bin/env bun
 // Serves the runtime's tools over MCP stdio. Used by the Codex harness
-// (Codex cannot host an in-process MCP server). Env: COUNSEL_VAULT (required).
+// (Codex cannot host an in-process MCP server), which is why this is a
+// separate process and not a function call: everything it needs about the
+// caller's run arrives as environment variables.
+//
+// Env:
+//   COUNSEL_VAULT       (required) the vault root.
+//   COUNSEL_TENANT      the tenant; defaults to `default`.
+//   COUNSEL_PLUGIN_ROOT where `primitives/` and `scripts/` live; defaults to
+//                       this file's own repo root, correct in a normal install.
+//   COUNSEL_THREAD_ID   the thread a proposal belongs to. Without it there is
+//                       nowhere to record one, so `propose_update` is not
+//                       offered and the knowledge-system paths stay read-only
+//                       for this run.
 import { resolve } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
@@ -10,7 +22,10 @@ import { readVaultConfig } from '../vault/resolve-root';
 import { registerOnServer, toMcpTools } from './bridge';
 import { ToolRegistry } from '../tools/registry';
 import { builtinTools } from '../tools/builtin';
-import { DEFAULT_TENANT } from '../core/types';
+import { ThreadStore } from '../threads/store';
+import { readPrimitiveTool } from '../loop/primitives';
+import { proposeUpdateTool } from '../loop/proposals';
+import { DEFAULT_TENANT, type ToolDef } from '../core/types';
 
 const vault = process.env.COUNSEL_VAULT;
 if (!vault) {
@@ -18,13 +33,27 @@ if (!vault) {
   process.exit(2);
 }
 
+const tenant = process.env.COUNSEL_TENANT ?? DEFAULT_TENANT;
+const pluginRoot = process.env.COUNSEL_PLUGIN_ROOT ?? resolve(import.meta.dir, '../../..');
+const threadId = process.env.COUNSEL_THREAD_ID;
+
 const store = new FsVaultStore(vault);
-const repoRoot = resolve(import.meta.dir, '../../..');
 
 const registry = new ToolRegistry();
-for (const t of builtinTools({ vaultRoot: vault, repoRoot })) registry.register(t);
+for (const t of builtinTools({ vaultRoot: vault, repoRoot: pluginRoot })) registry.register(t);
 
-const specs = toMcpTools([...guardedVaultTools(store, readVaultConfig(vault)), ...registry.available()], process.env.COUNSEL_TENANT ?? DEFAULT_TENANT);
+// The same tool set the in-process loop assembles (`counsel-loop.ts`'s
+// `stepTools`), so the Codex tier is not a second-class citizen: the guarded
+// vault tools, `read_primitive`, and — when a thread is in play —
+// `propose_update`, which is the only way through the `remember` gate.
+const tools: ToolDef[] = [
+  ...guardedVaultTools(store, readVaultConfig(vault)),
+  readPrimitiveTool(pluginRoot) as ToolDef,
+  ...(threadId ? [proposeUpdateTool(new ThreadStore(vault), store, threadId, tenant) as ToolDef] : []),
+  ...registry.available(),
+];
+
+const specs = toMcpTools(tools, tenant);
 const server = new McpServer({ name: 'counsel', version: '0.1.0' });
 registerOnServer(server, specs);
 await server.connect(new StdioServerTransport());

--- a/runtime/src/mcp/stdio.ts
+++ b/runtime/src/mcp/stdio.ts
@@ -5,7 +5,8 @@ import { resolve } from 'node:path';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { FsVaultStore } from '../vault/fs-store';
-import { vaultTools } from '../vault/vault-tools';
+import { guardedVaultTools } from '../vault/vault-tools';
+import { readVaultConfig } from '../vault/resolve-root';
 import { registerOnServer, toMcpTools } from './bridge';
 import { ToolRegistry } from '../tools/registry';
 import { builtinTools } from '../tools/builtin';
@@ -23,7 +24,7 @@ const repoRoot = resolve(import.meta.dir, '../../..');
 const registry = new ToolRegistry();
 for (const t of builtinTools({ vaultRoot: vault, repoRoot })) registry.register(t);
 
-const specs = toMcpTools([...vaultTools(store), ...registry.available()], process.env.COUNSEL_TENANT ?? DEFAULT_TENANT);
+const specs = toMcpTools([...guardedVaultTools(store, readVaultConfig(vault)), ...registry.available()], process.env.COUNSEL_TENANT ?? DEFAULT_TENANT);
 const server = new McpServer({ name: 'counsel', version: '0.1.0' });
 registerOnServer(server, specs);
 await server.connect(new StdioServerTransport());

--- a/runtime/src/providers/claude-harness.test.ts
+++ b/runtime/src/providers/claude-harness.test.ts
@@ -128,3 +128,14 @@ describe('buildQueryOptions', () => {
     expect(proxied.env?.ANTHROPIC_API_KEY).toBeUndefined();
   });
 });
+
+describe('sessions', () => {
+  test('system/init → session event with the session id', () => {
+    expect(mapClaudeMessage({ type: 'system', subtype: 'init', session_id: 'sess-1', cwd: '/x' })).toEqual([{ type: 'session', id: 'sess-1' }]);
+  });
+  test('buildQueryOptions passes resume when a session id is given, omits it otherwise', () => {
+    const base = { tenant: 'default', system: 's', messages: [], tools: [] };
+    expect(buildQueryOptions({ ...base, session: { id: 'sess-1' } }, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBe('sess-1');
+    expect(buildQueryOptions(base, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBeUndefined();
+  });
+});

--- a/runtime/src/providers/claude-harness.test.ts
+++ b/runtime/src/providers/claude-harness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
-import { buildQueryOptions, mapClaudeMessage } from './claude-harness';
+import { buildQueryOptions, mapClaudeMessage, shouldCleanupCwd } from './claude-harness';
 import { toHarnessJsonSchema } from './schema';
 import type { StepRequest } from '../core/types';
 
@@ -137,5 +137,14 @@ describe('sessions', () => {
     const base = { tenant: 'default', system: 's', messages: [], tools: [] };
     expect(buildQueryOptions({ ...base, session: { id: 'sess-1' } }, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBe('sess-1');
     expect(buildQueryOptions(base, 'm', {}, '/tmp/x', { PATH: '/p', HOME: '/h', USER: 'u' }).resume).toBeUndefined();
+  });
+});
+
+describe('shouldCleanupCwd', () => {
+  test('true when no cwd was supplied — run() created its own temp cwd and must remove it', () => {
+    expect(shouldCleanupCwd(undefined)).toBe(true);
+  });
+  test('false when a cwd was supplied by the caller — run() must not remove it', () => {
+    expect(shouldCleanupCwd('/some/persistent/cwd')).toBe(false);
   });
 });

--- a/runtime/src/providers/claude-harness.ts
+++ b/runtime/src/providers/claude-harness.ts
@@ -16,6 +16,9 @@ type AnyMsg = { type: string; [k: string]: unknown };
 export function mapClaudeMessage(raw: unknown, outputSchema?: ZodType<unknown>): StepEvent[] {
   const msg = raw as AnyMsg;
   const out: StepEvent[] = [];
+  if (msg.type === 'system' && msg.subtype === 'init' && typeof msg.session_id === 'string') {
+    return [{ type: 'session', id: msg.session_id }];
+  }
   if (msg.type === 'assistant' || msg.type === 'user') {
     const content = ((msg.message as { content?: unknown[] })?.content ?? []) as Array<Record<string, unknown>>;
     for (const block of content) {
@@ -99,6 +102,7 @@ export function buildQueryOptions(req: StepRequest, model: string, server: unkno
     allowDangerouslySkipPermissions: true,
     maxTurns: req.maxToolCalls ?? 20,
     cwd,
+    ...(req.session?.id ? { resume: req.session.id } : {}),
     // `env` REPLACES the child CLI process's environment. Pinned to the three
     // variables the CLI needs to run at all: `PATH` (so `bun` and the CLI's
     // own subprocesses resolve), `HOME`, and `USER`. Everything else in
@@ -128,7 +132,7 @@ export class ClaudeHarnessProvider implements ModelProvider {
   readonly kind = 'harness' as const;
   readonly capabilities: Capabilities = { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' };
 
-  constructor(private readonly opts: { model: string; id?: string }) {
+  constructor(private readonly opts: { model: string; id?: string; cwd?: string }) {
     this.id = opts.id ?? `claude-sub/${opts.model}`;
   }
 
@@ -142,8 +146,12 @@ export class ClaudeHarnessProvider implements ModelProvider {
     const prompt = req.messages.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`).join('\n\n');
     // Acquired inside the try so a failure here (e.g. tmpdir unwritable)
     // reaches the caller as an `error` event and the finally can clean up
-    // whatever was created.
+    // whatever was created. A caller-supplied `opts.cwd` (debug-only, used by
+    // the CLI's `--cwd` option to pin the resume spike to a stable directory)
+    // is reused as-is and never removed here — the cleanup below only ever
+    // touches a directory this run created itself.
     let cwd: string | undefined;
+    let ownsCwd = false;
 
     // `query()` throws on a non-zero CLI exit — e.g. the CLI rejecting the
     // output schema before the turn starts (spike 9.3-B), or not being logged
@@ -153,18 +161,29 @@ export class ClaudeHarnessProvider implements ModelProvider {
     // contract every consumer is written against. `CodexHarnessProvider.run`
     // does the same.
     try {
-      cwd = mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
+      if (this.opts.cwd) {
+        cwd = this.opts.cwd;
+      } else {
+        cwd = mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
+        ownsCwd = true;
+      }
       const stream = query({ prompt, options: buildQueryOptions(req, this.opts.model, server, cwd) });
 
+      let sessionId: string | undefined;
       for await (const msg of stream) {
-        for (const ev of mapClaudeMessage(msg, req.outputSchema)) yield ev;
+        for (const ev of mapClaudeMessage(msg, req.outputSchema)) {
+          if (ev.type === 'session') { sessionId = ev.id; yield ev; continue; }
+          yield ev.type === 'done' && sessionId ? { ...ev, sessionId } : ev;
+        }
       }
     } catch (err) {
       yield { type: 'error', message: `claude harness: ${err instanceof Error ? err.message : String(err)}` };
     } finally {
       // One temp cwd per step; without this they accumulate for the life of
-      // the process. Also runs when the consumer abandons the generator early.
-      if (cwd) rmSync(cwd, { recursive: true, force: true });
+      // the process. Also runs when the consumer abandons the generator
+      // early. Never removes a caller-supplied `opts.cwd` — this run didn't
+      // create it.
+      if (cwd && ownsCwd) rmSync(cwd, { recursive: true, force: true });
     }
   }
 }

--- a/runtime/src/providers/claude-harness.ts
+++ b/runtime/src/providers/claude-harness.ts
@@ -127,13 +127,25 @@ export function buildQueryOptions(req: StepRequest, model: string, server: unkno
   };
 }
 
+/**
+ * Pure decision for `run()`'s `finally`: a caller-supplied `cwd` (the CLI's
+ * debug-only `--cwd`) is reused as-is and must survive the run, so cleanup
+ * only ever removes a directory `run()` created itself (`mkdtempSync`, when
+ * no `cwd` was supplied).
+ */
+export function shouldCleanupCwd(suppliedCwd?: string): boolean {
+  return !suppliedCwd;
+}
+
 export class ClaudeHarnessProvider implements ModelProvider {
   readonly id: string;
   readonly kind = 'harness' as const;
   readonly capabilities: Capabilities = { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' };
+  readonly cwd: string | undefined;
 
   constructor(private readonly opts: { model: string; id?: string; cwd?: string }) {
     this.id = opts.id ?? `claude-sub/${opts.model}`;
+    this.cwd = opts.cwd;
   }
 
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
@@ -151,7 +163,6 @@ export class ClaudeHarnessProvider implements ModelProvider {
     // is reused as-is and never removed here — the cleanup below only ever
     // touches a directory this run created itself.
     let cwd: string | undefined;
-    let ownsCwd = false;
 
     // `query()` throws on a non-zero CLI exit — e.g. the CLI rejecting the
     // output schema before the turn starts (spike 9.3-B), or not being logged
@@ -161,12 +172,7 @@ export class ClaudeHarnessProvider implements ModelProvider {
     // contract every consumer is written against. `CodexHarnessProvider.run`
     // does the same.
     try {
-      if (this.opts.cwd) {
-        cwd = this.opts.cwd;
-      } else {
-        cwd = mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
-        ownsCwd = true;
-      }
+      cwd = this.opts.cwd ?? mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
       const stream = query({ prompt, options: buildQueryOptions(req, this.opts.model, server, cwd) });
 
       let sessionId: string | undefined;
@@ -182,8 +188,8 @@ export class ClaudeHarnessProvider implements ModelProvider {
       // One temp cwd per step; without this they accumulate for the life of
       // the process. Also runs when the consumer abandons the generator
       // early. Never removes a caller-supplied `opts.cwd` — this run didn't
-      // create it.
-      if (cwd && ownsCwd) rmSync(cwd, { recursive: true, force: true });
+      // create it (see `shouldCleanupCwd`).
+      if (cwd && shouldCleanupCwd(this.opts.cwd)) rmSync(cwd, { recursive: true, force: true });
     }
   }
 }

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
 import { z } from 'zod';
-import { buildCodexConfig, buildCodexEnv, buildThreadOptions, cleanupIsolatedHome, mapCodexEvent, prepareIsolatedHome } from './codex-harness';
+import { buildCodexConfig, buildCodexEnv, buildThreadOptions, CodexHarnessProvider, cleanupIsolatedHome, mapCodexEvent, prepareIsolatedHome, resolveCodexHome } from './codex-harness';
 
 describe('mapCodexEvent', () => {
   test('agent_message → text', () => {
@@ -63,7 +63,6 @@ describe('mapCodexEvent', () => {
 
   test('unhandled item types (reasoning, command_execution, file_change, ...) are ignored, not thrown', () => {
     expect(mapCodexEvent({ type: 'item.completed', item: { type: 'reasoning', text: 'thinking...' } })).toEqual([]);
-    expect(mapCodexEvent({ type: 'thread.started', thread_id: 't1' })).toEqual([]);
     expect(mapCodexEvent({ type: 'turn.started' })).toEqual([]);
   });
 });
@@ -194,5 +193,19 @@ describe('cleanupIsolatedHome', () => {
     const proxied = buildCodexEnv('/iso', '/real', { PATH: '/p', HOME: '/h', HTTP_PROXY: 'http://px', OPENAI_API_KEY: 'sk' });
     expect(proxied.HTTP_PROXY).toBe('http://px');
     expect(proxied.OPENAI_API_KEY).toBeUndefined();
+  });
+});
+
+describe('sessions', () => {
+  test('thread.started → session event with the thread id', () => {
+    expect(mapCodexEvent({ type: 'thread.started', thread_id: 'th-1' })).toEqual([{ type: 'session', id: 'th-1' }]);
+  });
+  test('a persistent homeDir is used as CODEX_HOME and is not removed by run()', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    const p = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v', homeDir: home });
+    expect(p.homeDir).toBe(home);
+    // run() is not executed here (live); the contract is asserted via the exported helper:
+    expect(resolveCodexHome({ homeDir: home, realHome: '/real' })).toEqual({ isolatedHome: home, ephemeral: false });
+    expect(resolveCodexHome({ realHome: '/real' }).ephemeral).toBe(true);
   });
 });

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
@@ -259,6 +259,45 @@ describe('resolveCodexHome — credential re-seed', () => {
 
     resolveCodexHome({ homeDir, realHome });
     expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"first"}');
+  });
+
+  test('the copy is 0600 however permissive the real auth.json is', () => {
+    const realHome = mkdtempSync(join(tmpdir(), 'real-home-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"first"}');
+    chmodSync(join(realHome, 'auth.json'), 0o644);
+
+    // Initial copy: copyFileSync would otherwise give it the source's mode.
+    resolveCodexHome({ homeDir, realHome });
+    expect(statSync(join(homeDir, 'auth.json')).mode & 0o777).toBe(0o600);
+
+    // Re-seed: an overwrite keeps the DESTINATION's mode, so a copy loosened
+    // in between has to be tightened again too.
+    chmodSync(join(homeDir, 'auth.json'), 0o644);
+    const future = new Date(Date.now() + 60_000);
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"second"}');
+    utimesSync(join(realHome, 'auth.json'), future, future);
+
+    resolveCodexHome({ homeDir, realHome });
+    expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"second"}');
+    expect(statSync(join(homeDir, 'auth.json')).mode & 0o777).toBe(0o600);
+  });
+
+  test('a logout removes the copy rather than leaving a revoked credential behind', () => {
+    const realHome = mkdtempSync(join(tmpdir(), 'real-home-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"first"}');
+
+    resolveCodexHome({ homeDir, realHome });
+    expect(existsSync(join(homeDir, 'auth.json'))).toBe(true);
+
+    // The operator logs out: the real auth.json is gone. A persistent home
+    // outlives it, so the copy must not survive the credential.
+    rmSync(join(realHome, 'auth.json'));
+    resolveCodexHome({ homeDir, realHome });
+    expect(existsSync(join(homeDir, 'auth.json'))).toBe(false);
+    // Still a usable home, just an unauthenticated one.
+    expect(existsSync(homeDir)).toBe(true);
   });
 });
 

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, lstatSync, mkdtempSync, readFileSync, rmSync, statSync, symlinkSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
@@ -281,6 +281,27 @@ describe('resolveCodexHome — credential re-seed', () => {
     resolveCodexHome({ homeDir, realHome });
     expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"second"}');
     expect(statSync(join(homeDir, 'auth.json')).mode & 0o777).toBe(0o600);
+  });
+
+  test('a symlink planted at the destination is replaced by a real 0600 copy', () => {
+    const realHome = mkdtempSync(join(tmpdir(), 'real-home-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    const elsewhere = mkdtempSync(join(tmpdir(), 'elsewhere-'));
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"real"}');
+    // Someone else's file, aimed at by a link where our copy belongs.
+    const target = join(elsewhere, 'target.json');
+    writeFileSync(target, 'NOT OURS');
+    symlinkSync(target, join(homeDir, 'auth.json'));
+
+    resolveCodexHome({ homeDir, realHome });
+
+    // A real file, not a link: copyFileSync and chmodSync both FOLLOW links,
+    // so writing through it would have leaked the credential to `target`.
+    expect(lstatSync(join(homeDir, 'auth.json')).isSymbolicLink()).toBe(false);
+    expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"real"}');
+    expect(statSync(join(homeDir, 'auth.json')).mode & 0o777).toBe(0o600);
+    // The link's target was never touched.
+    expect(readFileSync(target, 'utf8')).toBe('NOT OURS');
   });
 
   test('a logout removes the copy rather than leaving a revoked credential behind', () => {

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -262,6 +262,25 @@ describe('resolveCodexHome — credential re-seed', () => {
   });
 });
 
+describe('CodexHarnessProvider.withHome', () => {
+  test('returns a new instance with the same id, pinned to the given home', () => {
+    const provider = new CodexHarnessProvider({ model: 'gpt-5.6-terra', vaultRoot: '/v', id: 'codex-sub/gpt-5.6-terra' });
+    const bound = provider.withHome('/homes/thread-1');
+
+    expect(bound).not.toBe(provider);
+    expect(bound.id).toBe('codex-sub/gpt-5.6-terra');
+    expect(bound.homeDir).toBe('/homes/thread-1');
+    // The original is untouched, so one registry entry can serve many threads.
+    expect(provider.homeDir).toBeUndefined();
+  });
+
+  test('two threads get independent homes off one provider', () => {
+    const provider = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v' });
+    expect(provider.withHome('/a').homeDir).toBe('/a');
+    expect(provider.withHome('/b').homeDir).toBe('/b');
+  });
+});
+
 describe('CodexHarnessProvider.run — resume precondition', () => {
   test('resuming without a persistent homeDir yields a single error event, before any SDK call', async () => {
     const provider = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v' });

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -262,7 +262,7 @@ describe('resolveCodexHome — credential re-seed', () => {
   });
 });
 
-describe('CodexHarnessProvider.withHome', () => {
+describe('CodexHarnessProvider.withThread / withHome', () => {
   test('returns a new instance with the same id, pinned to the given home', () => {
     const provider = new CodexHarnessProvider({ model: 'gpt-5.6-terra', vaultRoot: '/v', id: 'codex-sub/gpt-5.6-terra' });
     const bound = provider.withHome('/homes/thread-1');
@@ -278,6 +278,49 @@ describe('CodexHarnessProvider.withHome', () => {
     const provider = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v' });
     expect(provider.withHome('/a').homeDir).toBe('/a');
     expect(provider.withHome('/b').homeDir).toBe('/b');
+  });
+
+  test('withThread carries the thread id and plugin root into the stdio server env', () => {
+    const provider = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v' });
+    const bound = provider.withThread({ homeDir: '/homes/t1', threadId: 'thread-1', pluginRoot: '/plugin' });
+
+    expect(bound.homeDir).toBe('/homes/t1');
+    // The binding is what reaches the out-of-process MCP server.
+    const env = mcpEnv(buildCodexConfig({ vaultRoot: '/v', tenant: 'default', threadId: 'thread-1', pluginRoot: '/plugin' }));
+    expect(env.COUNSEL_THREAD_ID).toBe('thread-1');
+    expect(env.COUNSEL_PLUGIN_ROOT).toBe('/plugin');
+  });
+});
+
+/** The `mcp_servers.counsel.env` block `buildCodexConfig` flattens into
+ * `--config` overrides for the child CLI. */
+function mcpEnv(cfg: ReturnType<typeof buildCodexConfig>): Record<string, string> {
+  const servers = (cfg.config as { mcp_servers: { counsel: { env: Record<string, string> } } }).mcp_servers;
+  return servers.counsel.env;
+}
+
+describe('buildCodexConfig — stdio server environment', () => {
+  test('always passes the vault and tenant', () => {
+    const env = mcpEnv(buildCodexConfig({ vaultRoot: '/vault', tenant: 'acme' }));
+    expect(env.COUNSEL_VAULT).toBe('/vault');
+    expect(env.COUNSEL_TENANT).toBe('acme');
+  });
+
+  test('omits COUNSEL_THREAD_ID and COUNSEL_PLUGIN_ROOT when not given', () => {
+    const env = mcpEnv(buildCodexConfig({ vaultRoot: '/vault', tenant: 'default' }));
+    expect('COUNSEL_THREAD_ID' in env).toBe(false);
+    expect('COUNSEL_PLUGIN_ROOT' in env).toBe(false);
+  });
+
+  test('includes both when given — this is what unlocks propose_update and read_primitive', () => {
+    const env = mcpEnv(buildCodexConfig({
+      vaultRoot: '/vault',
+      tenant: 'default',
+      threadId: 'e4d0d0b2-0000-4000-8000-000000000000',
+      pluginRoot: '/repo',
+    }));
+    expect(env.COUNSEL_THREAD_ID).toBe('e4d0d0b2-0000-4000-8000-000000000000');
+    expect(env.COUNSEL_PLUGIN_ROOT).toBe('/repo');
   });
 });
 

--- a/runtime/src/providers/codex-harness.test.ts
+++ b/runtime/src/providers/codex-harness.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, test } from 'bun:test';
@@ -200,12 +200,75 @@ describe('sessions', () => {
   test('thread.started → session event with the thread id', () => {
     expect(mapCodexEvent({ type: 'thread.started', thread_id: 'th-1' })).toEqual([{ type: 'session', id: 'th-1' }]);
   });
-  test('a persistent homeDir is used as CODEX_HOME and is not removed by run()', async () => {
+  test('resolveCodexHome reports ephemeral:false for a persistent homeDir', () => {
     const home = mkdtempSync(join(tmpdir(), 'persist-home-'));
     const p = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v', homeDir: home });
     expect(p.homeDir).toBe(home);
     // run() is not executed here (live); the contract is asserted via the exported helper:
     expect(resolveCodexHome({ homeDir: home, realHome: '/real' })).toEqual({ isolatedHome: home, ephemeral: false });
     expect(resolveCodexHome({ realHome: '/real' }).ephemeral).toBe(true);
+  });
+});
+
+describe('resolveCodexHome — real-home guard (normalized)', () => {
+  test('throws when homeDir equals the real CODEX_HOME', () => {
+    expect(() => resolveCodexHome({ homeDir: '/real/home', realHome: '/real/home' })).toThrow();
+  });
+
+  test('throws on a trailing-slash variant of the real CODEX_HOME', () => {
+    expect(() => resolveCodexHome({ homeDir: '/real/home/', realHome: '/real/home' })).toThrow();
+  });
+
+  test('throws when homeDir is nested inside the real CODEX_HOME', () => {
+    expect(() => resolveCodexHome({ homeDir: '/real/home/nested', realHome: '/real/home' })).toThrow();
+  });
+
+  test('passes for an unrelated homeDir', () => {
+    const home = mkdtempSync(join(tmpdir(), 'unrelated-home-'));
+    expect(resolveCodexHome({ homeDir: home, realHome: '/real/home' })).toEqual({ isolatedHome: home, ephemeral: false });
+  });
+});
+
+describe('resolveCodexHome — credential re-seed', () => {
+  test('re-copies auth.json when the real file is newer than the existing copy', () => {
+    const realHome = mkdtempSync(join(tmpdir(), 'real-home-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"first"}');
+
+    resolveCodexHome({ homeDir, realHome }); // initial copy
+    expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"first"}');
+
+    const future = new Date(Date.now() + 60_000);
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"second"}');
+    utimesSync(join(realHome, 'auth.json'), future, future);
+
+    resolveCodexHome({ homeDir, realHome });
+    expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"second"}');
+  });
+
+  test('leaves the copy untouched when the real file is not newer', () => {
+    const realHome = mkdtempSync(join(tmpdir(), 'real-home-'));
+    const homeDir = mkdtempSync(join(tmpdir(), 'persist-home-'));
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"first"}');
+
+    resolveCodexHome({ homeDir, realHome }); // initial copy
+
+    const past = new Date(Date.now() - 60_000);
+    writeFileSync(join(realHome, 'auth.json'), '{"token":"stale-but-untouched"}');
+    utimesSync(join(realHome, 'auth.json'), past, past);
+
+    resolveCodexHome({ homeDir, realHome });
+    expect(readFileSync(join(homeDir, 'auth.json'), 'utf8')).toBe('{"token":"first"}');
+  });
+});
+
+describe('CodexHarnessProvider.run — resume precondition', () => {
+  test('resuming without a persistent homeDir yields a single error event, before any SDK call', async () => {
+    const provider = new CodexHarnessProvider({ model: 'm', vaultRoot: '/v' });
+    const events: unknown[] = [];
+    for await (const ev of provider.run({ tenant: 'default', system: 's', messages: [], tools: [], session: { id: 'x' } })) {
+      events.push(ev);
+    }
+    expect(events).toEqual([{ type: 'error', message: 'codex harness: resuming a thread requires a persistent homeDir' }]);
   });
 });

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -286,8 +286,19 @@ function normalizePath(p: string): string {
 /**
  * Seeds or refreshes `<homeDir>/auth.json` from the real `CODEX_HOME`'s
  * `auth.json`, per the "keeps a credential copy for the life of the thread"
- * policy in `resolveCodexHome`'s doc comment. No-op when the real home has
- * no `auth.json` (not logged in) — same rationale as `prepareIsolatedHome`.
+ * policy in `resolveCodexHome`'s doc comment.
+ *
+ * When the real home has NO `auth.json` — the operator logged out, or the
+ * file was revoked — an existing copy is removed rather than left behind. A
+ * persistent home outlives the credential it was seeded from, so leaving the
+ * copy would keep a revoked token usable from this thread and would keep it
+ * on disk indefinitely after the operator believed they had logged out.
+ *
+ * Every copy is chmod'ed 0600 afterwards. `copyFileSync` gives the
+ * destination the SOURCE's mode on create and leaves the existing mode alone
+ * on overwrite, so a permissive `~/.codex/auth.json` — or a copy created
+ * before the enclosing directory's 0700 was tightened — would otherwise
+ * publish the operator's credentials to every local account.
  *
  * Initial copy (destination doesn't exist yet) uses
  * `constants.COPYFILE_EXCL`, which makes `copyFileSync` fail rather than
@@ -304,11 +315,20 @@ function normalizePath(p: string): string {
  */
 function seedCodexAuth(homeDir: string, realHome: string): void {
   const authSrc = join(realHome, 'auth.json');
-  if (!existsSync(authSrc)) return;
   const authDest = join(homeDir, 'auth.json');
+  if (!existsSync(authSrc)) {
+    // Logged out: the copy must not outlive the credential it copied.
+    try {
+      rmSync(authDest, { force: true });
+    } catch {
+      /* best effort — nothing here can make a missing credential worse */
+    }
+    return;
+  }
   if (!existsSync(authDest)) {
     try {
       copyFileSync(authSrc, authDest, constants.COPYFILE_EXCL);
+      chmodSync(authDest, 0o600);
     } catch {
       // Refused (already exists / symlink) — leave the destination alone.
     }
@@ -317,6 +337,10 @@ function seedCodexAuth(homeDir: string, realHome: string): void {
   if (statSync(authSrc).mtimeMs > statSync(authDest).mtimeMs) {
     copyFileSync(authSrc, authDest);
   }
+  // Unconditional, not just after a re-copy: an overwrite keeps the
+  // destination's existing mode, and a copy made before this rule existed
+  // still has whatever mode the source had.
+  chmodSync(authDest, 0o600);
 }
 
 /**

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -379,6 +379,19 @@ export class CodexHarnessProvider implements ModelProvider {
     this.homeDir = opts.homeDir;
   }
 
+  /**
+   * A copy of this provider — same model, id, and vault — pinned to a
+   * persistent `CODEX_HOME`. The counsel loop calls this with the thread's
+   * own home (`ThreadStore.codexHomeFor`) so `resumeThread` can find the
+   * session state a previous step left behind: a registry-built provider is
+   * shared across threads, so the home has to be bound per thread, not per
+   * provider. Returns a new instance rather than mutating, so two threads
+   * can use the same registry entry concurrently.
+   */
+  withHome(dir: string): CodexHarnessProvider {
+    return new CodexHarnessProvider({ ...this.opts, homeDir: dir });
+  }
+
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
     // Checked first, before anything is created: `resumeThread` needs the
     // same `CODEX_HOME` the original thread ran under (session/thread state

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -1,6 +1,6 @@
-import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { chmodSync, constants, copyFileSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
+import { join, resolve, sep } from 'node:path';
 import type { ZodType } from 'zod';
 import { Codex, type CodexOptions, type ThreadOptions } from '@openai/codex-sdk';
 import type { Capabilities, ModelProvider, StepEvent, StepRequest, Tenant } from '../core/types';
@@ -250,21 +250,90 @@ export function cleanupIsolatedHome(isolatedHome: string): void {
 }
 
 /**
+ * Resolves a filesystem path to a canonical form for comparison: absolute
+ * (`resolve`) and, when the path actually exists, symlink-resolved
+ * (`realpathSync`) so a symlinked alias of the real `CODEX_HOME` can't slip
+ * past the guard below. A nonexistent path (the common case for `homeDir`,
+ * which this function may be about to create) falls back to the resolved
+ * form — `resolve()` alone already normalizes away trailing slashes and
+ * `.`/`..` segments, which is what catches the trailing-slash-variant case.
+ */
+function normalizePath(p: string): string {
+  const abs = resolve(p);
+  try {
+    return realpathSync(abs);
+  } catch {
+    return abs;
+  }
+}
+
+/**
+ * Seeds or refreshes `<homeDir>/auth.json` from the real `CODEX_HOME`'s
+ * `auth.json`, per the "keeps a credential copy for the life of the thread"
+ * policy in `resolveCodexHome`'s doc comment. No-op when the real home has
+ * no `auth.json` (not logged in) — same rationale as `prepareIsolatedHome`.
+ *
+ * Initial copy (destination doesn't exist yet) uses
+ * `constants.COPYFILE_EXCL`, which makes `copyFileSync` fail rather than
+ * write through the destination path if something already occupies it
+ * (e.g. a symlink planted between the `existsSync` check and this call, or
+ * one restored from a stale persistent home) — the failure is swallowed
+ * because the safe response to "something unexpected is already there" is
+ * to leave it alone, not to overwrite it.
+ *
+ * Re-seed (destination already exists as a plain file): only overwrites
+ * when the real file's `mtimeMs` is strictly newer than the copy's, so an
+ * operator re-login (new `auth.json`) propagates into a long-lived
+ * persistent home without re-copying on every single call.
+ */
+function seedCodexAuth(homeDir: string, realHome: string): void {
+  const authSrc = join(realHome, 'auth.json');
+  if (!existsSync(authSrc)) return;
+  const authDest = join(homeDir, 'auth.json');
+  if (!existsSync(authDest)) {
+    try {
+      copyFileSync(authSrc, authDest, constants.COPYFILE_EXCL);
+    } catch {
+      // Refused (already exists / symlink) — leave the destination alone.
+    }
+    return;
+  }
+  if (statSync(authSrc).mtimeMs > statSync(authDest).mtimeMs) {
+    copyFileSync(authSrc, authDest);
+  }
+}
+
+/**
  * Resolves which `CODEX_HOME` a run should use. When the caller supplies a
  * persistent `homeDir` (e.g. so a session can be resumed across steps via
  * `resumeThread`), that directory is reused as-is and seeded with the
- * operator's `auth.json` the same way `prepareIsolatedHome` does, but it is
- * never removed by the caller (`ephemeral: false`) — the same directory has
- * to still be there on the next step. Without a `homeDir`, behavior is
- * unchanged from before: a fresh isolated home is created per run and must
- * be torn down after (`ephemeral: true`).
+ * operator's `auth.json` via `seedCodexAuth`, but it is never removed by the
+ * caller (`ephemeral: false`) — the same directory has to still be there on
+ * the next step. This deliberately **reverses** `prepareIsolatedHome`'s
+ * per-run rule ("must not outlive the run that needed it"): a persistent
+ * home keeps its plaintext credential copy for the life of the *thread*
+ * (spec §2), not just one step. `ThreadStore.remove()` (a later task) is
+ * what deletes it once the thread itself is gone.
+ *
+ * Without a `homeDir`, behavior is unchanged from before: a fresh isolated
+ * home is created per run and must be torn down after (`ephemeral: true`).
+ *
+ * The real-home guard compares *normalized* paths (`normalizePath`), so it
+ * also rejects a `homeDir` that only differs from `realHome` by a trailing
+ * slash, a symlink alias, or by being nested inside it — any of those would
+ * still hand the operator's live credentials directory to what's supposed
+ * to be an isolated slot.
  */
 export function resolveCodexHome(opts: { homeDir?: string; realHome: string }): { isolatedHome: string; ephemeral: boolean } {
   if (opts.homeDir) {
-    if (opts.homeDir === opts.realHome) throw new Error('homeDir must not be the real CODEX_HOME');
+    const normHome = normalizePath(opts.homeDir);
+    const normReal = normalizePath(opts.realHome);
+    if (normHome === normReal || normHome.startsWith(normReal + sep)) {
+      throw new Error('homeDir must not be the real CODEX_HOME, or nested inside it');
+    }
     mkdirSync(opts.homeDir, { recursive: true, mode: 0o700 });
-    const authSrc = join(opts.realHome, 'auth.json');
-    if (existsSync(authSrc) && !existsSync(join(opts.homeDir, 'auth.json'))) copyFileSync(authSrc, join(opts.homeDir, 'auth.json'));
+    chmodSync(opts.homeDir, 0o700);
+    seedCodexAuth(opts.homeDir, opts.realHome);
     return { isolatedHome: opts.homeDir, ephemeral: false };
   }
   return { isolatedHome: prepareIsolatedHome(opts.realHome), ephemeral: true };
@@ -311,6 +380,17 @@ export class CodexHarnessProvider implements ModelProvider {
   }
 
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
+    // Checked first, before anything is created: `resumeThread` needs the
+    // same `CODEX_HOME` the original thread ran under (session/thread state
+    // lives under it), so resuming into a fresh ephemeral home — which
+    // `prepareIsolatedHome` would otherwise silently hand this run — can
+    // never find that state. A caller-supplied `homeDir` is the only way
+    // that continuity is guaranteed across two separate `run()` calls.
+    if (req.session?.id && !this.opts.homeDir) {
+      yield { type: 'error', message: 'codex harness: resuming a thread requires a persistent homeDir' };
+      return;
+    }
+
     const realHome = process.env.CODEX_HOME ?? join(homedir(), '.codex');
     // Acquired inside the try: if either temp dir cannot be created the
     // failure becomes an `error` event, and the finally removes whatever

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -180,14 +180,30 @@ export function buildThreadOptions(model: string, cwd: string): ThreadOptions {
  * persisted under `~/.codex/sessions`) land in the isolated temp home
  * instead of the operator's real one (round-1 review, "Important 4").
  */
-export function buildCodexConfig(opts: { vaultRoot: string; tenant: Tenant }): CodexOptions {
+export function buildCodexConfig(opts: {
+  vaultRoot: string;
+  tenant: Tenant;
+  /** The thread whose transcript `propose_update` appends to. The stdio
+   * server registers that tool only when this is set — without a thread
+   * there is nowhere for a proposal to live. */
+  threadId?: string;
+  /** Where `read_primitive` reads `primitives/*.md` from. Omitted, the
+   * stdio server falls back to its own repo root, which is correct in a
+   * normal install and wrong only for a relocated plugin. */
+  pluginRoot?: string;
+}): CodexOptions {
   return {
     config: {
       mcp_servers: {
         counsel: {
           command: 'bun',
           args: [STDIO_SERVER],
-          env: { COUNSEL_VAULT: opts.vaultRoot, COUNSEL_TENANT: opts.tenant },
+          env: {
+            COUNSEL_VAULT: opts.vaultRoot,
+            COUNSEL_TENANT: opts.tenant,
+            ...(opts.threadId ? { COUNSEL_THREAD_ID: opts.threadId } : {}),
+            ...(opts.pluginRoot ? { COUNSEL_PLUGIN_ROOT: opts.pluginRoot } : {}),
+          },
           // Without this, EVERY MCP tool call is denied with "MCP tool call
           // requires approval, but approval policy is never" — the thread's
           // `approvalPolicy` default of `never` means *deny*, not *allow*
@@ -374,22 +390,43 @@ export class CodexHarnessProvider implements ModelProvider {
 
   readonly homeDir: string | undefined;
 
-  constructor(private readonly opts: { model: string; vaultRoot: string; id?: string; homeDir?: string }) {
+  constructor(
+    private readonly opts: {
+      model: string;
+      vaultRoot: string;
+      id?: string;
+      homeDir?: string;
+      threadId?: string;
+      pluginRoot?: string;
+    },
+  ) {
     this.id = opts.id ?? `codex-sub/${opts.model}`;
     this.homeDir = opts.homeDir;
   }
 
   /**
-   * A copy of this provider — same model, id, and vault — pinned to a
-   * persistent `CODEX_HOME`. The counsel loop calls this with the thread's
-   * own home (`ThreadStore.codexHomeFor`) so `resumeThread` can find the
-   * session state a previous step left behind: a registry-built provider is
-   * shared across threads, so the home has to be bound per thread, not per
-   * provider. Returns a new instance rather than mutating, so two threads
-   * can use the same registry entry concurrently.
+   * A copy of this provider — same model, id, and vault — bound to one
+   * thread: its persistent `CODEX_HOME` (so `resumeThread` finds the session
+   * state a previous step left behind) and its id, which reaches the stdio
+   * MCP server as `COUNSEL_THREAD_ID` and is what lets that server offer
+   * `propose_update`. A registry-built provider is shared across threads, so
+   * both have to be bound per thread, not per provider. Returns a new
+   * instance rather than mutating, so two threads can use the same registry
+   * entry concurrently.
    */
+  withThread(opts: { homeDir: string; threadId?: string; pluginRoot?: string }): CodexHarnessProvider {
+    return new CodexHarnessProvider({
+      ...this.opts,
+      homeDir: opts.homeDir,
+      ...(opts.threadId ? { threadId: opts.threadId } : {}),
+      ...(opts.pluginRoot ? { pluginRoot: opts.pluginRoot } : {}),
+    });
+  }
+
+  /** `withThread` with only the home bound — the original two-step spelling,
+   * kept for callers that have no thread id to give. */
   withHome(dir: string): CodexHarnessProvider {
-    return new CodexHarnessProvider({ ...this.opts, homeDir: dir });
+    return this.withThread({ homeDir: dir });
   }
 
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
@@ -426,7 +463,12 @@ export class CodexHarnessProvider implements ModelProvider {
       ephemeralHome = resolved.ephemeral;
       cwd = mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
       const codex = new Codex({
-        ...buildCodexConfig({ vaultRoot: this.opts.vaultRoot, tenant: req.tenant }),
+        ...buildCodexConfig({
+          vaultRoot: this.opts.vaultRoot,
+          tenant: req.tenant,
+          ...(this.opts.threadId ? { threadId: this.opts.threadId } : {}),
+          ...(this.opts.pluginRoot ? { pluginRoot: this.opts.pluginRoot } : {}),
+        }),
         env: buildCodexEnv(isolatedHome, realHome, process.env),
       });
       const thread = req.session?.id

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -1,4 +1,4 @@
-import { copyFileSync, existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { copyFileSync, existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import type { ZodType } from 'zod';
@@ -32,6 +32,10 @@ type AnyEv = { type: string; [k: string]: unknown };
  */
 export function mapCodexEvent(raw: unknown, outputSchema?: ZodType<unknown>, finalResponse?: string): StepEvent[] {
   const ev = raw as AnyEv;
+
+  if (ev.type === 'thread.started' && typeof ev.thread_id === 'string') {
+    return [{ type: 'session', id: ev.thread_id }];
+  }
 
   if (ev.type === 'item.completed') {
     const item = ev.item as Record<string, unknown>;
@@ -246,6 +250,27 @@ export function cleanupIsolatedHome(isolatedHome: string): void {
 }
 
 /**
+ * Resolves which `CODEX_HOME` a run should use. When the caller supplies a
+ * persistent `homeDir` (e.g. so a session can be resumed across steps via
+ * `resumeThread`), that directory is reused as-is and seeded with the
+ * operator's `auth.json` the same way `prepareIsolatedHome` does, but it is
+ * never removed by the caller (`ephemeral: false`) — the same directory has
+ * to still be there on the next step. Without a `homeDir`, behavior is
+ * unchanged from before: a fresh isolated home is created per run and must
+ * be torn down after (`ephemeral: true`).
+ */
+export function resolveCodexHome(opts: { homeDir?: string; realHome: string }): { isolatedHome: string; ephemeral: boolean } {
+  if (opts.homeDir) {
+    if (opts.homeDir === opts.realHome) throw new Error('homeDir must not be the real CODEX_HOME');
+    mkdirSync(opts.homeDir, { recursive: true, mode: 0o700 });
+    const authSrc = join(opts.realHome, 'auth.json');
+    if (existsSync(authSrc) && !existsSync(join(opts.homeDir, 'auth.json'))) copyFileSync(authSrc, join(opts.homeDir, 'auth.json'));
+    return { isolatedHome: opts.homeDir, ephemeral: false };
+  }
+  return { isolatedHome: prepareIsolatedHome(opts.realHome), ephemeral: true };
+}
+
+/**
  * Pure builder for the child CLI process's environment. `CodexOptions.env`
  * *replaces* the child's environment rather than extending `process.env`
  * (index.d.ts:236-239: "When provided, the SDK will not inherit variables
@@ -278,8 +303,11 @@ export class CodexHarnessProvider implements ModelProvider {
   readonly kind = 'harness' as const;
   readonly capabilities: Capabilities = { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' };
 
-  constructor(private readonly opts: { model: string; vaultRoot: string; id?: string }) {
+  readonly homeDir: string | undefined;
+
+  constructor(private readonly opts: { model: string; vaultRoot: string; id?: string; homeDir?: string }) {
     this.id = opts.id ?? `codex-sub/${opts.model}`;
+    this.homeDir = opts.homeDir;
   }
 
   async *run(req: StepRequest): AsyncIterable<StepEvent> {
@@ -288,6 +316,7 @@ export class CodexHarnessProvider implements ModelProvider {
     // failure becomes an `error` event, and the finally removes whatever
     // did get created (the isolated home holds a credential copy).
     let isolatedHome: string | undefined;
+    let ephemeralHome = true;
     let cwd: string | undefined;
 
     // `CodexExec.run` (the SDK's process runner) throws on a non-zero CLI
@@ -299,13 +328,17 @@ export class CodexHarnessProvider implements ModelProvider {
     // try for the same reason — `buildCodexEnv` throws on a defeated
     // isolation, and that must reach the caller as an `error` event too.
     try {
-      isolatedHome = prepareIsolatedHome(realHome);
+      const resolved = resolveCodexHome({ homeDir: this.opts.homeDir, realHome });
+      isolatedHome = resolved.isolatedHome;
+      ephemeralHome = resolved.ephemeral;
       cwd = mkdtempSync(join(tmpdir(), 'counsel-cwd-'));
       const codex = new Codex({
         ...buildCodexConfig({ vaultRoot: this.opts.vaultRoot, tenant: req.tenant }),
         env: buildCodexEnv(isolatedHome, realHome, process.env),
       });
-      const thread = codex.startThread(buildThreadOptions(this.opts.model, cwd));
+      const thread = req.session?.id
+        ? codex.resumeThread(req.session.id, buildThreadOptions(this.opts.model, cwd))
+        : codex.startThread(buildThreadOptions(this.opts.model, cwd));
 
       const transcript = req.messages.map(m => `${m.role === 'user' ? 'User' : 'Assistant'}: ${m.content}`).join('\n\n');
       const prompt = `${req.system}\n\n${transcript}`;
@@ -313,12 +346,16 @@ export class CodexHarnessProvider implements ModelProvider {
       const { events } = await thread.runStreamed(prompt, req.outputSchema ? { outputSchema: toHarnessJsonSchema(req.outputSchema) } : {});
 
       let lastText = '';
+      let sessionId: string | undefined;
       for await (const ev of events) {
         const e = ev as AnyEv;
         if (e.type === 'item.completed' && (e.item as { type?: string })?.type === 'agent_message') {
           lastText = String((e.item as { text?: string }).text ?? '');
         }
-        for (const out of mapCodexEvent(ev, req.outputSchema, lastText)) yield out;
+        for (const out of mapCodexEvent(ev, req.outputSchema, lastText)) {
+          if (out.type === 'session') { sessionId = out.id; yield out; continue; }
+          yield out.type === 'done' && sessionId ? { ...out, sessionId } : out;
+        }
       }
     } catch (err) {
       yield { type: 'error', message: `codex harness: ${err instanceof Error ? err.message : String(err)}` };
@@ -326,8 +363,10 @@ export class CodexHarnessProvider implements ModelProvider {
       // The isolated home holds a plaintext copy of the operator's
       // `auth.json`; leaving one behind per run would scatter live
       // credentials through the temp directory. This also runs when the
-      // consumer abandons the generator early.
-      if (isolatedHome) cleanupIsolatedHome(isolatedHome);
+      // consumer abandons the generator early. A persistent `homeDir` is
+      // never removed here — it must survive to be reused by a later
+      // `resumeThread` step (see `resolveCodexHome`).
+      if (isolatedHome && ephemeralHome) cleanupIsolatedHome(isolatedHome);
       if (cwd) rmSync(cwd, { recursive: true, force: true });
     }
   }

--- a/runtime/src/providers/codex-harness.ts
+++ b/runtime/src/providers/codex-harness.ts
@@ -1,4 +1,4 @@
-import { chmodSync, constants, copyFileSync, existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
+import { chmodSync, constants, copyFileSync, existsSync, lstatSync, mkdirSync, mkdtempSync, realpathSync, rmSync, statSync } from 'node:fs';
 import { homedir, tmpdir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 import type { ZodType } from 'zod';
@@ -300,6 +300,13 @@ function normalizePath(p: string): string {
  * before the enclosing directory's 0700 was tightened — would otherwise
  * publish the operator's credentials to every local account.
  *
+ * A symlink at the destination is removed rather than written through: both
+ * `copyFileSync` and `chmodSync` follow links, so a planted one would send
+ * the live credential wherever it points. Everything after that point is
+ * best-effort and logs to stderr instead of throwing — a home without a
+ * usable credential still runs, and the CLI's own auth error says more than
+ * an exception thrown from here would.
+ *
  * Initial copy (destination doesn't exist yet) uses
  * `constants.COPYFILE_EXCL`, which makes `copyFileSync` fail rather than
  * write through the destination path if something already occupies it
@@ -325,6 +332,17 @@ function seedCodexAuth(homeDir: string, realHome: string): void {
     }
     return;
   }
+  // A symlink at the destination is not a copy of anything — it is a pointer
+  // someone else chose. `copyFileSync` and `chmodSync` both FOLLOW it, so the
+  // re-seed below would write the operator's live credentials through it and
+  // then chmod whatever it aims at. Drop it and fall through to the EXCL
+  // create path, which refuses to write through anything at all.
+  try {
+    if (lstatSync(authDest).isSymbolicLink()) rmSync(authDest, { force: true });
+  } catch {
+    // Nothing at the destination yet — the create path below handles it.
+  }
+
   if (!existsSync(authDest)) {
     try {
       copyFileSync(authSrc, authDest, constants.COPYFILE_EXCL);
@@ -334,13 +352,23 @@ function seedCodexAuth(homeDir: string, realHome: string): void {
     }
     return;
   }
-  if (statSync(authSrc).mtimeMs > statSync(authDest).mtimeMs) {
-    copyFileSync(authSrc, authDest);
+
+  // Seeding is best-effort: a home that ends up without a usable credential
+  // still runs, and the CLI reports its own auth failure with far better
+  // context than a thrown error from here, which would take down a step that
+  // may not have needed the credential at all.
+  try {
+    if (statSync(authSrc).mtimeMs > statSync(authDest).mtimeMs) {
+      copyFileSync(authSrc, authDest);
+    }
+    // Unconditional, not just after a re-copy: an overwrite keeps the
+    // destination's existing mode, and a copy made before this rule existed
+    // still has whatever mode the source had.
+    chmodSync(authDest, 0o600);
+  } catch (err) {
+    const why = err instanceof Error ? err.message : String(err);
+    console.error(`counsel-os: could not refresh ${authDest}: ${why}`);
   }
-  // Unconditional, not just after a re-copy: an overwrite keeps the
-  // destination's existing mode, and a copy made before this rule existed
-  // still has whatever mode the source had.
-  chmodSync(authDest, 0o600);
 }
 
 /**

--- a/runtime/src/providers/direct.ts
+++ b/runtime/src/providers/direct.ts
@@ -1,6 +1,7 @@
 import { Output, stepCountIs, streamText, tool, type LanguageModel } from 'ai';
 import { anthropic } from '@ai-sdk/anthropic';
 import { openai } from '@ai-sdk/openai';
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { ollama } from 'ai-sdk-ollama';
 import type { Capabilities, ModelProvider, StepEvent, StepRequest } from '../core/types';
 import { runToolDef } from '../core/fake-provider';
@@ -86,13 +87,28 @@ const CAPS: Record<string, Capabilities> = {
   anthropic: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'apikey' },
   openai:    { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'apikey' },
   ollama:    { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'local' },
+  'openai-compatible': { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'apikey' },
 };
 
-export function directProviderFromId(id: string): DirectProvider {
+export function directProviderFromId(
+  id: string,
+  reg: { baseURL?: string; apiKey?: string; capabilities?: Partial<Capabilities> } = {},
+): DirectProvider {
   const [vendor, ...rest] = id.split('/');
   const name = rest.join('/');
   const caps = CAPS[vendor ?? ''];
-  if (!caps || !name) throw new Error(`unknown direct provider id: ${id}`);
-  const model = vendor === 'anthropic' ? anthropic(name) : vendor === 'openai' ? openai(name) : ollama(name);
-  return new DirectProvider({ id, model, capabilities: caps });
+  if (!caps || !name) throw new Error(`unknown provider: ${id}`);
+  let model: LanguageModel;
+  if (vendor === 'anthropic') {
+    model = anthropic(name);
+  } else if (vendor === 'openai') {
+    model = openai(name);
+  } else if (vendor === 'openai-compatible') {
+    if (!reg.baseURL) throw new Error(`unknown provider: openai-compatible requires baseURL for ${id}`);
+    model = createOpenAICompatible({ name, baseURL: reg.baseURL, apiKey: reg.apiKey })(name);
+  } else {
+    model = ollama(name);
+  }
+  const capabilities = { ...caps, ...reg.capabilities };
+  return new DirectProvider({ id, model, capabilities });
 }

--- a/runtime/src/providers/index.test.ts
+++ b/runtime/src/providers/index.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import { buildProviders } from './index';
+import type { ClaudeHarnessProvider } from './claude-harness';
+import type { CodexHarnessProvider } from './codex-harness';
 
 describe('buildProviders', () => {
   test('routes ids to the right provider class', () => {
@@ -12,5 +14,20 @@ describe('buildProviders', () => {
   });
   test('unknown vendor throws', () => {
     expect(() => buildProviders({ ids: ['nope/x'], vaultRoot: '/tmp/v' })).toThrow(/unknown/);
+  });
+  test('threads claudeCwd to the Claude provider and codexHomeDir to the Codex provider', () => {
+    const [claude, codex] = buildProviders({
+      ids: ['claude-sub/opus', 'codex-sub/gpt-5'],
+      vaultRoot: '/tmp/v',
+      claudeCwd: '/pinned/cwd',
+      codexHomeDir: '/pinned/codex-home',
+    });
+    expect((claude as ClaudeHarnessProvider).cwd).toBe('/pinned/cwd');
+    expect((codex as CodexHarnessProvider).homeDir).toBe('/pinned/codex-home');
+  });
+  test('omits cwd/homeDir on the providers when claudeCwd/codexHomeDir are not given', () => {
+    const [claude, codex] = buildProviders({ ids: ['claude-sub/opus', 'codex-sub/gpt-5'], vaultRoot: '/tmp/v' });
+    expect((claude as ClaudeHarnessProvider).cwd).toBeUndefined();
+    expect((codex as CodexHarnessProvider).homeDir).toBeUndefined();
   });
 });

--- a/runtime/src/providers/index.ts
+++ b/runtime/src/providers/index.ts
@@ -3,12 +3,12 @@ import { ClaudeHarnessProvider } from './claude-harness';
 import { CodexHarnessProvider } from './codex-harness';
 import { directProviderFromId } from './direct';
 
-export function buildProviders(opts: { ids: string[]; vaultRoot: string }): ModelProvider[] {
+export function buildProviders(opts: { ids: string[]; vaultRoot: string; claudeCwd?: string; codexHomeDir?: string }): ModelProvider[] {
   return opts.ids.map(id => {
     const [vendor, ...rest] = id.split('/');
     const model = rest.join('/');
-    if (vendor === 'claude-sub') return new ClaudeHarnessProvider({ model, id });
-    if (vendor === 'codex-sub') return new CodexHarnessProvider({ model, vaultRoot: opts.vaultRoot, id });
+    if (vendor === 'claude-sub') return new ClaudeHarnessProvider({ model, id, ...(opts.claudeCwd ? { cwd: opts.claudeCwd } : {}) });
+    if (vendor === 'codex-sub') return new CodexHarnessProvider({ model, vaultRoot: opts.vaultRoot, id, ...(opts.codexHomeDir ? { homeDir: opts.codexHomeDir } : {}) });
     return directProviderFromId(id);
   });
 }

--- a/runtime/src/providers/registry.test.ts
+++ b/runtime/src/providers/registry.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync } from 'node:fs'; import { tmpdir } from 'node:os'; import { join } from 'node:path';
+import { loadRegistry, BUILTIN_DEFAULT } from './registry';
+
+describe('loadRegistry', () => {
+  test('no file → built-ins with the built-in default', () => {
+    const r = loadRegistry({ file: '/nonexistent/providers.yaml', vaultRoot: '/v' });
+    expect(r.defaultId).toBe(BUILTIN_DEFAULT);
+    expect(r.providers.map(p => p.id)).toContain('claude-sub/claude-opus-5');
+    expect(r.router.resolve().id).toBe(BUILTIN_DEFAULT);
+  });
+  test('file adds openai-compatible providers and overrides default + tasks', () => {
+    const f = join(mkdtempSync(join(tmpdir(), 'reg-')), 'providers.yaml');
+    writeFileSync(f, `default: openai-compatible/groq\nproviders:\n  - id: openai-compatible/groq\n    baseURL: https://api.groq.com/openai/v1\n    apiKeyEnv: GROQ_API_KEY\n    capabilities: { contextTokens: 128000 }\ntasks:\n  classify: { prefer: openai-compatible/groq }\n`);
+    const r = loadRegistry({ file: f, vaultRoot: '/v', env: { GROQ_API_KEY: 'k' } });
+    const groq = r.providers.find(p => p.id === 'openai-compatible/groq')!;
+    expect(groq.capabilities.contextTokens).toBe(128000);
+    expect(groq.capabilities.auth).toBe('apikey');
+    expect(r.router.resolve('classify').id).toBe('openai-compatible/groq');
+  });
+  test('unknown id prefix fails at load time', () => {
+    const f = join(mkdtempSync(join(tmpdir(), 'reg-')), 'providers.yaml');
+    writeFileSync(f, `providers:\n  - id: nope/x\n`);
+    expect(() => loadRegistry({ file: f, vaultRoot: '/v' })).toThrow(/unknown provider/);
+  });
+});

--- a/runtime/src/providers/registry.ts
+++ b/runtime/src/providers/registry.ts
@@ -1,0 +1,32 @@
+import { z } from 'zod';
+import { existsSync, readFileSync } from 'node:fs';
+import { homedir } from 'node:os'; import { join } from 'node:path';
+import type { Capabilities, ModelProvider } from '../core/types';
+import { Router, parseRouterConfig, type RouterConfig } from '../router/router';
+import { buildProviders } from './index';
+import { directProviderFromId } from './direct';
+import { withRetry } from './retry';
+
+export const BUILTIN_DEFAULT = 'claude-sub/claude-opus-5';
+export const BUILTIN_IDS = ['claude-sub/claude-opus-5', 'codex-sub/gpt-5.6-terra', 'ollama/gemma4:e4b'];
+export const DEFAULT_REGISTRY_FILE = join(homedir(), '.counsel-os', 'providers.yaml');
+
+const Entry = z.object({ id: z.string(), baseURL: z.string().optional(), apiKeyEnv: z.string().optional(),
+  capabilities: z.object({ tools: z.boolean(), caching: z.boolean(), thinking: z.boolean(), contextTokens: z.number(), auth: z.enum(['subscription','apikey','local']) }).partial().optional() });
+export const RegistryFile = z.object({ default: z.string().optional(), providers: z.array(Entry).optional(), tasks: z.record(z.string(), z.any()).optional() });
+
+export function loadRegistry(opts: { file?: string; vaultRoot: string; env?: NodeJS.ProcessEnv }) {
+  const file = opts.file ?? DEFAULT_REGISTRY_FILE; const env = opts.env ?? process.env;
+  const raw = existsSync(file) ? RegistryFile.parse(Bun.YAML.parse(readFileSync(file, 'utf8'))) : {};
+  const providers: ModelProvider[] = buildProviders({ ids: BUILTIN_IDS, vaultRoot: opts.vaultRoot });
+  for (const e of raw.providers ?? []) {
+    const [vendor] = e.id.split('/');
+    if (vendor === 'claude-sub' || vendor === 'codex-sub') { providers.push(...buildProviders({ ids: [e.id], vaultRoot: opts.vaultRoot })); continue; }
+    if (!['anthropic','openai','ollama','openai-compatible'].includes(vendor ?? '')) throw new Error(`unknown provider id prefix: ${e.id}`);
+    providers.push(directProviderFromId(e.id, { baseURL: e.baseURL, apiKey: e.apiKeyEnv ? env[e.apiKeyEnv] : undefined, capabilities: e.capabilities as Partial<Capabilities> }));
+  }
+  const wrapped = providers.map(p => (p.kind === 'direct' ? withRetry(p) : p));
+  const defaultId = raw.default ?? BUILTIN_DEFAULT;
+  const cfg: RouterConfig = { default: defaultId, tasks: raw.tasks };
+  return { providers: wrapped, router: new Router(cfg, wrapped), defaultId };
+}

--- a/runtime/src/providers/registry.ts
+++ b/runtime/src/providers/registry.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { existsSync, readFileSync } from 'node:fs';
-import { homedir } from 'node:os'; import { join } from 'node:path';
+import { join } from 'node:path';
+import { counselHome } from '../core/home';
 import type { Capabilities, ModelProvider } from '../core/types';
 import { Router, parseRouterConfig, type RouterConfig } from '../router/router';
 import { buildProviders } from './index';
@@ -9,14 +10,20 @@ import { withRetry } from './retry';
 
 export const BUILTIN_DEFAULT = 'claude-sub/claude-opus-5';
 export const BUILTIN_IDS = ['claude-sub/claude-opus-5', 'codex-sub/gpt-5.6-terra', 'ollama/gemma4:e4b'];
-export const DEFAULT_REGISTRY_FILE = join(homedir(), '.counsel-os', 'providers.yaml');
+/** `<counselHome>/providers.yaml`. Resolved per call, not frozen at module
+ * load, because `counselHome` reads `COUNSEL_OS_HOME` — a constant computed
+ * at import time would pin the developer's real home into every later
+ * `loadRegistry`, which is exactly the bug this replaces. */
+export function defaultRegistryFile(env: NodeJS.ProcessEnv = process.env): string {
+  return join(counselHome(env), 'providers.yaml');
+}
 
 const Entry = z.object({ id: z.string(), baseURL: z.string().optional(), apiKeyEnv: z.string().optional(),
   capabilities: z.object({ tools: z.boolean(), caching: z.boolean(), thinking: z.boolean(), contextTokens: z.number(), auth: z.enum(['subscription','apikey','local']) }).partial().optional() });
 export const RegistryFile = z.object({ default: z.string().optional(), providers: z.array(Entry).optional(), tasks: z.record(z.string(), z.any()).optional() });
 
 export function loadRegistry(opts: { file?: string; vaultRoot: string; env?: NodeJS.ProcessEnv }) {
-  const file = opts.file ?? DEFAULT_REGISTRY_FILE; const env = opts.env ?? process.env;
+  const env = opts.env ?? process.env; const file = opts.file ?? defaultRegistryFile(env);
   const raw = existsSync(file) ? RegistryFile.parse(Bun.YAML.parse(readFileSync(file, 'utf8'))) : {};
   const providers: ModelProvider[] = buildProviders({ ids: BUILTIN_IDS, vaultRoot: opts.vaultRoot });
   for (const e of raw.providers ?? []) {

--- a/runtime/src/providers/retry.test.ts
+++ b/runtime/src/providers/retry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { withRetry } from './retry';
+import { isRetryable, withRetry } from './retry';
 import type { ModelProvider, StepEvent } from '../core/types';
 function flaky(fails: number, msg: string): ModelProvider & { calls: number } {
   const p = { id: 'x/y', kind: 'direct' as const, calls: 0, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1, auth: 'apikey' as const },
@@ -59,5 +59,30 @@ describe('withRetry', () => {
     const p = textThenMore(); const r = withRetry(p, { tries: 3, sleep: async () => {} });
     for await (const _e of r.run(req)) { break; }
     expect(p.closed).toBe(1);
+  });
+});
+
+describe('isRetryable', () => {
+  test('a bare three-digit number in prose is not a status code', () => {
+    // The old `\b(429|5\d\d)\b` retried these three times each.
+    expect(isRetryable('row 512 missing')).toBe(false);
+    expect(isRetryable('clause 500 of the agreement is ambiguous')).toBe(false);
+    expect(isRetryable('exhibit 429 not found')).toBe(false);
+    expect(isRetryable('structured output failed validation')).toBe(false);
+  });
+
+  test('a status code introduced as one, or leading the message, is retryable', () => {
+    expect(isRetryable('HTTP 503')).toBe(true);
+    expect(isRetryable('status 429')).toBe(true);
+    expect(isRetryable('503 Service Unavailable')).toBe(true);
+    expect(isRetryable('status code: 500')).toBe(true);
+    expect(isRetryable('upstream returned HTTP/529')).toBe(true);
+  });
+
+  test('a named transient condition is retryable with no status code at all', () => {
+    expect(isRetryable('rate limit exceeded')).toBe(true);
+    expect(isRetryable('the model is Overloaded')).toBe(true);
+    expect(isRetryable('read ECONNRESET')).toBe(true);
+    expect(isRetryable('connect ETIMEDOUT 10.0.0.1:443')).toBe(true);
   });
 });

--- a/runtime/src/providers/retry.test.ts
+++ b/runtime/src/providers/retry.test.ts
@@ -8,6 +8,35 @@ function flaky(fails: number, msg: string): ModelProvider & { calls: number } {
 }
 async function last(it: AsyncIterable<StepEvent>) { let e: StepEvent | undefined; for await (const x of it) e = x; return e!; }
 const req = { tenant: 'default', system: '', messages: [], tools: [] };
+
+// A provider that always fails retryably, tracking whether each attempt's
+// generator ran its `finally` (i.e. was actually closed, not abandoned
+// mid-stream when `withRetry` moves on to the next attempt).
+function flakyWithCleanup(msg: string): ModelProvider & { closed: number } {
+  const p = { id: 'x/y', kind: 'direct' as const, closed: 0, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1, auth: 'apikey' as const },
+    async *run(): AsyncIterable<StepEvent> {
+      try { yield { type: 'error', message: msg }; }
+      finally { p.closed++; }
+    } };
+  return p;
+}
+
+// A successful multi-event provider, to check cleanup when the *caller* of
+// `withRetry`'s output abandons the stream early (a `break` out of a
+// `for await`), which should propagate a `.return()` down to the real
+// provider's generator so its `finally` still runs.
+function textThenMore(): ModelProvider & { closed: number } {
+  const p = { id: 'x/y', kind: 'direct' as const, closed: 0, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1, auth: 'apikey' as const },
+    async *run(): AsyncIterable<StepEvent> {
+      try {
+        yield { type: 'text', text: 'hi' };
+        yield { type: 'text', text: 'more' };
+        yield { type: 'done', output: 'ok', usage: { inputTokens: 0, outputTokens: 0 } };
+      } finally { p.closed++; }
+    } };
+  return p;
+}
+
 describe('withRetry', () => {
   test('retries a 429/5xx-shaped error and succeeds', async () => {
     const p = flaky(2, 'HTTP 429 rate limited'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
@@ -20,5 +49,15 @@ describe('withRetry', () => {
   test('gives up after tries and yields the last error', async () => {
     const p = flaky(5, 'HTTP 503'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
     expect((await last(r.run(req))).type).toBe('error'); expect(p.calls).toBe(3);
+  });
+  test('closes every abandoned attempt when retrying (no leaked generators)', async () => {
+    const p = flakyWithCleanup('HTTP 503'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    await last(r.run(req));
+    expect(p.closed).toBe(3);
+  });
+  test('closes the underlying provider when the caller breaks early', async () => {
+    const p = textThenMore(); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    for await (const _e of r.run(req)) { break; }
+    expect(p.closed).toBe(1);
   });
 });

--- a/runtime/src/providers/retry.test.ts
+++ b/runtime/src/providers/retry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, test } from 'bun:test';
+import { withRetry } from './retry';
+import type { ModelProvider, StepEvent } from '../core/types';
+function flaky(fails: number, msg: string): ModelProvider & { calls: number } {
+  const p = { id: 'x/y', kind: 'direct' as const, calls: 0, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1, auth: 'apikey' as const },
+    async *run(): AsyncIterable<StepEvent> { p.calls++; if (p.calls <= fails) { yield { type: 'error', message: msg }; return; } yield { type: 'done', output: 'ok', usage: { inputTokens: 0, outputTokens: 0 } }; } };
+  return p;
+}
+async function last(it: AsyncIterable<StepEvent>) { let e: StepEvent | undefined; for await (const x of it) e = x; return e!; }
+const req = { tenant: 'default', system: '', messages: [], tools: [] };
+describe('withRetry', () => {
+  test('retries a 429/5xx-shaped error and succeeds', async () => {
+    const p = flaky(2, 'HTTP 429 rate limited'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('done'); expect(p.calls).toBe(3);
+  });
+  test('does not retry other errors', async () => {
+    const p = flaky(5, 'structured output failed validation'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('error'); expect(p.calls).toBe(1);
+  });
+  test('gives up after tries and yields the last error', async () => {
+    const p = flaky(5, 'HTTP 503'); const r = withRetry(p, { tries: 3, sleep: async () => {} });
+    expect((await last(r.run(req))).type).toBe('error'); expect(p.calls).toBe(3);
+  });
+});

--- a/runtime/src/providers/retry.ts
+++ b/runtime/src/providers/retry.ts
@@ -9,15 +9,24 @@ export function withRetry(p: ModelProvider, opts: { tries?: number; baseMs?: num
     async *run(req: StepRequest): AsyncIterable<StepEvent> {
       for (let attempt = 1; ; attempt++) {
         const it = p.run(req)[Symbol.asyncIterator]();
-        const head: StepEvent[] = []; let first = await it.next();
-        while (!first.done && first.value.type === 'session') { head.push(first.value); first = await it.next(); }
-        if (!first.done && first.value.type === 'error' && attempt < tries && RETRYABLE.test(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
-        for (const e of head) yield e;
-        if (first.done) return;
-        yield first.value;
-        if (first.value.type === 'error') return;
-        for (let n = await it.next(); !n.done; n = await it.next()) yield n.value;
-        return;
+        try {
+          const head: StepEvent[] = []; let first = await it.next();
+          while (!first.done && first.value.type === 'session') { head.push(first.value); first = await it.next(); }
+          if (!first.done && first.value.type === 'error' && attempt < tries && RETRYABLE.test(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
+          for (const e of head) yield e;
+          if (first.done) return;
+          yield first.value;
+          if (first.value.type === 'error') return;
+          for (let n = await it.next(); !n.done; n = await it.next()) yield n.value;
+          return;
+        } finally {
+          // Close the underlying provider's iterator whether we're abandoning
+          // it to retry, or our own caller abandoned us mid-stream (a `break`
+          // out of a `for await` on this generator resumes us here via an
+          // implicit `.return()`). A throwing `return()` must not escape and
+          // mask whatever the try block was already doing (yielding/retrying).
+          try { await it.return?.(); } catch { /* ignore */ }
+        }
       }
     },
   };

--- a/runtime/src/providers/retry.ts
+++ b/runtime/src/providers/retry.ts
@@ -1,0 +1,24 @@
+import type { ModelProvider, StepEvent, StepRequest } from '../core/types';
+
+const RETRYABLE = /\b(429|5\d\d|rate limit|overloaded|ECONNRESET|ETIMEDOUT)\b/i;
+
+export function withRetry(p: ModelProvider, opts: { tries?: number; baseMs?: number; sleep?: (ms: number) => Promise<void> } = {}): ModelProvider {
+  const tries = opts.tries ?? 3, baseMs = opts.baseMs ?? 500, sleep = opts.sleep ?? (ms => new Promise(r => setTimeout(r, ms)));
+  return {
+    id: p.id, kind: p.kind, capabilities: p.capabilities,
+    async *run(req: StepRequest): AsyncIterable<StepEvent> {
+      for (let attempt = 1; ; attempt++) {
+        const it = p.run(req)[Symbol.asyncIterator]();
+        const head: StepEvent[] = []; let first = await it.next();
+        while (!first.done && first.value.type === 'session') { head.push(first.value); first = await it.next(); }
+        if (!first.done && first.value.type === 'error' && attempt < tries && RETRYABLE.test(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
+        for (const e of head) yield e;
+        if (first.done) return;
+        yield first.value;
+        if (first.value.type === 'error') return;
+        for (let n = await it.next(); !n.done; n = await it.next()) yield n.value;
+        return;
+      }
+    },
+  };
+}

--- a/runtime/src/providers/retry.ts
+++ b/runtime/src/providers/retry.ts
@@ -1,6 +1,30 @@
 import type { ModelProvider, StepEvent, StepRequest } from '../core/types';
 
-const RETRYABLE = /\b(429|5\d\d|rate limit|overloaded|ECONNRESET|ETIMEDOUT)\b/i;
+/**
+ * Providers report a retryable failure as free-form prose, so this matches on
+ * shape. Two shapes, deliberately narrow:
+ *
+ * A status code only counts when the text says it is one. `\b(429|5\d\d)\b`
+ * matched any three-digit number in any sentence — "row 512 missing" and
+ * "clause 500 of the agreement" both retried a permanent failure three times.
+ * So a 429/5xx has to be introduced by `HTTP`, `status`, or `code`, or start
+ * the message ("503 Service Unavailable"). The code range is spelled out
+ * (`50[0-9]`, `5[1-9]\d`) rather than `5\d\d` so it cannot be read as
+ * "anything in the 500s of some other numbering".
+ *
+ * Or the text names a transient condition outright — a rate limit, an
+ * overloaded upstream, a dropped or timed-out socket.
+ */
+const STATUS_CODE = '(?:429|50[0-9]|5[1-9]\\d)';
+const RETRYABLE_STATUS = new RegExp(`(?:\\b(?:HTTP|status|code)\\b[\\s:/=]*${STATUS_CODE}\\b)|(?:^${STATUS_CODE}\\b)`, 'i');
+const RETRYABLE_WORDS = /\b(rate limit|overloaded|ECONNRESET|ETIMEDOUT)\b/i;
+
+/** True when `message` looks like a transient provider failure worth
+ * retrying. Exported for its own test — the cost of getting it wrong is
+ * either three attempts at a permanent error or none at a transient one. */
+export function isRetryable(message: string): boolean {
+  return RETRYABLE_STATUS.test(message) || RETRYABLE_WORDS.test(message);
+}
 
 export function withRetry(p: ModelProvider, opts: { tries?: number; baseMs?: number; sleep?: (ms: number) => Promise<void> } = {}): ModelProvider {
   const tries = opts.tries ?? 3, baseMs = opts.baseMs ?? 500, sleep = opts.sleep ?? (ms => new Promise(r => setTimeout(r, ms)));
@@ -12,7 +36,7 @@ export function withRetry(p: ModelProvider, opts: { tries?: number; baseMs?: num
         try {
           const head: StepEvent[] = []; let first = await it.next();
           while (!first.done && first.value.type === 'session') { head.push(first.value); first = await it.next(); }
-          if (!first.done && first.value.type === 'error' && attempt < tries && RETRYABLE.test(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
+          if (!first.done && first.value.type === 'error' && attempt < tries && isRetryable(first.value.message)) { await sleep(baseMs * 2 ** (attempt - 1)); continue; }
           for (const e of head) yield e;
           if (first.done) return;
           yield first.value;

--- a/runtime/src/server/auth.test.ts
+++ b/runtime/src/server/auth.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+import { bearerToken, isAuthorized, tokensMatch } from './auth';
+
+const req = (headers: Record<string, string> = {}): Request =>
+  new Request('http://127.0.0.1:7431/health', { headers });
+
+describe('bearerToken', () => {
+  test('reads the credential, case-insensitively on the scheme', () => {
+    expect(bearerToken(req({ authorization: 'Bearer abc' }))).toBe('abc');
+    expect(bearerToken(req({ authorization: 'bearer abc' }))).toBe('abc');
+  });
+
+  test('is null for anything that is not a bearer credential', () => {
+    expect(bearerToken(req())).toBeNull();
+    expect(bearerToken(req({ authorization: 'Basic abc' }))).toBeNull();
+    expect(bearerToken(req({ authorization: 'Bearer' }))).toBeNull();
+    expect(bearerToken(req({ authorization: 'Bearer ' }))).toBeNull();
+  });
+});
+
+describe('tokensMatch', () => {
+  test('accepts only the exact token, whatever the lengths', () => {
+    expect(tokensMatch('secret', 'secret')).toBe(true);
+    expect(tokensMatch('secre', 'secret')).toBe(false);
+    expect(tokensMatch('secrets', 'secret')).toBe(false);
+    expect(tokensMatch('', 'secret')).toBe(false);
+    expect(tokensMatch('Secret', 'secret')).toBe(false);
+  });
+});
+
+describe('isAuthorized', () => {
+  test('needs both a bearer header and the right token', () => {
+    expect(isAuthorized(req({ authorization: 'Bearer secret' }), 'secret')).toBe(true);
+    expect(isAuthorized(req({ authorization: 'Bearer nope' }), 'secret')).toBe(false);
+    expect(isAuthorized(req(), 'secret')).toBe(false);
+  });
+});

--- a/runtime/src/server/auth.ts
+++ b/runtime/src/server/auth.ts
@@ -1,0 +1,30 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/**
+ * Pulls the bearer credential out of an `Authorization` header. Anything
+ * else — no header, another scheme, an empty credential — is `null`, which
+ * the caller treats exactly like a wrong token.
+ */
+export function bearerToken(req: Request): string | null {
+  const header = req.headers.get('authorization');
+  if (!header) return null;
+  const match = /^Bearer[ \t]+(\S+)$/i.exec(header.trim());
+  return match ? match[1]! : null;
+}
+
+/**
+ * Constant-time token comparison. Both sides are hashed first so the compare
+ * is over two fixed-length digests: `timingSafeEqual` throws on a length
+ * mismatch, and short-circuiting on length would leak the token's length to
+ * anyone who can time the loopback socket.
+ */
+export function tokensMatch(presented: string, expected: string): boolean {
+  const digest = (s: string): Buffer => createHash('sha256').update(s, 'utf8').digest();
+  return timingSafeEqual(digest(presented), digest(expected));
+}
+
+/** True when the request carries the server's bearer token. */
+export function isAuthorized(req: Request, expected: string): boolean {
+  const presented = bearerToken(req);
+  return presented !== null && tokensMatch(presented, expected);
+}

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -347,7 +347,9 @@ describe('one thread at a time', () => {
     const { events } = await store.get('default', id);
     expect(events.map(kindOf)).toEqual([
       ...['user', 'step', 'tool_call', 'proposal', 'tool_result', 'done'],
-      ...['user', 'step', 'text', 'text', 'text', 'done'],
+      // The provider's three `text` deltas are one logged `text` event —
+      // `stream()` coalesces a run of them (they still stream as three).
+      ...['user', 'step', 'text', 'done'],
     ]);
     const proposal = events.find(e => 't' in e && e.t === 'proposal') as Extract<ThreadEvent, { t: 'proposal' }>;
     expect(proposal.status).toBe('approved');

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -3,7 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { FakeModelProvider } from '../core/fake-provider';
+import { FakeModelProvider, runToolDef } from '../core/fake-provider';
 import type { Capabilities, ModelProvider, StepEvent, StepRequest } from '../core/types';
 import { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent } from '../threads/store';
@@ -321,6 +321,75 @@ describe('POST /threads/:id/approve', () => {
   });
 });
 
+describe('one thread at a time', () => {
+  test('an approve during a step leaves both the step and the decision intact', async () => {
+    // `updateProposal` rewrites the whole log (read → temp → rename). That
+    // rewrite is safe only because every ThreadStore mutator happens to be
+    // wholly synchronous — no `await` between the read and the rename — so
+    // nothing can append into the window. This asserts the end state both
+    // ways round; the lock is what keeps it true if that changes (every
+    // other store here already uses fs/promises).
+    const app = appWith([new SeedThenSlowProvider()]);
+    const id = await newThread(app);
+    await step(app, id, { message: 'seed' });
+
+    const seeded = (await store.get('default', id)).events;
+    expect(seeded.map(kindOf)).toEqual(['user', 'step', 'tool_call', 'proposal', 'tool_result', 'done']);
+    const proposalId = (seeded.find(e => 't' in e && e.t === 'proposal') as Extract<ThreadEvent, { t: 'proposal' }>).id;
+
+    const [stepRes, approveRes] = await Promise.all([
+      call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'second' } }),
+      call(app, 'POST', `/threads/${id}/approve`, { body: { proposalId, decision: 'approve' } }),
+    ]);
+    await stepRes.text();
+    expect(approveRes.status).toBe(200);
+
+    const { events } = await store.get('default', id);
+    expect(events.map(kindOf)).toEqual([
+      ...['user', 'step', 'tool_call', 'proposal', 'tool_result', 'done'],
+      ...['user', 'step', 'text', 'text', 'text', 'done'],
+    ]);
+    const proposal = events.find(e => 't' in e && e.t === 'proposal') as Extract<ThreadEvent, { t: 'proposal' }>;
+    expect(proposal.status).toBe('approved');
+    expect(readFileSync(join(vaultRoot, 'practice', 'standards', 'x.md'), 'utf8')).toBe('NEW TEXT\n');
+  });
+
+  test('a delete waits for the step in flight instead of pulling the log out from under it', async () => {
+    const app = appWith([new SlowProvider()]);
+    const id = await newThread(app);
+
+    // The response resolves once the stream is open and the first event has
+    // been read — the step is in flight and holds the lock. The delete
+    // arrives in that window on purpose; racing the two with Promise.all
+    // would only assert which handler reached the lock first.
+    const stepRes = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'first' } });
+    const deleting = call(app, 'DELETE', `/threads/${id}`);
+    const streamed = parseSse(await stepRes.text());
+
+    // Deleted mid-stream, the step's next append hits a log that is gone and
+    // the run dies with "thread log write failed". Serialized, it finishes.
+    expect(streamed.map(f => f.event)).toEqual(['text', 'done']);
+    expect((await deleting).status).toBe(204);
+    expect((await call(app, 'GET', `/threads/${id}`)).status).toBe(404);
+  });
+
+  test('a client that hangs up closes the provider', async () => {
+    // Nobody is reading any more: the provider must be told, or a harness
+    // subprocess keeps running with no consumer.
+    const provider = new EndlessProvider();
+    const app = appWith([provider]);
+    const id = await newThread(app);
+
+    const res = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'hi' } });
+    const reader = res.body!.getReader();
+    await reader.read();
+    await reader.cancel();
+
+    await waitFor(() => provider.closed);
+    expect(provider.closed).toBe(true);
+  });
+});
+
 describe('vault', () => {
   test('read and list are read-only views of the vault', async () => {
     const app = appWithFake();
@@ -347,14 +416,23 @@ describe('vault', () => {
     expect((await call(app, 'GET', '/vault/read?path=../x')).status).toBe(400);
     expect((await call(app, 'GET', '/vault/read?path=/etc/passwd')).status).toBe(400);
     expect((await call(app, 'GET', '/vault/list?dir=..')).status).toBe(400);
-    // The store's own bookkeeping is not readable either.
+    // The store's own bookkeeping is not readable either — in any casing,
+    // since the filesystem underneath is case-insensitive.
     expect((await call(app, 'GET', '/vault/read?path=.counsel/threads')).status).toBe(400);
+    expect((await call(app, 'GET', '/vault/read?path=.Counsel/threads')).status).toBe(400);
+    expect((await call(app, 'GET', '/vault/list?dir=.COUNSEL')).status).toBe(400);
   });
 
   test('a missing file is 404 and a missing path parameter is 400', async () => {
     const app = appWithFake();
     expect((await call(app, 'GET', '/vault/read?path=matters/none.md')).status).toBe(404);
     expect((await call(app, 'GET', '/vault/read')).status).toBe(400);
+  });
+
+  test('reading a directory is 400, not 404 — the path names the wrong kind of thing', async () => {
+    const app = appWithFake();
+    await vault.write('default', 'matters/acme/notes.md', 'NOTES\n');
+    expect((await call(app, 'GET', '/vault/read?path=matters/acme')).status).toBe(400);
   });
 
   test('writes are not exposed', async () => {
@@ -382,5 +460,72 @@ class SlowProvider implements ModelProvider {
     yield { type: 'text', text: 'slow' };
     await new Promise(r => setTimeout(r, 15));
     yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+  }
+}
+
+/** Polls until `pred` holds or the deadline passes — the provider's `finally`
+ * runs a turn or two after the reader is cancelled. */
+async function waitFor(pred: () => boolean, ms = 2000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred() && Date.now() < deadline) await new Promise(r => setTimeout(r, 5));
+}
+
+/** First run: propose a knowledge write (seeding a pending proposal). Second
+ * run: dawdle, so an overlapping approve has something to collide with. */
+class SeedThenSlowProvider implements ModelProvider {
+  readonly id = 'seed/slow';
+  readonly kind = 'direct' as const;
+  readonly capabilities: Capabilities = {
+    tools: true,
+    caching: false,
+    thinking: false,
+    contextTokens: 1_000_000,
+    auth: 'local',
+  };
+  private calls = 0;
+
+  async *run(req: StepRequest): AsyncIterable<StepEvent> {
+    if (this.calls++ === 0) {
+      const input = { path: 'practice/standards/x.md', content: 'NEW TEXT\n', rationale: 'because' };
+      yield { type: 'tool_call', id: 'seed-0', name: 'propose_update', input };
+      const result = await runToolDef(req.tools, 'propose_update', input, req.tenant);
+      yield { type: 'tool_result', id: 'seed-0', name: 'propose_update', output: result.output, isError: result.isError };
+      yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+      return;
+    }
+    for (const text of ['one', 'two', 'three']) {
+      await new Promise(r => setTimeout(r, 10));
+      yield { type: 'text', text };
+    }
+    yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+  }
+}
+
+/** Streams until someone stops it, and records that it was stopped. Bounded
+ * so a regression fails the assertion instead of spinning forever. */
+class EndlessProvider implements ModelProvider {
+  readonly id = 'endless/endless';
+  readonly kind = 'direct' as const;
+  readonly capabilities: Capabilities = {
+    tools: true,
+    caching: false,
+    thinking: false,
+    contextTokens: 1_000_000,
+    auth: 'local',
+  };
+  closed = false;
+
+  async *run(req: StepRequest): AsyncIterable<StepEvent> {
+    void req;
+    try {
+      yield { type: 'text', text: 'first' };
+      for (let i = 0; i < 100; i++) {
+        await new Promise(r => setTimeout(r, 10));
+        yield { type: 'text', text: `chunk ${i}` };
+      }
+      yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+    } finally {
+      this.closed = true;
+    }
   }
 }

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1,0 +1,386 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { randomUUID } from 'node:crypto';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FakeModelProvider } from '../core/fake-provider';
+import type { Capabilities, ModelProvider, StepEvent, StepRequest } from '../core/types';
+import { Router } from '../router/router';
+import { ThreadStore, type ThreadEvent } from '../threads/store';
+import { FsVaultStore } from '../vault/fs-store';
+import { createApp, type App, type ServerDeps } from './routes';
+
+const TOKEN = 'test-token-0123456789';
+
+let vaultRoot: string;
+let pluginRoot: string;
+let vault: FsVaultStore;
+let store: ThreadStore;
+
+beforeEach(() => {
+  vaultRoot = mkdtempSync(join(tmpdir(), 'routes-vault-'));
+  pluginRoot = mkdtempSync(join(tmpdir(), 'routes-plugin-'));
+  mkdirSync(join(pluginRoot, 'skills', 'counsel'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'skills', 'counsel', 'SKILL.md'), '---\nname: counsel\n---\n\nBODY.\n', 'utf8');
+  mkdirSync(join(pluginRoot, 'primitives'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'primitives', 'draft.md'), 'DRAFT.\n', 'utf8');
+  vault = new FsVaultStore(vaultRoot);
+  store = new ThreadStore(vaultRoot, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'routes-codex-')) });
+});
+
+function appWith(providers: ModelProvider[]): App {
+  const deps: ServerDeps = {
+    token: TOKEN,
+    tenant: 'default',
+    vaultRoot,
+    pluginRoot,
+    vault,
+    store,
+    providers,
+    router: new Router({ default: providers[0]!.id }, providers),
+    platform: 'macos',
+  };
+  return createApp(deps);
+}
+
+function appWithFake(script: ConstructorParameters<typeof FakeModelProvider>[0] = [{ text: 'hello there' }]): App {
+  return appWith([new FakeModelProvider(script)]);
+}
+
+interface CallOptions {
+  body?: unknown;
+  token?: string | null;
+}
+
+function call(app: App, method: string, path: string, opts: CallOptions = {}): Promise<Response> {
+  const token = opts.token === undefined ? TOKEN : opts.token;
+  const headers: Record<string, string> = {};
+  if (token !== null) headers['authorization'] = `Bearer ${token}`;
+  if (opts.body !== undefined) headers['content-type'] = 'application/json';
+  return app(
+    new Request(`http://127.0.0.1:7431${path}`, {
+      method,
+      headers,
+      ...(opts.body === undefined ? {} : { body: JSON.stringify(opts.body) }),
+    }),
+  );
+}
+
+interface Frame {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+function parseSse(text: string): Frame[] {
+  return text
+    .split('\n\n')
+    .filter(block => block.trim() !== '')
+    .map(block => {
+      const lines = block.split('\n');
+      const eventLine = lines.find(l => l.startsWith('event: '))!;
+      const data = lines.filter(l => l.startsWith('data: ')).map(l => l.slice(6)).join('\n');
+      return { event: eventLine.slice('event: '.length), data: JSON.parse(data) as Record<string, unknown> };
+    });
+}
+
+async function newThread(app: App): Promise<string> {
+  const res = await call(app, 'POST', '/threads', { body: { title: 'a thread' } });
+  expect(res.status).toBe(201);
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function step(app: App, id: string, body: Record<string, unknown>): Promise<{ res: Response; frames: Frame[] }> {
+  const res = await call(app, 'POST', `/threads/${id}/steps`, { body });
+  const frames = res.headers.get('content-type') === 'text/event-stream' ? parseSse(await res.text()) : [];
+  return { res, frames };
+}
+
+function kindOf(ev: ThreadEvent): string {
+  return 't' in ev ? ev.t : ev.type;
+}
+
+describe('auth', () => {
+  test('every route needs a bearer token', async () => {
+    const app = appWithFake();
+    for (const path of ['/health', '/threads', '/vault/list']) {
+      expect((await call(app, 'GET', path, { token: null })).status).toBe(401);
+      expect((await call(app, 'GET', path, { token: 'wrong-token' })).status).toBe(401);
+      // A prefix of the real token must not pass either.
+      expect((await call(app, 'GET', path, { token: TOKEN.slice(0, -1) })).status).toBe(401);
+    }
+  });
+
+  test('an unknown route is 404, even with a good token', async () => {
+    expect((await call(appWithFake(), 'GET', '/nope')).status).toBe(404);
+  });
+});
+
+describe('GET /health', () => {
+  test('lists the providers and the default', async () => {
+    const res = await call(appWithFake(), 'GET', '/health');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      vault: string;
+      tenant: string;
+      default: string;
+      providers: Array<{ id: string; kind: string; auth: string; capabilities: Capabilities }>;
+    };
+    expect(body.vault).toBe(vaultRoot);
+    expect(body.tenant).toBe('default');
+    expect(body.default).toBe('fake/fake');
+    expect(body.providers).toHaveLength(1);
+    expect(body.providers[0]!.id).toBe('fake/fake');
+    expect(body.providers[0]!.kind).toBe('direct');
+    expect(body.providers[0]!.auth).toBe('local');
+    expect(body.providers[0]!.capabilities.tools).toBe(true);
+  });
+});
+
+describe('threads', () => {
+  test('POST creates (201), GET lists and reads, DELETE removes', async () => {
+    const app = appWithFake();
+    const id = await newThread(app);
+
+    const listed = (await (await call(app, 'GET', '/threads')).json()) as Array<{ id: string; title?: string }>;
+    expect(listed.map(h => h.id)).toEqual([id]);
+    expect(listed[0]!.title).toBe('a thread');
+
+    const one = (await (await call(app, 'GET', `/threads/${id}`)).json()) as {
+      header: { id: string };
+      events: ThreadEvent[];
+    };
+    expect(one.header.id).toBe(id);
+    expect(one.events).toEqual([]);
+
+    expect((await call(app, 'DELETE', `/threads/${id}`)).status).toBe(204);
+    expect((await call(app, 'GET', `/threads/${id}`)).status).toBe(404);
+  });
+
+  test('POST accepts no body at all', async () => {
+    const res = await call(appWithFake(), 'POST', '/threads');
+    expect(res.status).toBe(201);
+  });
+
+  test('an unknown thread is 404 and a malformed id is 400', async () => {
+    const app = appWithFake();
+    expect((await call(app, 'GET', `/threads/${randomUUID()}`)).status).toBe(404);
+    expect((await call(app, 'GET', '/threads/not-a-uuid')).status).toBe(400);
+    expect((await call(app, 'POST', `/threads/${randomUUID()}/steps`, { body: { message: 'hi' } })).status).toBe(404);
+  });
+
+  test('a bad body is 400', async () => {
+    const app = appWithFake();
+    const id = await newThread(app);
+    expect((await call(app, 'POST', `/threads/${id}/steps`, { body: { nope: 1 } })).status).toBe(400);
+    expect((await call(app, 'POST', '/threads', { body: { title: 42 } })).status).toBe(400);
+  });
+});
+
+describe('POST /threads/:id/steps', () => {
+  test('streams the step as SSE, ends with done, and reports the run id', async () => {
+    const app = appWithFake([{ text: 'hello there' }]);
+    const id = await newThread(app);
+
+    const { res, frames } = await step(app, id, { message: 'hi' });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/event-stream');
+    expect(res.headers.get('x-run-id')).toBeTruthy();
+    expect(frames.map(f => f.event)).toEqual(['text', 'done']);
+    expect(frames[0]!.data['text']).toBe('hello there');
+
+    // The thread now shows the whole turn.
+    const one = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { events: ThreadEvent[] };
+    expect(one.events.map(kindOf)).toEqual(['user', 'step', 'text', 'done']);
+  });
+
+  test('an unknown provider id is 422', async () => {
+    const app = appWithFake();
+    const id = await newThread(app);
+    const res = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'hi', provider: 'nope/nope' } });
+    expect(res.status).toBe(422);
+    expect(((await res.json()) as { error: string }).error).toContain('nope/nope');
+  });
+
+  test('an unsatisfiable task route is 422', async () => {
+    const fake = new FakeModelProvider([{ text: 'x' }]);
+    const app = createApp({
+      token: TOKEN,
+      tenant: 'default',
+      vaultRoot,
+      pluginRoot,
+      vault,
+      store,
+      providers: [fake],
+      router: new Router(
+        { default: 'fake/fake', tasks: { heavy: { prefer: 'missing/model', require: { contextTokens: 99_000_000 } } } },
+        [fake],
+      ),
+      platform: 'macos',
+    });
+    const id = await newThread(app);
+    const res = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'hi', task: 'heavy' } });
+    expect(res.status).toBe(422);
+  });
+
+  test('concurrent steps on one thread run one after the other', async () => {
+    const app = appWith([new SlowProvider()]);
+    const id = await newThread(app);
+
+    const [a, b] = await Promise.all([
+      call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'first' } }),
+      call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'second' } }),
+    ]);
+    await Promise.all([a.text(), b.text()]);
+
+    // Interleaved runs would produce user,user,step,step,…; serialized runs
+    // produce two clean turns.
+    const { events } = await store.get('default', id);
+    expect(events.map(kindOf)).toEqual(['user', 'step', 'text', 'done', 'user', 'step', 'text', 'done']);
+    const users = events.filter((e): e is Extract<ThreadEvent, { t: 'user' }> => 't' in e && e.t === 'user');
+    expect(users.map(u => u.content)).toEqual(['first', 'second']);
+  });
+});
+
+describe('POST /threads/:id/approve', () => {
+  const proposal = {
+    toolCalls: [
+      {
+        name: 'propose_update',
+        input: { path: 'practice/standards/x.md', content: 'NEW TEXT\n', rationale: 'because' },
+      },
+    ],
+    text: 'proposed',
+  };
+
+  async function seedProposal(app: App): Promise<{ threadId: string; proposalId: string }> {
+    const threadId = await newThread(app);
+    await step(app, threadId, { message: 'remember this' });
+    const { events } = await store.get('default', threadId);
+    const ev = events.find((e): e is Extract<ThreadEvent, { t: 'proposal' }> => 't' in e && e.t === 'proposal');
+    expect(ev).toBeDefined();
+    return { threadId, proposalId: ev!.id };
+  }
+
+  test('approve writes the vault file and returns the updated proposal', async () => {
+    const app = appWithFake([proposal]);
+    const { threadId, proposalId } = await seedProposal(app);
+
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, {
+      body: { proposalId, decision: 'approve' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { proposal: { status: string; path: string }; version: string };
+    expect(body.proposal.status).toBe('approved');
+    expect(body.proposal.path).toBe('practice/standards/x.md');
+    expect(body.version).toBeTruthy();
+    expect(readFileSync(join(vaultRoot, 'practice', 'standards', 'x.md'), 'utf8')).toBe('NEW TEXT\n');
+  });
+
+  test('reject leaves the vault alone', async () => {
+    const app = appWithFake([proposal]);
+    const { threadId, proposalId } = await seedProposal(app);
+
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, {
+      body: { proposalId, decision: 'reject' },
+    });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { proposal: { status: string } }).proposal.status).toBe('rejected');
+    expect(await vault.version('default', 'practice/standards/x.md')).toBeNull();
+  });
+
+  test('a path changed since the proposal is 409 with both versions', async () => {
+    const app = appWithFake([proposal]);
+    const { threadId, proposalId } = await seedProposal(app);
+    await vault.write('default', 'practice/standards/x.md', 'SOMEONE ELSE\n');
+
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, {
+      body: { proposalId, decision: 'approve' },
+    });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { conflict: { expected: string; actual: string } };
+    expect(body.conflict.expected).toBe('missing');
+    expect(body.conflict.actual).toBeTruthy();
+    expect(readFileSync(join(vaultRoot, 'practice', 'standards', 'x.md'), 'utf8')).toBe('SOMEONE ELSE\n');
+  });
+
+  test('an unknown proposal is 404', async () => {
+    const app = appWithFake([proposal]);
+    const { threadId } = await seedProposal(app);
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, {
+      body: { proposalId: randomUUID(), decision: 'approve' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  test('a decision on an already-decided proposal is 409', async () => {
+    const app = appWithFake([proposal]);
+    const { threadId, proposalId } = await seedProposal(app);
+    await call(app, 'POST', `/threads/${threadId}/approve`, { body: { proposalId, decision: 'reject' } });
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, { body: { proposalId, decision: 'approve' } });
+    expect(res.status).toBe(409);
+  });
+});
+
+describe('vault', () => {
+  test('read and list are read-only views of the vault', async () => {
+    const app = appWithFake();
+    await vault.write('default', 'matters/acme/notes.md', 'NOTES\n');
+
+    const read = await call(app, 'GET', '/vault/read?path=matters/acme/notes.md');
+    expect(read.status).toBe(200);
+    const body = (await read.json()) as { path: string; content: string; version: string | null };
+    expect(body.content).toBe('NOTES\n');
+    expect(body.version).toBeTruthy();
+
+    const list = await call(app, 'GET', '/vault/list?dir=matters/acme');
+    expect(list.status).toBe(200);
+    const entries = (await list.json()) as Array<{ path: string; kind: string }>;
+    expect(entries).toEqual([{ path: 'matters/acme/notes.md', kind: 'file' }]);
+
+    // The vault root lists without a dir parameter.
+    const root = (await (await call(app, 'GET', '/vault/list')).json()) as Array<{ path: string }>;
+    expect(root.map(e => e.path)).toContain('matters');
+  });
+
+  test('a path that escapes the vault is 400', async () => {
+    const app = appWithFake();
+    expect((await call(app, 'GET', '/vault/read?path=../x')).status).toBe(400);
+    expect((await call(app, 'GET', '/vault/read?path=/etc/passwd')).status).toBe(400);
+    expect((await call(app, 'GET', '/vault/list?dir=..')).status).toBe(400);
+    // The store's own bookkeeping is not readable either.
+    expect((await call(app, 'GET', '/vault/read?path=.counsel/threads')).status).toBe(400);
+  });
+
+  test('a missing file is 404 and a missing path parameter is 400', async () => {
+    const app = appWithFake();
+    expect((await call(app, 'GET', '/vault/read?path=matters/none.md')).status).toBe(404);
+    expect((await call(app, 'GET', '/vault/read')).status).toBe(400);
+  });
+
+  test('writes are not exposed', async () => {
+    expect((await call(appWithFake(), 'POST', '/vault/read', { body: { path: 'x' } })).status).toBe(404);
+  });
+});
+
+/** A provider whose events arrive over a few turns of the event loop, so two
+ * overlapping requests would interleave their thread-log writes if the server
+ * did not serialize them. */
+class SlowProvider implements ModelProvider {
+  readonly id = 'slow/slow';
+  readonly kind = 'direct' as const;
+  readonly capabilities: Capabilities = {
+    tools: true,
+    caching: false,
+    thinking: false,
+    contextTokens: 1_000_000,
+    auth: 'local',
+  };
+
+  async *run(req: StepRequest): AsyncIterable<StepEvent> {
+    void req;
+    await new Promise(r => setTimeout(r, 15));
+    yield { type: 'text', text: 'slow' };
+    await new Promise(r => setTimeout(r, 15));
+    yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+  }
+}

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -1,0 +1,359 @@
+import { z } from 'zod';
+import { RouterError } from '../core/types';
+import { runStep, type CounselLoopDeps } from '../loop/counsel-loop';
+import { applyProposal } from '../loop/proposals';
+import type { ThreadEvent, ThreadHeader } from '../threads/store';
+import { normalizeVaultPath } from '../vault/knowledge-paths';
+import { isAuthorized } from './auth';
+import { sseFromEvents, type StreamEvent } from './sse';
+
+export interface ServerDeps extends CounselLoopDeps {
+  /** The bearer token every request must present (spec §4.5). */
+  token: string;
+  /** The provider `GET /health` reports as the default. Defaults to whatever
+   * the router resolves with no task. */
+  defaultProviderId?: string;
+}
+
+export type App = (req: Request) => Promise<Response>;
+
+const CreateThreadBody = z.object({ title: z.string().optional(), matter: z.string().optional() });
+
+const StepBody = z.object({
+  message: z.string().min(1),
+  task: z.string().optional(),
+  provider: z.string().optional(),
+  /** A JSON Schema, converted to zod for the provider's structured output. */
+  outputSchema: z.record(z.string(), z.unknown()).optional(),
+});
+
+const ApproveBody = z.object({
+  proposalId: z.string().min(1),
+  decision: z.enum(['approve', 'reject']),
+});
+
+function text(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+function fail(status: number, error: string, extra: Record<string, unknown> = {}): Response {
+  return json({ error, ...extra }, status);
+}
+
+/** An `HttpError` is a route saying "answer with this status" from anywhere
+ * in its body; everything else that throws becomes a 500. */
+class HttpError extends Error {
+  constructor(readonly status: number, message: string, readonly extra: Record<string, unknown> = {}) {
+    super(message);
+  }
+}
+
+/**
+ * Parses a JSON request body against `schema`. An absent body is `{}`, so a
+ * route whose fields are all optional (`POST /threads`) works with no body
+ * at all. Malformed JSON and schema violations are both 400 (spec §5).
+ */
+async function body<T>(req: Request, schema: z.ZodType<T>): Promise<T> {
+  const raw = await req.text();
+  let parsed: unknown = {};
+  if (raw.trim() !== '') {
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new HttpError(400, 'invalid JSON body');
+    }
+  }
+  const result = schema.safeParse(parsed);
+  if (!result.success) {
+    throw new HttpError(400, 'invalid request body', { issues: result.error.issues });
+  }
+  return result.data;
+}
+
+/**
+ * Reads a thread, turning the store's failure modes into status codes: a
+ * malformed id or tenant is the caller's mistake (400), a well-formed id
+ * with nothing behind it is 404, and anything else (a broken vault, a
+ * permissions problem) is a real 500 rather than a fictional 404.
+ */
+async function loadThread(deps: ServerDeps, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {
+  try {
+    return await deps.store.get(deps.tenant, id);
+  } catch (err) {
+    const message = text(err);
+    if (message.includes('invalid thread id') || message.includes('invalid tenant')) {
+      throw new HttpError(400, message);
+    }
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') throw new HttpError(404, `unknown thread: ${id}`);
+    throw err;
+  }
+}
+
+/**
+ * Answers "can this step even run?" before a single SSE byte goes out.
+ * `runStep` reports both of these as an `error` event inside a 200 stream,
+ * which is right for a failure discovered mid-run but wrong for a request
+ * that was never going to work: spec §5 wants 422 for an unknown provider
+ * id or an unsatisfiable task route, and a status code can only be chosen
+ * before the response begins.
+ */
+function checkProvider(deps: ServerDeps, opts: { provider?: string; task?: string }): void {
+  if (opts.provider !== undefined) {
+    if (!deps.providers.some(p => p.id === opts.provider)) {
+      throw new HttpError(422, `unknown provider: ${opts.provider}`);
+    }
+    return;
+  }
+  try {
+    deps.router.resolve(opts.task);
+  } catch (err) {
+    if (err instanceof RouterError) throw new HttpError(422, err.message);
+    throw err;
+  }
+}
+
+/** Vault paths from the query string get the same normalization the model's
+ * tools get, so `../` and absolute paths are rejected identically (400). */
+function vaultPath(raw: string): string {
+  try {
+    return normalizeVaultPath(raw);
+  } catch (err) {
+    throw new HttpError(400, text(err));
+  }
+}
+
+/** Maps a store failure on a normalized path: `.counsel/` is reserved (400),
+ * a missing file is 404. */
+function vaultFailure(err: unknown): never {
+  const message = text(err);
+  if (message.includes('reserved path') || message.includes('path outside vault')) {
+    throw new HttpError(400, message);
+  }
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code === 'ENOENT' || code === 'ENOTDIR') throw new HttpError(404, message);
+  throw err;
+}
+
+/**
+ * Runs one function per thread at a time. Two `POST /threads/:id/steps` on
+ * the same thread would otherwise interleave their appends — `ThreadStore`
+ * does a read-modify-write of the header on every event and has no lock —
+ * so the second request waits for the first step's stream to finish before
+ * its own run begins. Different threads never wait on each other.
+ */
+class ThreadLocks {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async acquire(key: string): Promise<() => void> {
+    const previous = this.tails.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const mine = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    const tail = previous.then(() => mine);
+    this.tails.set(key, tail);
+    await previous;
+    return () => {
+      release();
+      // Drop the entry once nobody is queued behind it, so a long-lived
+      // server does not keep a promise per thread it ever served.
+      void tail.then(() => {
+        if (this.tails.get(key) === tail) this.tails.delete(key);
+      });
+    };
+  }
+}
+
+/** Releases the thread lock when the step's stream ends — normally, by
+ * throwing, or because the client hung up and the consumer called
+ * `return()` on the generator. */
+async function* withRelease(source: AsyncIterable<StreamEvent>, release: () => void): AsyncIterable<StreamEvent> {
+  try {
+    yield* source;
+  } finally {
+    release();
+  }
+}
+
+/**
+ * The whole HTTP surface (spec §4.5) as a plain fetch handler: no socket, no
+ * Bun.serve, so the route tests drive it directly with `Request` objects.
+ * `serve.ts` is the only thing that binds it to a port.
+ */
+export function createApp(deps: ServerDeps): App {
+  const locks = new ThreadLocks();
+
+  const defaultProviderId = (): string | null => {
+    if (deps.defaultProviderId !== undefined) return deps.defaultProviderId;
+    try {
+      return deps.router.resolve().id;
+    } catch {
+      return null;
+    }
+  };
+
+  const health = (): Response =>
+    json({
+      vault: deps.vaultRoot,
+      tenant: deps.tenant,
+      providers: deps.providers.map(p => ({
+        id: p.id,
+        kind: p.kind,
+        auth: p.capabilities.auth,
+        capabilities: p.capabilities,
+      })),
+      default: defaultProviderId(),
+    });
+
+  const createThread = async (req: Request): Promise<Response> => {
+    const init = await body(req, CreateThreadBody);
+    return json(await deps.store.create(deps.tenant, init), 201);
+  };
+
+  const getThread = async (id: string): Promise<Response> => json(await loadThread(deps, id));
+
+  const deleteThread = async (id: string): Promise<Response> => {
+    await loadThread(deps, id);
+    await deps.store.remove(deps.tenant, id);
+    return new Response(null, { status: 204 });
+  };
+
+  const steps = async (req: Request, id: string): Promise<Response> => {
+    const input = await body(req, StepBody);
+    await loadThread(deps, id);
+    checkProvider(deps, input);
+
+    let outputSchema: z.ZodType<unknown> | undefined;
+    if (input.outputSchema) {
+      try {
+        outputSchema = z.fromJSONSchema(input.outputSchema as Record<string, unknown>) as z.ZodType<unknown>;
+      } catch (err) {
+        throw new HttpError(400, `invalid outputSchema: ${text(err)}`);
+      }
+    }
+
+    const release = await locks.acquire(`${deps.tenant}/${id}`);
+    try {
+      const events = runStep(deps, {
+        threadId: id,
+        message: input.message,
+        ...(input.task === undefined ? {} : { task: input.task }),
+        ...(input.provider === undefined ? {} : { providerId: input.provider }),
+        ...(outputSchema === undefined ? {} : { outputSchema }),
+      });
+      return await sseFromEvents(withRelease(events, release));
+    } catch (err) {
+      release();
+      throw err;
+    }
+  };
+
+  const approve = async (req: Request, id: string): Promise<Response> => {
+    const input = await body(req, ApproveBody);
+    await loadThread(deps, id);
+
+    let result;
+    try {
+      result = await applyProposal(deps.store, deps.vault, deps.tenant, id, input.proposalId, input.decision);
+    } catch (err) {
+      const message = text(err);
+      if (message.startsWith('unknown proposal:')) throw new HttpError(404, message);
+      throw err;
+    }
+
+    if (result.status === 'conflict') {
+      return fail(409, `vault conflict on ${await proposalPath(deps, id, input.proposalId)}`, { conflict: result.conflict });
+    }
+    // The proposal had already been decided — the earlier decision stands
+    // and nothing was written.
+    if ('error' in result) {
+      return fail(409, result.error, { proposal: await findProposal(deps, id, input.proposalId) });
+    }
+    return json({
+      proposal: await findProposal(deps, id, input.proposalId),
+      ...(result.status === 'approved' ? { version: result.version } : {}),
+    });
+  };
+
+  const vaultRead = async (url: URL): Promise<Response> => {
+    const raw = url.searchParams.get('path');
+    if (raw === null || raw === '') throw new HttpError(400, 'path is required');
+    const path = vaultPath(raw);
+    try {
+      return json({ path, content: await deps.vault.read(deps.tenant, path), version: await deps.vault.version(deps.tenant, path) });
+    } catch (err) {
+      vaultFailure(err);
+    }
+  };
+
+  const vaultList = async (url: URL): Promise<Response> => {
+    const dir = vaultPath(url.searchParams.get('dir') ?? '.');
+    try {
+      return json(await deps.vault.list(deps.tenant, dir));
+    } catch (err) {
+      vaultFailure(err);
+    }
+  };
+
+  return async function app(req: Request): Promise<Response> {
+    try {
+      if (!isAuthorized(req, deps.token)) return fail(401, 'unauthorized');
+
+      const url = new URL(req.url);
+      const segments = url.pathname.split('/').filter(s => s !== '');
+      const [first, second, third] = segments;
+      const { method } = req;
+
+      if (segments.length === 1 && first === 'health' && method === 'GET') return health();
+
+      if (segments.length === 1 && first === 'threads') {
+        if (method === 'GET') return json(await deps.store.list(deps.tenant));
+        if (method === 'POST') return await createThread(req);
+      }
+
+      if (segments.length === 2 && first === 'threads' && second !== undefined) {
+        if (method === 'GET') return await getThread(second);
+        if (method === 'DELETE') return await deleteThread(second);
+      }
+
+      if (segments.length === 3 && first === 'threads' && second !== undefined && method === 'POST') {
+        if (third === 'steps') return await steps(req, second);
+        if (third === 'approve') return await approve(req, second);
+      }
+
+      if (segments.length === 2 && first === 'vault' && method === 'GET') {
+        if (second === 'read') return await vaultRead(url);
+        if (second === 'list') return await vaultList(url);
+      }
+
+      return fail(404, `no route for ${method} ${url.pathname}`);
+    } catch (err) {
+      if (err instanceof HttpError) return fail(err.status, err.message, err.extra);
+      return fail(500, text(err));
+    }
+  };
+}
+
+/** The path a proposal targets, for the conflict message. */
+async function proposalPath(deps: ServerDeps, threadId: string, proposalId: string): Promise<string> {
+  return (await findProposal(deps, threadId, proposalId))?.path ?? 'the proposed path';
+}
+
+/** The proposal event as it now stands, which is what `POST /approve`
+ * answers with (spec §4.5: "updated proposal event"). */
+async function findProposal(
+  deps: ServerDeps,
+  threadId: string,
+  proposalId: string,
+): Promise<Extract<ThreadEvent, { t: 'proposal' }> | null> {
+  const { events } = await deps.store.get(deps.tenant, threadId);
+  return (
+    events.find(
+      (ev): ev is Extract<ThreadEvent, { t: 'proposal' }> => 't' in ev && ev.t === 'proposal' && ev.id === proposalId,
+    ) ?? null
+  );
+}

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -134,6 +134,10 @@ function vaultFailure(err: unknown): never {
     throw new HttpError(400, message);
   }
   const code = (err as NodeJS.ErrnoException).code;
+  // EISDIR: `/vault/read` was pointed at a directory (and ENOTDIR, a file
+  // used as one). The path is well-formed but names the wrong kind of thing
+  // — the caller's mistake, not a missing file.
+  if (code === 'EISDIR') throw new HttpError(400, message);
   if (code === 'ENOENT' || code === 'ENOTDIR') throw new HttpError(404, message);
   throw err;
 }
@@ -187,6 +191,18 @@ async function* withRelease(source: AsyncIterable<StreamEvent>, release: () => v
 export function createApp(deps: ServerDeps): App {
   const locks = new ThreadLocks();
 
+  /** Runs `fn` with this thread's lock held for its whole duration — for the
+   * handlers that finish inside one function. `steps` cannot use it: its work
+   * outlives the handler, so it releases when the stream ends instead. */
+  const withThreadLock = async <T>(id: string, fn: () => Promise<T>): Promise<T> => {
+    const release = await locks.acquire(`${deps.tenant}/${id}`);
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  };
+
   const defaultProviderId = (): string | null => {
     if (deps.defaultProviderId !== undefined) return deps.defaultProviderId;
     try {
@@ -216,11 +232,12 @@ export function createApp(deps: ServerDeps): App {
 
   const getThread = async (id: string): Promise<Response> => json(await loadThread(deps, id));
 
-  const deleteThread = async (id: string): Promise<Response> => {
-    await loadThread(deps, id);
-    await deps.store.remove(deps.tenant, id);
-    return new Response(null, { status: 204 });
-  };
+  const deleteThread = async (id: string): Promise<Response> =>
+    withThreadLock(id, async () => {
+      await loadThread(deps, id);
+      await deps.store.remove(deps.tenant, id);
+      return new Response(null, { status: 204 });
+    });
 
   const steps = async (req: Request, id: string): Promise<Response> => {
     const input = await body(req, StepBody);
@@ -254,6 +271,13 @@ export function createApp(deps: ServerDeps): App {
 
   const approve = async (req: Request, id: string): Promise<Response> => {
     const input = await body(req, ApproveBody);
+    // Under the thread lock: `updateProposal` rewrites the whole log
+    // (read → temp file → rename), so an approve landing mid-step would drop
+    // every event the step appended after that read.
+    return withThreadLock(id, () => decide(id, input));
+  };
+
+  const decide = async (id: string, input: z.infer<typeof ApproveBody>): Promise<Response> => {
     await loadThread(deps, id);
 
     let result;
@@ -333,7 +357,11 @@ export function createApp(deps: ServerDeps): App {
       return fail(404, `no route for ${method} ${url.pathname}`);
     } catch (err) {
       if (err instanceof HttpError) return fail(err.status, err.message, err.extra);
-      return fail(500, text(err));
+      // An unexpected failure is a bug, and its message can carry absolute
+      // paths and vault contents. The operator gets the detail on stderr;
+      // the client gets a status code.
+      console.error(`counsel-os server: ${req.method} ${req.url} failed:`, err);
+      return fail(500, 'internal error');
     }
   };
 }

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -57,6 +57,27 @@ describe('startServer', () => {
     expect(existsSync(file)).toBe(false);
   });
 
+  test('COUNSEL_OS_HOME redirects the codex homes and the provider registry', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    const home = env.COUNSEL_OS_HOME!;
+    // No `registryFile`: this is the whole point — the DEFAULT registry path
+    // has to follow the override, not the developer's real home.
+    writeFileSync(join(home, 'providers.yaml'), 'default: ollama/gemma4:e4b\n', 'utf8');
+
+    running = await startServer({ vault, pluginRoot, port: 0, env });
+
+    // Each thread's Codex home holds a copy of `auth.json`, so it must land
+    // under the home the operator pointed at, not under the real `$HOME`.
+    const threadId = '11111111-2222-4333-8444-555555555555';
+    expect(running.store.codexHomeFor(threadId)).toBe(join(home, 'codex', threadId));
+
+    const health = await fetch(`${running.url}/health`, {
+      headers: { authorization: `Bearer ${running.token}` },
+    });
+    expect(health.status).toBe(200);
+    expect(((await health.json()) as { default: string }).default).toBe('ollama/gemma4:e4b');
+  });
+
   test('a busy default port falls through to an OS-assigned one', async () => {
     const a = fixture();
     const b = fixture();

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { counselHome, runtimeFilePath, startServer, type RunningServer, type RuntimeFile } from './serve';
+
+let running: RunningServer | undefined;
+
+afterEach(async () => {
+  await running?.stop();
+  running = undefined;
+});
+
+function fixture(): { vault: string; pluginRoot: string; env: NodeJS.ProcessEnv } {
+  const vault = mkdtempSync(join(tmpdir(), 'serve-vault-'));
+  const pluginRoot = mkdtempSync(join(tmpdir(), 'serve-plugin-'));
+  mkdirSync(join(pluginRoot, 'skills', 'counsel'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'skills', 'counsel', 'SKILL.md'), '---\nname: counsel\n---\n\nBODY.\n', 'utf8');
+  const home = mkdtempSync(join(tmpdir(), 'serve-home-'));
+  return { vault, pluginRoot, env: { ...process.env, COUNSEL_OS_HOME: home } };
+}
+
+describe('startServer', () => {
+  test('binds loopback, publishes runtime.json 0600, and cleans it up on stop', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    running = await startServer({
+      vault,
+      pluginRoot,
+      port: 0,
+      env,
+      registryFile: join(vault, 'no-such-providers.yaml'),
+    });
+
+    const file = runtimeFilePath(env);
+    expect(counselHome(env)).toBe(env.COUNSEL_OS_HOME!);
+    expect(existsSync(file)).toBe(true);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+
+    const contents = JSON.parse(readFileSync(file, 'utf8')) as RuntimeFile;
+    expect(contents.port).toBe(running.port);
+    expect(contents.token).toBe(running.token);
+    expect(contents.vault).toBe(vault);
+    expect(contents.pid).toBe(process.pid);
+    expect(Number.isNaN(Date.parse(contents.startedAt))).toBe(false);
+
+    // The published token is the one the server actually accepts, and it is
+    // required.
+    const health = await fetch(`${running.url}/health`, {
+      headers: { authorization: `Bearer ${contents.token}` },
+    });
+    expect(health.status).toBe(200);
+    expect(((await health.json()) as { vault: string }).vault).toBe(vault);
+    expect((await fetch(`${running.url}/health`)).status).toBe(401);
+
+    await running.stop();
+    running = undefined;
+    expect(existsSync(file)).toBe(false);
+  });
+
+  test('a busy default port falls through to an OS-assigned one', async () => {
+    const a = fixture();
+    const b = fixture();
+    // No explicit port: the first takes DEFAULT_PORT (unless something else
+    // already holds it, in which case both fall through), the second must
+    // land somewhere else rather than failing to start.
+    const first = await startServer({ vault: a.vault, pluginRoot: a.pluginRoot, env: a.env, registryFile: join(a.vault, 'none.yaml') });
+    const second = await startServer({ vault: b.vault, pluginRoot: b.pluginRoot, env: b.env, registryFile: join(b.vault, 'none.yaml') });
+    try {
+      expect(second.port).not.toBe(first.port);
+      const health = await fetch(`${second.url}/health`, { headers: { authorization: `Bearer ${second.token}` } });
+      expect(health.status).toBe(200);
+    } finally {
+      await first.stop();
+      await second.stop();
+    }
+  });
+
+  test('a fresh token per process', async () => {
+    const a = fixture();
+    const b = fixture();
+    const first = await startServer({ vault: a.vault, pluginRoot: a.pluginRoot, port: 0, env: a.env, registryFile: join(a.vault, 'none.yaml') });
+    const second = await startServer({ vault: b.vault, pluginRoot: b.pluginRoot, port: 0, env: b.env, registryFile: join(b.vault, 'none.yaml') });
+    try {
+      expect(first.token).not.toBe(second.token);
+      expect(first.port).not.toBe(second.port);
+      // One server's token is no good at the other.
+      const crossed = await fetch(`${second.url}/health`, { headers: { authorization: `Bearer ${first.token}` } });
+      expect(crossed.status).toBe(401);
+    } finally {
+      await first.stop();
+      await second.stop();
+    }
+  });
+});

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { counselHome, runtimeFilePath, startServer, type RunningServer, type RuntimeFile } from './serve';
@@ -73,6 +73,38 @@ describe('startServer', () => {
       await first.stop();
       await second.stop();
     }
+  });
+
+  test('a runtime.json another process now owns survives stop()', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+    const file = runtimeFilePath(env);
+
+    // A second `serve` took over the handshake: the file now points at that
+    // server. This one shutting down must not delete the live server's file
+    // and leave the adapter with nothing to read.
+    const theirs = { port: 9999, token: 'theirs', vault, pid: process.pid + 1, startedAt: new Date().toISOString() };
+    writeFileSync(file, JSON.stringify(theirs), 'utf8');
+
+    await running.stop();
+    running = undefined;
+    expect(existsSync(file)).toBe(true);
+    expect((JSON.parse(readFileSync(file, 'utf8')) as RuntimeFile).token).toBe('theirs');
+  });
+
+  test('a leftover world-readable runtime.json ends up 0600', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    const file = runtimeFilePath(env);
+    mkdirSync(join(file, '..'), { recursive: true });
+    writeFileSync(file, '{"stale":true}', 'utf8');
+    chmodSync(file, 0o644);
+
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+
+    // writeFileSync's mode applies only on create, so an overwrite in place
+    // would have kept 0644 and published the token to every local account.
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+    expect((JSON.parse(readFileSync(file, 'utf8')) as RuntimeFile).token).toBe(running.token);
   });
 
   test('a fresh token per process', async () => {

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from 'node:crypto';
-import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { DEFAULT_TENANT } from '../core/types';
@@ -108,13 +108,38 @@ function listen(port: number | undefined, fetch: (req: Request) => Promise<Respo
   }
 }
 
-/** Writes `runtime.json` 0600: it holds the bearer token. `writeFileSync`'s
- * mode only applies when it creates the file, so an existing one (a previous
- * run's, possibly with looser bits) is chmod'ed too. */
+/**
+ * Publishes `runtime.json`, which holds the bearer token, so two properties
+ * have to hold at once.
+ *
+ * 0600: `writeFileSync`'s mode applies only when it creates the file, so a
+ * leftover world-readable file from an earlier run would keep its mode and
+ * quietly publish the token. Writing a fresh temp file and renaming over the
+ * old one replaces the inode, mode and all.
+ *
+ * Atomic: a reader (the plugin adapter, on every skill invocation) must
+ * never catch a half-written file. `rename` within a directory is atomic, so
+ * a reader sees either the old file or the new one.
+ */
 function writeRuntimeFile(path: string, contents: RuntimeFile): void {
   mkdirSync(join(path, '..'), { recursive: true, mode: 0o700 });
-  writeFileSync(path, JSON.stringify(contents, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
-  chmodSync(path, 0o600);
+  // Named for this process: two servers starting at once must not write the
+  // same temp file.
+  const tmp = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmp, JSON.stringify(contents, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+}
+
+/** Reads the pid out of a `runtime.json`, or `null` when there is nothing
+ * readable and parseable there. */
+function runtimeFileOwner(path: string): number | null {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<RuntimeFile>;
+    return typeof parsed.pid === 'number' ? parsed.pid : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -159,6 +184,12 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
     if (removed) return;
     removed = true;
     try {
+      // Only if the file is still OURS. A second `serve` overwrites the
+      // handshake and becomes the runtime the adapter talks to; this one
+      // shutting down afterwards must not delete the live server's file and
+      // leave the adapter with nothing. A file we cannot read or parse is
+      // not provably ours either, so it stays.
+      if (runtimeFileOwner(file) !== process.pid) return;
       rmSync(file, { force: true });
     } catch {
       /* best effort — the process is going away either way */

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'node:crypto';
 import { chmodSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
+import { counselHome } from '../core/home';
 import { DEFAULT_TENANT } from '../core/types';
 import { loadRegistry } from '../providers/registry';
 import { ThreadStore } from '../threads/store';
@@ -27,7 +27,7 @@ export interface StartServerOptions {
   /** Where `skills/`, `primitives/`, and `scripts/` live. Defaults to the
    * repo root, or `COUNSEL_PLUGIN_ROOT` for an installed-plugin layout. */
   pluginRoot?: string;
-  /** Overrides `~/.counsel-os/providers.yaml`. */
+  /** Overrides `<counselHome>/providers.yaml`. */
   registryFile?: string;
   env?: NodeJS.ProcessEnv;
 }
@@ -37,14 +37,26 @@ export interface RunningServer {
   token: string;
   vault: string;
   url: string;
+  /** The thread store this server is serving from — exposed so a caller (and
+   * the tests) can see where thread state, including each thread's Codex
+   * home, actually lands. */
+  store: ThreadStore;
   /** Stops listening and removes `runtime.json`. */
   stop(): Promise<void>;
 }
 
 /** `~/.counsel-os`, or `COUNSEL_OS_HOME` — the override the tests use so they
- * never touch the developer's real runtime file. */
-export function counselHome(env: NodeJS.ProcessEnv = process.env): string {
-  return env.COUNSEL_OS_HOME ?? join(homedir(), '.counsel-os');
+ * never touch the developer's real runtime file. Defined in `core/home.ts`
+ * (the registry needs it too, without a server dependency) and re-exported
+ * here, where it has always been imported from. */
+export { counselHome };
+
+/** Where each thread's persistent Codex home lives. Under `counselHome`, not
+ * unconditionally under the real `$HOME`: these directories hold a copy of
+ * the operator's `auth.json`, so they belong wherever the operator pointed
+ * the runtime's state. */
+export function codexHomeRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return join(counselHome(env), 'codex');
 }
 
 /** The handshake file the plugin adapter reads (spec §4.7). */
@@ -160,13 +172,17 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
   });
 
   const token = randomBytes(32).toString('hex');
+  // The store is given the environment's codex root explicitly: its own
+  // default is the real `$HOME`, which would ignore `COUNSEL_OS_HOME` and
+  // drop a copy of `auth.json` somewhere the operator never pointed at.
+  const store = new ThreadStore(vaultRoot, { codexHomeRoot: codexHomeRoot(env) });
   const app = createApp({
     token,
     tenant: DEFAULT_TENANT,
     vaultRoot,
     pluginRoot,
     vault: new FsVaultStore(vaultRoot),
-    store: new ThreadStore(vaultRoot),
+    store,
     providers,
     router,
     defaultProviderId: defaultId,
@@ -210,6 +226,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
     token,
     vault: vaultRoot,
     url: `http://${HOSTNAME}:${port}`,
+    store,
     async stop(): Promise<void> {
       process.off('SIGINT', onSignal);
       process.off('SIGTERM', onSignal);

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -1,0 +1,190 @@
+import { randomBytes } from 'node:crypto';
+import { chmodSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { DEFAULT_TENANT } from '../core/types';
+import { loadRegistry } from '../providers/registry';
+import { ThreadStore } from '../threads/store';
+import { FsVaultStore } from '../vault/fs-store';
+import { resolveLegalRoot } from '../vault/resolve-root';
+import { createApp } from './routes';
+
+type BunServer = ReturnType<typeof Bun.serve>;
+
+/** The port the plugin adapter tries first. `runtime.json` is what actually
+ * tells a client where the server is, so falling off it is not fatal. */
+export const DEFAULT_PORT = 7431;
+
+/** Loopback only (spec §4.5). Nothing here is safe on a public interface. */
+export const HOSTNAME = '127.0.0.1';
+
+export interface StartServerOptions {
+  /** Vault root. Omitted → `resolveLegalRoot()`, the shared discovery algorithm. */
+  vault?: string;
+  /** Bind port. Omitted → `DEFAULT_PORT`, falling back to an OS-assigned one
+   * when it is busy. An explicit port is never silently substituted. */
+  port?: number;
+  /** Where `skills/`, `primitives/`, and `scripts/` live. Defaults to the
+   * repo root, or `COUNSEL_PLUGIN_ROOT` for an installed-plugin layout. */
+  pluginRoot?: string;
+  /** Overrides `~/.counsel-os/providers.yaml`. */
+  registryFile?: string;
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface RunningServer {
+  port: number;
+  token: string;
+  vault: string;
+  url: string;
+  /** Stops listening and removes `runtime.json`. */
+  stop(): Promise<void>;
+}
+
+/** `~/.counsel-os`, or `COUNSEL_OS_HOME` — the override the tests use so they
+ * never touch the developer's real runtime file. */
+export function counselHome(env: NodeJS.ProcessEnv = process.env): string {
+  return env.COUNSEL_OS_HOME ?? join(homedir(), '.counsel-os');
+}
+
+/** The handshake file the plugin adapter reads (spec §4.7). */
+export function runtimeFilePath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(counselHome(env), 'runtime.json');
+}
+
+export interface RuntimeFile {
+  port: number;
+  token: string;
+  vault: string;
+  pid: number;
+  startedAt: string;
+}
+
+/**
+ * The plugin root: `COUNSEL_PLUGIN_ROOT` when set (an installed plugin puts
+ * `skills/` somewhere else entirely), otherwise the repo root — three levels
+ * up from `runtime/src/server/`.
+ */
+export function defaultPluginRoot(env: NodeJS.ProcessEnv = process.env): string {
+  return env.COUNSEL_PLUGIN_ROOT ?? resolve(import.meta.dir, '../../..');
+}
+
+/**
+ * Resolves the vault, or exits the way `scripts/resolve_legal_root.sh` does:
+ * the same messages on stderr and the same 1/2 exit codes, so a user who has
+ * seen one has seen both. `--vault` skips discovery entirely.
+ */
+export function resolveVaultOrExit(opts: StartServerOptions): string {
+  if (opts.vault) return resolve(opts.vault);
+  const env = opts.env ?? process.env;
+  const found = resolveLegalRoot({ env });
+  if (found.ok) return found.root;
+  if (found.code === 2) {
+    console.error('Multiple Counsel OS legal roots found. Set COUNSEL_OS_LEGAL_ROOT to choose one:');
+    for (const root of found.candidates) console.error(`  ${root}`);
+    process.exit(2);
+  }
+  if (env.COUNSEL_OS_LEGAL_ROOT) {
+    console.error(`COUNSEL_OS_LEGAL_ROOT is not a marked Counsel OS legal root: ${env.COUNSEL_OS_LEGAL_ROOT}`);
+  } else {
+    console.error('No Counsel OS legal root found. Set COUNSEL_OS_LEGAL_ROOT, or run /counsel-os:setup.');
+  }
+  process.exit(1);
+}
+
+/**
+ * Binds the app. The default port is a convenience, not a requirement — a
+ * second runtime, or anything else already on 7431, falls through to an
+ * OS-assigned port and publishes it in `runtime.json`. A port the caller
+ * asked for explicitly is never substituted: they asked for that one.
+ */
+function listen(port: number | undefined, fetch: (req: Request) => Promise<Response>): BunServer {
+  const serve = (p: number): BunServer => Bun.serve({ hostname: HOSTNAME, port: p, fetch, idleTimeout: 0 });
+  if (port !== undefined) return serve(port);
+  try {
+    return serve(DEFAULT_PORT);
+  } catch {
+    return serve(0);
+  }
+}
+
+/** Writes `runtime.json` 0600: it holds the bearer token. `writeFileSync`'s
+ * mode only applies when it creates the file, so an existing one (a previous
+ * run's, possibly with looser bits) is chmod'ed too. */
+function writeRuntimeFile(path: string, contents: RuntimeFile): void {
+  mkdirSync(join(path, '..'), { recursive: true, mode: 0o700 });
+  writeFileSync(path, JSON.stringify(contents, null, 2) + '\n', { encoding: 'utf8', mode: 0o600 });
+  chmodSync(path, 0o600);
+}
+
+/**
+ * Starts the local runtime: resolve the vault, load the provider registry,
+ * bind loopback, and publish `runtime.json` for the plugin adapter.
+ *
+ * The token is fresh per process — it lives only in that file (0600) and in
+ * memory, so stopping the server ends every credential it issued.
+ */
+export async function startServer(opts: StartServerOptions = {}): Promise<RunningServer> {
+  const env = opts.env ?? process.env;
+  const vaultRoot = resolveVaultOrExit(opts);
+  const pluginRoot = opts.pluginRoot ?? defaultPluginRoot(env);
+  const { providers, router, defaultId } = loadRegistry({
+    vaultRoot,
+    env,
+    ...(opts.registryFile === undefined ? {} : { file: opts.registryFile }),
+  });
+
+  const token = randomBytes(32).toString('hex');
+  const app = createApp({
+    token,
+    tenant: DEFAULT_TENANT,
+    vaultRoot,
+    pluginRoot,
+    vault: new FsVaultStore(vaultRoot),
+    store: new ThreadStore(vaultRoot),
+    providers,
+    router,
+    defaultProviderId: defaultId,
+  });
+
+  const server = listen(opts.port, app);
+  const port = server.port ?? opts.port ?? DEFAULT_PORT;
+  const file = runtimeFilePath(env);
+  writeRuntimeFile(file, { port, token, vault: vaultRoot, pid: process.pid, startedAt: new Date().toISOString() });
+
+  // The handshake file must not outlive the process that owns it: a stale
+  // one sends the adapter at a dead port with a dead token.
+  let removed = false;
+  const removeFile = (): void => {
+    if (removed) return;
+    removed = true;
+    try {
+      rmSync(file, { force: true });
+    } catch {
+      /* best effort — the process is going away either way */
+    }
+  };
+  const onSignal = (): void => {
+    removeFile();
+    process.exit(0);
+  };
+  process.on('SIGINT', onSignal);
+  process.on('SIGTERM', onSignal);
+  process.on('exit', removeFile);
+
+  console.log(`counsel-os runtime on http://${HOSTNAME}:${port} (vault: ${vaultRoot})`);
+
+  return {
+    port,
+    token,
+    vault: vaultRoot,
+    url: `http://${HOSTNAME}:${port}`,
+    async stop(): Promise<void> {
+      process.off('SIGINT', onSignal);
+      process.off('SIGTERM', onSignal);
+      process.off('exit', removeFile);
+      removeFile();
+      await server.stop(true);
+    },
+  };
+}

--- a/runtime/src/server/sse.test.ts
+++ b/runtime/src/server/sse.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, test } from 'bun:test';
+import type { StepEvent } from '../core/types';
+import { NO_TERMINAL_EVENT, sseFromEvents } from './sse';
+
+type Ev = StepEvent & { runId?: string };
+
+interface Frame {
+  event: string;
+  data: Record<string, unknown>;
+}
+
+/** Parses an SSE body back into frames. Deliberately dumb: the point is to
+ * assert the wire format this module promises, not to re-use its encoder. */
+function parseSse(text: string): Frame[] {
+  return text
+    .split('\n\n')
+    .filter(block => block.trim() !== '')
+    .map(block => {
+      const lines = block.split('\n');
+      const eventLine = lines.find(l => l.startsWith('event: '));
+      if (!eventLine) throw new Error(`frame has no event line: ${block}`);
+      const data = lines
+        .filter(l => l.startsWith('data: '))
+        .map(l => l.slice('data: '.length))
+        .join('\n');
+      return { event: eventLine.slice('event: '.length), data: JSON.parse(data) as Record<string, unknown> };
+    });
+}
+
+async function* from(events: Ev[]): AsyncIterable<Ev> {
+  for (const ev of events) yield ev;
+}
+
+async function frames(res: Response): Promise<Frame[]> {
+  return parseSse(await res.text());
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms));
+
+describe('sseFromEvents', () => {
+  test('coalesces adjacent text deltas and flushes them before any other event', async () => {
+    const res = await sseFromEvents(
+      from([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: 'b' },
+        { type: 'tool_call', id: 't1', name: 'vault_read', input: { path: 'x.md' } },
+        { type: 'text', text: 'c' },
+        { type: 'done', output: null, usage: { inputTokens: 1, outputTokens: 2 } },
+      ]),
+      { coalesceMs: 0 },
+    );
+
+    const got = await frames(res);
+    expect(got.map(f => f.event)).toEqual(['text', 'tool_call', 'text', 'done']);
+    expect(got[0]!.data['text']).toBe('ab');
+    expect(got[2]!.data['text']).toBe('c');
+    expect(got[1]!.data['name']).toBe('vault_read');
+  });
+
+  test('is a text/event-stream carrying the first event\'s runId', async () => {
+    const res = await sseFromEvents(
+      from([
+        { type: 'text', text: 'hi', runId: 'run-1' },
+        { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 }, runId: 'run-1' },
+      ]),
+      { coalesceMs: 0 },
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/event-stream');
+    expect(res.headers.get('x-run-id')).toBe('run-1');
+    expect((await frames(res)).map(f => f.event)).toEqual(['text', 'done']);
+  });
+
+  test('flushes on the size bound', async () => {
+    const res = await sseFromEvents(
+      from([
+        { type: 'text', text: 'a' },
+        { type: 'text', text: 'b' },
+        { type: 'text', text: 'c' },
+        { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } },
+      ]),
+      { coalesceMs: 0, maxChars: 2 },
+    );
+
+    const got = await frames(res);
+    expect(got.map(f => f.event)).toEqual(['text', 'text', 'done']);
+    expect(got[0]!.data['text']).toBe('ab');
+    expect(got[1]!.data['text']).toBe('c');
+  });
+
+  test('flushes on the timer when the source goes quiet', async () => {
+    async function* slow(): AsyncIterable<Ev> {
+      yield { type: 'text', text: 'a' };
+      await sleep(60);
+      yield { type: 'text', text: 'b' };
+      yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+    }
+
+    const got = await frames(await sseFromEvents(slow(), { coalesceMs: 10 }));
+    expect(got.map(f => f.event)).toEqual(['text', 'text', 'done']);
+    expect(got[0]!.data['text']).toBe('a');
+    expect(got[1]!.data['text']).toBe('b');
+  });
+
+  test('a source that ends without a terminal event still ends with error', async () => {
+    const got = await frames(
+      await sseFromEvents(from([{ type: 'text', text: 'half a sentence' }]), { coalesceMs: 0 }),
+    );
+
+    expect(got.map(f => f.event)).toEqual(['text', 'error']);
+    expect(got.at(-1)!.data['message']).toBe(NO_TERMINAL_EVENT);
+  });
+
+  test('a source that throws mid-stream ends with error, buffered text first', async () => {
+    async function* boom(): AsyncIterable<Ev> {
+      yield { type: 'text', text: 'partial' };
+      throw new Error('provider exploded');
+    }
+
+    const got = await frames(await sseFromEvents(boom(), { coalesceMs: 0 }));
+    expect(got.map(f => f.event)).toEqual(['text', 'error']);
+    expect(got[0]!.data['text']).toBe('partial');
+    expect(got[1]!.data['message']).toBe('provider exploded');
+  });
+
+  test('a source that throws before its first event still yields a terminal error', async () => {
+    async function* boom(): AsyncIterable<Ev> {
+      throw new Error('could not start');
+      yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } };
+    }
+
+    const got = await frames(await sseFromEvents(boom(), { coalesceMs: 0 }));
+    expect(got.map(f => f.event)).toEqual(['error']);
+    expect(got[0]!.data['message']).toBe('could not start');
+  });
+
+  test('an empty source ends with error', async () => {
+    const got = await frames(await sseFromEvents(from([]), { coalesceMs: 0 }));
+    expect(got.map(f => f.event)).toEqual(['error']);
+  });
+});

--- a/runtime/src/server/sse.test.ts
+++ b/runtime/src/server/sse.test.ts
@@ -89,7 +89,7 @@ describe('sseFromEvents', () => {
     expect(got[1]!.data['text']).toBe('c');
   });
 
-  test('flushes on the timer when the source goes quiet', async () => {
+  test('flushes on the max-latency timer, without waiting for the source to finish', async () => {
     async function* slow(): AsyncIterable<Ev> {
       yield { type: 'text', text: 'a' };
       await sleep(60);

--- a/runtime/src/server/sse.ts
+++ b/runtime/src/server/sse.ts
@@ -4,9 +4,12 @@ import type { StepEvent } from '../core/types';
 export type StreamEvent = StepEvent & { runId?: string };
 
 export interface SseOptions {
-  /** Quiet time after which buffered text deltas are flushed. `0` disables
-   * the timer, so text then flushes only on the size bound or on the next
-   * non-text event — what the tests use to get deterministic frames. */
+  /** How long a text delta may sit in the buffer before it goes out: the
+   * timer starts when the buffer stops being empty and is NOT restarted by
+   * later deltas, so it bounds latency rather than waiting for a quiet gap —
+   * a provider streaming steadily still flushes every `coalesceMs`. `0`
+   * disables it, leaving the size bound and non-text events as the only
+   * flushes, which is what makes the tests deterministic. */
   coalesceMs?: number;
   /** Buffered characters after which text is flushed regardless of the timer. */
   maxChars?: number;
@@ -33,7 +36,7 @@ function frame(ev: StreamEvent): string {
 /**
  * Renders a step's events as `text/event-stream`.
  *
- * Text deltas are coalesced — buffered until the stream goes quiet for
+ * Text deltas are coalesced — buffered until the oldest one has waited
  * `coalesceMs`, until `maxChars` have piled up, or until any non-text event
  * needs to go out (the buffer is flushed first, so a `tool_call` never
  * overtakes the text that preceded it).

--- a/runtime/src/server/sse.ts
+++ b/runtime/src/server/sse.ts
@@ -1,0 +1,164 @@
+import type { StepEvent } from '../core/types';
+
+/** What the loop yields: a `StepEvent` tagged with the run that produced it. */
+export type StreamEvent = StepEvent & { runId?: string };
+
+export interface SseOptions {
+  /** Quiet time after which buffered text deltas are flushed. `0` disables
+   * the timer, so text then flushes only on the size bound or on the next
+   * non-text event — what the tests use to get deterministic frames. */
+  coalesceMs?: number;
+  /** Buffered characters after which text is flushed regardless of the timer. */
+  maxChars?: number;
+}
+
+/** Spec §2: Ollama streams per token; the UI must not. */
+export const DEFAULT_COALESCE_MS = 50;
+export const DEFAULT_MAX_CHARS = 200;
+
+/** The synthesized terminal for a source that just stopped (spec §5: never a
+ * dropped connection without a terminal event). */
+export const NO_TERMINAL_EVENT = 'provider ended without a terminal event';
+
+function message(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** One SSE frame: the event type on the `event:` line, the whole event object
+ * (type included, so a client can switch on either) as JSON on `data:`. */
+function frame(ev: StreamEvent): string {
+  return `event: ${ev.type}\ndata: ${JSON.stringify(ev)}\n\n`;
+}
+
+/**
+ * Renders a step's events as `text/event-stream`.
+ *
+ * Text deltas are coalesced — buffered until the stream goes quiet for
+ * `coalesceMs`, until `maxChars` have piled up, or until any non-text event
+ * needs to go out (the buffer is flushed first, so a `tool_call` never
+ * overtakes the text that preceded it).
+ *
+ * The stream ALWAYS ends with a `done` or an `error`: a source that throws
+ * ends with the thrown message, and a source that simply stops gets
+ * `NO_TERMINAL_EVENT` synthesized. A client can therefore treat a closed
+ * connection with no terminal frame as a transport failure, never as a
+ * finished step.
+ *
+ * The first event is read before the `Response` is constructed — that is
+ * what puts its `runId` in the `x-run-id` header — so this returns a
+ * promise. Everything after it streams.
+ */
+export async function sseFromEvents(
+  source: AsyncIterable<StreamEvent>,
+  opts: SseOptions = {},
+): Promise<Response> {
+  const coalesceMs = opts.coalesceMs ?? DEFAULT_COALESCE_MS;
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+
+  const it = source[Symbol.asyncIterator]();
+  let first: IteratorResult<StreamEvent> | undefined;
+  let startupError: string | undefined;
+  try {
+    first = await it.next();
+  } catch (err) {
+    startupError = message(err);
+  }
+  const runId = first && !first.done ? first.value.runId : undefined;
+
+  const encoder = new TextEncoder();
+  // Hoisted out of `start` so `cancel` can stop the pump: after the client
+  // hangs up, an `enqueue`/`close` on the controller throws.
+  let closed = false;
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      let buffer = '';
+      let bufferRunId: string | undefined;
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const send = (ev: StreamEvent): void => {
+        if (closed) return;
+        controller.enqueue(encoder.encode(frame(ev)));
+      };
+
+      const flush = (): void => {
+        if (timer !== undefined) {
+          clearTimeout(timer);
+          timer = undefined;
+        }
+        if (buffer === '') return;
+        const text = buffer;
+        const evRunId = bufferRunId;
+        buffer = '';
+        bufferRunId = undefined;
+        send({ type: 'text', text, ...(evRunId === undefined ? {} : { runId: evRunId }) });
+      };
+
+      const bufferText = (ev: Extract<StreamEvent, { type: 'text' }>): void => {
+        buffer += ev.text;
+        bufferRunId ??= ev.runId;
+        if (buffer.length >= maxChars) {
+          flush();
+        } else if (coalesceMs > 0 && timer === undefined) {
+          timer = setTimeout(() => {
+            timer = undefined;
+            flush();
+          }, coalesceMs);
+        }
+      };
+
+      const pump = async (): Promise<void> => {
+        let sawTerminal = false;
+        try {
+          if (startupError !== undefined) {
+            send({ type: 'error', message: startupError });
+            sawTerminal = true;
+          } else {
+            for (let next = first!; !next.done; next = await it.next()) {
+              const ev = next.value;
+              if (ev.type === 'text') {
+                bufferText(ev);
+                continue;
+              }
+              flush();
+              send(ev);
+              if (ev.type === 'done' || ev.type === 'error') sawTerminal = true;
+            }
+          }
+        } catch (err) {
+          flush();
+          send({ type: 'error', message: message(err) });
+          sawTerminal = true;
+        }
+        flush();
+        if (!sawTerminal) send({ type: 'error', message: NO_TERMINAL_EVENT });
+        if (!closed) {
+          closed = true;
+          controller.close();
+        }
+      };
+
+      // Detached on purpose: the source is drained as fast as it produces,
+      // rather than one event per reader pull. A step's events are small and
+      // few, and draining them promptly is what lets the caller release its
+      // per-thread lock as soon as the step is really over.
+      void pump();
+    },
+    cancel(): void {
+      // The client hung up: stop the provider rather than run it to
+      // completion into a socket nobody is reading.
+      closed = true;
+      void it.return?.(undefined);
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: {
+      'content-type': 'text/event-stream',
+      'cache-control': 'no-cache',
+      connection: 'keep-alive',
+      'x-accel-buffering': 'no',
+      ...(runId === undefined ? {} : { 'x-run-id': runId }),
+    },
+  });
+}

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -55,6 +55,27 @@ describe('ThreadStore', () => {
     expect(got.header.updatedAt >= header.updatedAt).toBe(true);
   });
 
+  test('clearSession forgets one provider\'s session and leaves the others alone', async () => {
+    const header = await store.create('default', {});
+    await store.setSession('default', header.id, 'claude-sub/opus-5', 'sess-123');
+    await store.setSession('default', header.id, 'codex-sub/gpt', 'thread-456');
+
+    await store.clearSession('default', header.id, 'claude-sub/opus-5');
+
+    const got = await store.get('default', header.id);
+    expect(got.header.sessions).toEqual({ 'codex-sub/gpt': 'thread-456' });
+  });
+
+  test('clearSession on a provider with no session is a no-op', async () => {
+    const header = await store.create('default', {});
+    await store.setSession('default', header.id, 'codex-sub/gpt', 'thread-456');
+
+    await store.clearSession('default', header.id, 'claude-sub/opus-5');
+
+    const got = await store.get('default', header.id);
+    expect(got.header.sessions).toEqual({ 'codex-sub/gpt': 'thread-456' });
+  });
+
   test('updateProposal flips the status of the matching proposal event', async () => {
     const header = await store.create('default', {});
     await store.append('default', header.id, {

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test, beforeEach } from 'bun:test';
+import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -123,7 +124,30 @@ describe('ThreadStore', () => {
 
   test('codexHomeFor defaults to ~/.counsel-os/codex/<id> when codexHomeRoot is not injected', () => {
     const defaultStore = new ThreadStore(root);
-    const path = defaultStore.codexHomeFor('some-id');
-    expect(path.endsWith(join('.counsel-os', 'codex', 'some-id'))).toBe(true);
+    const id = randomUUID();
+    const path = defaultStore.codexHomeFor(id);
+    expect(path.endsWith(join('.counsel-os', 'codex', id))).toBe(true);
+  });
+
+  test('rejects a path-traversal thread id', async () => {
+    await expect(store.get('default', '../../x')).rejects.toThrow('invalid thread id');
+  });
+
+  test('rejects a path-traversal tenant', async () => {
+    await expect(store.get('../t', randomUUID())).rejects.toThrow('invalid tenant');
+  });
+
+  test('a real uuid passes id validation', async () => {
+    const header = await store.create('default', {});
+    await expect(store.get('default', header.id)).resolves.toBeDefined();
+  });
+
+  test('append on an unknown thread throws and creates no orphan .jsonl', async () => {
+    const unknownId = randomUUID();
+    await expect(
+      store.append('default', unknownId, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'hi' })
+    ).rejects.toThrow();
+
+    expect(existsSync(join(root, '.counsel', 'threads', 'default', `${unknownId}.jsonl`))).toBe(false);
   });
 });

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test, beforeEach } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ThreadStore } from './store';
+import type { ThreadEvent } from './store';
+
+let root: string;
+let codexHomeRoot: string;
+let store: ThreadStore;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'threads-'));
+  codexHomeRoot = mkdtempSync(join(tmpdir(), 'codex-'));
+  store = new ThreadStore(root, { codexHomeRoot });
+});
+
+describe('ThreadStore', () => {
+  test('create, then list, then get returns the header and no events', async () => {
+    const header = await store.create('default', { title: 'Acme NDA' });
+    expect(header.id).toBeTruthy();
+    expect(header.title).toBe('Acme NDA');
+    expect(header.sessions).toEqual({});
+    expect(header.createdAt).toBe(header.updatedAt);
+
+    const listed = await store.list('default');
+    expect(listed).toHaveLength(1);
+    expect(listed[0]).toEqual(header);
+
+    const got = await store.get('default', header.id);
+    expect(got.header).toEqual(header);
+    expect(got.events).toEqual([]);
+  });
+
+  test('append three events, then get returns them in order', async () => {
+    const header = await store.create('default', {});
+    const events: ThreadEvent[] = [
+      { t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'hello' },
+      { type: 'text', text: 'hi there', at: '2026-01-01T00:00:01.000Z' },
+      { type: 'done', output: null, usage: { inputTokens: 1, outputTokens: 1 }, at: '2026-01-01T00:00:02.000Z' },
+    ];
+    for (const ev of events) await store.append('default', header.id, ev);
+
+    const got = await store.get('default', header.id);
+    expect(got.events).toEqual(events);
+  });
+
+  test('setSession persists into the header', async () => {
+    const header = await store.create('default', {});
+    await store.setSession('default', header.id, 'claude-sub/opus-5', 'sess-123');
+
+    const got = await store.get('default', header.id);
+    expect(got.header.sessions).toEqual({ 'claude-sub/opus-5': 'sess-123' });
+    expect(got.header.updatedAt >= header.updatedAt).toBe(true);
+  });
+
+  test('updateProposal flips the status of the matching proposal event', async () => {
+    const header = await store.create('default', {});
+    await store.append('default', header.id, {
+      t: 'user',
+      at: '2026-01-01T00:00:00.000Z',
+      content: 'update the NDA',
+    });
+    await store.append('default', header.id, {
+      t: 'proposal',
+      at: '2026-01-01T00:00:01.000Z',
+      id: 'prop-1',
+      path: 'matters/acme/nda.md',
+      content: 'new content',
+      rationale: 'because',
+      status: 'pending',
+      expectedVersion: 'abc123',
+    });
+    await store.append('default', header.id, {
+      t: 'proposal',
+      at: '2026-01-01T00:00:02.000Z',
+      id: 'prop-2',
+      path: 'matters/acme/other.md',
+      content: 'other content',
+      rationale: 'because too',
+      status: 'pending',
+      expectedVersion: null,
+    });
+
+    await store.updateProposal('default', header.id, 'prop-1', 'approved');
+
+    const got = await store.get('default', header.id);
+    expect(got.events).toHaveLength(3);
+    const prop1 = got.events.find(e => 't' in e && e.t === 'proposal' && e.id === 'prop-1');
+    const prop2 = got.events.find(e => 't' in e && e.t === 'proposal' && e.id === 'prop-2');
+    expect(prop1).toMatchObject({ status: 'approved' });
+    expect(prop2).toMatchObject({ status: 'pending' });
+    // order is preserved by the rewrite
+    expect('t' in got.events[0]! && got.events[0]!.t).toBe('user');
+    expect(got.events[1]).toMatchObject({ id: 'prop-1' });
+    expect(got.events[2]).toMatchObject({ id: 'prop-2' });
+  });
+
+  test('remove deletes the header, the log, and the codex home dir', async () => {
+    const header = await store.create('default', {});
+    await store.append('default', header.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'hi' });
+
+    const codexHome = store.codexHomeFor(header.id);
+    mkdirSync(codexHome, { recursive: true });
+    writeFileSync(join(codexHome, 'session.json'), '{}', 'utf8');
+    expect(existsSync(codexHome)).toBe(true);
+
+    await store.remove('default', header.id);
+
+    expect(existsSync(join(root, '.counsel', 'threads', 'default', `${header.id}.json`))).toBe(false);
+    expect(existsSync(join(root, '.counsel', 'threads', 'default', `${header.id}.jsonl`))).toBe(false);
+    expect(existsSync(codexHome)).toBe(false);
+
+    const listed = await store.list('default');
+    expect(listed).toHaveLength(0);
+  });
+
+  test('ids of two creates differ', async () => {
+    const a = await store.create('default', {});
+    const b = await store.create('default', {});
+    expect(a.id).not.toBe(b.id);
+  });
+
+  test('codexHomeFor defaults to ~/.counsel-os/codex/<id> when codexHomeRoot is not injected', () => {
+    const defaultStore = new ThreadStore(root);
+    const path = defaultStore.codexHomeFor('some-id');
+    expect(path.endsWith(join('.counsel-os', 'codex', 'some-id'))).toBe(true);
+  });
+});

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -31,6 +31,11 @@ export interface ThreadHeader {
 export type ThreadEvent =
   | { t: 'user'; at: string; content: string }
   | { t: 'step'; at: string; runId: string; provider: string; task?: string }
+  // Spec §5's warning event: something the run recovered from, worth
+  // showing in the transcript but not an `error` and not model output. The
+  // resume-failure fallback is the first user — it records that the vendor
+  // session was gone and the step replayed the history instead.
+  | { t: 'warning'; at: string; message: string }
   | (StepEvent & { at: string })
   | {
       t: 'proposal';

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -154,6 +154,22 @@ export class ThreadStore {
     this.writeHeader(tenant, header);
   }
 
+  /**
+   * Forgets this thread's vendor session for `providerId` — the resume-failure
+   * fallback (spec §5): when a vendor reports the session/thread is gone, the
+   * loop drops the dead id and replays the log for that step instead. A
+   * provider with no stored session is left untouched.
+   */
+  async clearSession(tenant: Tenant, id: string, providerId: string): Promise<void> {
+    this.validateTenant(tenant);
+    this.validateId(id);
+    const header = this.readHeader(tenant, id);
+    if (!(providerId in header.sessions)) return;
+    delete header.sessions[providerId];
+    header.updatedAt = new Date().toISOString();
+    this.writeHeader(tenant, header);
+  }
+
   async updateProposal(
     tenant: Tenant,
     id: string,

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -12,6 +12,13 @@ import type { StepEvent, Tenant } from '../core/types';
  */
 const THREADS_DIR = join('.counsel', 'threads');
 
+// `tenant` and `id` both land directly in filesystem paths (`dir`/`headerPath`/
+// `logPath`/`codexHomeFor`). Without validation a value like `../../etc` would
+// escape the threads dir the same way `FsVaultStore` guards against for vault
+// paths. Every public method validates both before touching disk.
+const ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/;
+const TENANT_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/;
+
 export interface ThreadHeader {
   id: string;
   title?: string;
@@ -50,6 +57,14 @@ export class ThreadStore {
     this.codexHomeRoot = opts.codexHomeRoot ?? join(homedir(), '.counsel-os', 'codex');
   }
 
+  private validateTenant(tenant: Tenant): void {
+    if (!TENANT_RE.test(tenant)) throw new Error('invalid tenant');
+  }
+
+  private validateId(id: string): void {
+    if (!ID_RE.test(id)) throw new Error('invalid thread id');
+  }
+
   private dir(tenant: Tenant): string {
     return join(this.root, THREADS_DIR, tenant);
   }
@@ -62,6 +77,11 @@ export class ThreadStore {
     return join(this.dir(tenant), `${id}.jsonl`);
   }
 
+  // `readHeader`/`writeHeader` are paired for read-modify-write updates in
+  // `append`/`setSession`/`updateProposal`. That safety depends on those call
+  // sites staying fully synchronous between the read and the write — no
+  // `await` in between — since there is no per-thread lock and an interleaved
+  // async update could otherwise clobber a concurrent one.
   private readHeader(tenant: Tenant, id: string): ThreadHeader {
     return JSON.parse(readFileSync(this.headerPath(tenant, id), 'utf8')) as ThreadHeader;
   }
@@ -79,6 +99,7 @@ export class ThreadStore {
   }
 
   async create(tenant: Tenant, init: { title?: string; matter?: string } = {}): Promise<ThreadHeader> {
+    this.validateTenant(tenant);
     const id = randomUUID();
     const now = new Date().toISOString();
     const header: ThreadHeader = {
@@ -96,10 +117,13 @@ export class ThreadStore {
   }
 
   async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {
+    this.validateTenant(tenant);
+    this.validateId(id);
     return { header: this.readHeader(tenant, id), events: this.readEvents(tenant, id) };
   }
 
   async list(tenant: Tenant): Promise<ThreadHeader[]> {
+    this.validateTenant(tenant);
     const dir = this.dir(tenant);
     if (!existsSync(dir)) return [];
     const headers = readdirSync(dir)
@@ -110,13 +134,20 @@ export class ThreadStore {
   }
 
   async append(tenant: Tenant, id: string, ev: ThreadEvent): Promise<void> {
-    writeFileSync(this.logPath(tenant, id), JSON.stringify(ev) + '\n', { flag: 'a' });
+    this.validateTenant(tenant);
+    this.validateId(id);
+    // Read the header first — it doubles as the existence check for the
+    // thread, so a missing/unknown thread throws before the log write below,
+    // and never leaves behind an orphan `.jsonl`.
     const header = this.readHeader(tenant, id);
+    writeFileSync(this.logPath(tenant, id), JSON.stringify(ev) + '\n', { flag: 'a' });
     header.updatedAt = new Date().toISOString();
     this.writeHeader(tenant, header);
   }
 
   async setSession(tenant: Tenant, id: string, providerId: string, sessionId: string): Promise<void> {
+    this.validateTenant(tenant);
+    this.validateId(id);
     const header = this.readHeader(tenant, id);
     header.sessions[providerId] = sessionId;
     header.updatedAt = new Date().toISOString();
@@ -129,6 +160,8 @@ export class ThreadStore {
     proposalId: string,
     status: 'pending' | 'approved' | 'rejected'
   ): Promise<void> {
+    this.validateTenant(tenant);
+    this.validateId(id);
     const events = this.readEvents(tenant, id).map(ev =>
       't' in ev && ev.t === 'proposal' && ev.id === proposalId ? { ...ev, status } : ev
     );
@@ -143,12 +176,15 @@ export class ThreadStore {
   }
 
   async remove(tenant: Tenant, id: string): Promise<void> {
+    this.validateTenant(tenant);
+    this.validateId(id);
     rmSync(this.headerPath(tenant, id), { force: true });
     rmSync(this.logPath(tenant, id), { force: true });
     rmSync(this.codexHomeFor(id), { recursive: true, force: true });
   }
 
   codexHomeFor(id: string): string {
+    this.validateId(id);
     return join(this.codexHomeRoot, id);
   }
 }

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -1,0 +1,154 @@
+import { randomUUID } from 'node:crypto';
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { StepEvent, Tenant } from '../core/types';
+
+/**
+ * Threads live under `<vaultRoot>/.counsel/threads/`, which `FsVaultStore.abs()`
+ * deliberately rejects (that ban is on model-reachable tools). The runtime
+ * itself is the intended writer of `.counsel/`, so this store talks to
+ * `node:fs` directly instead of going through `VaultStore`.
+ */
+const THREADS_DIR = join('.counsel', 'threads');
+
+export interface ThreadHeader {
+  id: string;
+  title?: string;
+  matter?: string;
+  createdAt: string;
+  updatedAt: string;
+  sessions: Record<string, string>;
+}
+
+export type ThreadEvent =
+  | { t: 'user'; at: string; content: string }
+  | { t: 'step'; at: string; runId: string; provider: string; task?: string }
+  | (StepEvent & { at: string })
+  | {
+      t: 'proposal';
+      at: string;
+      id: string;
+      path: string;
+      content: string;
+      rationale: string;
+      status: 'pending' | 'approved' | 'rejected';
+      expectedVersion: string | null;
+    };
+
+export interface ThreadStoreOptions {
+  /** Overrides `~/.counsel-os/codex` for tests. */
+  codexHomeRoot?: string;
+}
+
+export class ThreadStore {
+  private readonly root: string;
+  private readonly codexHomeRoot: string;
+
+  constructor(root: string, opts: ThreadStoreOptions = {}) {
+    this.root = root;
+    this.codexHomeRoot = opts.codexHomeRoot ?? join(homedir(), '.counsel-os', 'codex');
+  }
+
+  private dir(tenant: Tenant): string {
+    return join(this.root, THREADS_DIR, tenant);
+  }
+
+  private headerPath(tenant: Tenant, id: string): string {
+    return join(this.dir(tenant), `${id}.json`);
+  }
+
+  private logPath(tenant: Tenant, id: string): string {
+    return join(this.dir(tenant), `${id}.jsonl`);
+  }
+
+  private readHeader(tenant: Tenant, id: string): ThreadHeader {
+    return JSON.parse(readFileSync(this.headerPath(tenant, id), 'utf8')) as ThreadHeader;
+  }
+
+  private writeHeader(tenant: Tenant, header: ThreadHeader): void {
+    writeFileSync(this.headerPath(tenant, header.id), JSON.stringify(header, null, 2), 'utf8');
+  }
+
+  private readEvents(tenant: Tenant, id: string): ThreadEvent[] {
+    const text = readFileSync(this.logPath(tenant, id), 'utf8');
+    return text
+      .split('\n')
+      .filter(Boolean)
+      .map(line => JSON.parse(line) as ThreadEvent);
+  }
+
+  async create(tenant: Tenant, init: { title?: string; matter?: string } = {}): Promise<ThreadHeader> {
+    const id = randomUUID();
+    const now = new Date().toISOString();
+    const header: ThreadHeader = {
+      id,
+      title: init.title,
+      matter: init.matter,
+      createdAt: now,
+      updatedAt: now,
+      sessions: {},
+    };
+    mkdirSync(this.dir(tenant), { recursive: true });
+    this.writeHeader(tenant, header);
+    writeFileSync(this.logPath(tenant, id), '', 'utf8');
+    return header;
+  }
+
+  async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {
+    return { header: this.readHeader(tenant, id), events: this.readEvents(tenant, id) };
+  }
+
+  async list(tenant: Tenant): Promise<ThreadHeader[]> {
+    const dir = this.dir(tenant);
+    if (!existsSync(dir)) return [];
+    const headers = readdirSync(dir)
+      .filter(name => name.endsWith('.json'))
+      .map(name => this.readHeader(tenant, name.slice(0, -'.json'.length)));
+    headers.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+    return headers;
+  }
+
+  async append(tenant: Tenant, id: string, ev: ThreadEvent): Promise<void> {
+    writeFileSync(this.logPath(tenant, id), JSON.stringify(ev) + '\n', { flag: 'a' });
+    const header = this.readHeader(tenant, id);
+    header.updatedAt = new Date().toISOString();
+    this.writeHeader(tenant, header);
+  }
+
+  async setSession(tenant: Tenant, id: string, providerId: string, sessionId: string): Promise<void> {
+    const header = this.readHeader(tenant, id);
+    header.sessions[providerId] = sessionId;
+    header.updatedAt = new Date().toISOString();
+    this.writeHeader(tenant, header);
+  }
+
+  async updateProposal(
+    tenant: Tenant,
+    id: string,
+    proposalId: string,
+    status: 'pending' | 'approved' | 'rejected'
+  ): Promise<void> {
+    const events = this.readEvents(tenant, id).map(ev =>
+      't' in ev && ev.t === 'proposal' && ev.id === proposalId ? { ...ev, status } : ev
+    );
+    const logPath = this.logPath(tenant, id);
+    const tmpPath = `${logPath}.tmp`;
+    writeFileSync(tmpPath, events.map(ev => JSON.stringify(ev) + '\n').join(''), 'utf8');
+    renameSync(tmpPath, logPath);
+
+    const header = this.readHeader(tenant, id);
+    header.updatedAt = new Date().toISOString();
+    this.writeHeader(tenant, header);
+  }
+
+  async remove(tenant: Tenant, id: string): Promise<void> {
+    rmSync(this.headerPath(tenant, id), { force: true });
+    rmSync(this.logPath(tenant, id), { force: true });
+    rmSync(this.codexHomeFor(id), { recursive: true, force: true });
+  }
+
+  codexHomeFor(id: string): string {
+    return join(this.codexHomeRoot, id);
+  }
+}

--- a/runtime/src/threads/window.test.ts
+++ b/runtime/src/threads/window.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from 'bun:test';
+import { window } from './window';
+import type { ThreadEvent } from './store';
+
+describe('window', () => {
+  test('converts user/text events to Messages, merging consecutive text events and skipping tool events', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'first' },
+      { type: 'text', text: 'a', at: 't1' },
+      { type: 'text', text: 'b', at: 't2' },
+      { type: 'tool_call', id: '1', name: 'vault_read', input: {}, at: 't3' },
+      { type: 'tool_result', id: '1', name: 'vault_read', output: 'x', at: 't4' },
+      { type: 'text', text: 'c', at: 't5' },
+      { t: 'user', at: 't6', content: 'second' },
+    ];
+
+    const messages = window(events, 100_000);
+
+    expect(messages).toEqual([
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'ab' },
+      { role: 'assistant', content: 'c' },
+      { role: 'user', content: 'second' },
+    ]);
+  });
+
+  test('drops oldest messages first when over budget', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'one' },
+      { type: 'text', text: 'reply one', at: 't1' },
+      { t: 'user', at: 't2', content: 'two' },
+      { type: 'text', text: 'reply two', at: 't3' },
+      { t: 'user', at: 't4', content: 'three' },
+    ];
+
+    // Budget only big enough for the last user message plus a bit —
+    // the oldest turns must be dropped first.
+    const messages = window(events, 3);
+
+    expect(messages[messages.length - 1]).toEqual({ role: 'user', content: 'three' });
+    expect(messages.some(m => m.content === 'one')).toBe(false);
+    expect(messages.some(m => m.content === 'reply one')).toBe(false);
+  });
+
+  test('always keeps the last user message even when it alone exceeds the budget', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'short' },
+      { type: 'text', text: 'reply', at: 't1' },
+      { t: 'user', at: 't2', content: 'a'.repeat(400) },
+    ];
+
+    const messages = window(events, 1);
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toEqual({ role: 'user', content: 'a'.repeat(400) });
+  });
+
+  test('the token estimate is injectable', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'one' },
+      { type: 'text', text: 'reply one', at: 't1' },
+      { t: 'user', at: 't2', content: 'two' },
+    ];
+
+    // A custom estimate that counts every message as costing 10 tokens
+    // regardless of length forces a drop that length/4 would not.
+    const messages = window(events, 15, () => 10);
+
+    expect(messages).toEqual([{ role: 'user', content: 'two' }]);
+  });
+});

--- a/runtime/src/threads/window.test.ts
+++ b/runtime/src/threads/window.test.ts
@@ -55,6 +55,43 @@ describe('window', () => {
     expect(messages[0]).toEqual({ role: 'user', content: 'a'.repeat(400) });
   });
 
+  test('never returns an assistant-first window (Anthropic rejects a non-user first message)', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'A' },
+      { type: 'text', text: 'B', at: 't1' },
+      { t: 'user', at: 't2', content: 'C' },
+      { type: 'text', text: 'D', at: 't3' },
+      { t: 'user', at: 't4', content: 'E' },
+    ];
+
+    // Before the fix, this budget stopped the drop loop right after
+    // {role:'user',content:'A'} was shifted off, leaving the assistant 'B'
+    // message as the head: [assistant B, user C, assistant D, user E].
+    const messages = window(events, 4);
+
+    expect(messages[0]!.role).toBe('user');
+    expect(messages[messages.length - 1]).toEqual({ role: 'user', content: 'E' });
+  });
+
+  test('the head is never assistant across a range of budgets', () => {
+    const events: ThreadEvent[] = [
+      { t: 'user', at: 't0', content: 'A' },
+      { type: 'text', text: 'B', at: 't1' },
+      { t: 'user', at: 't2', content: 'C' },
+      { type: 'text', text: 'D', at: 't3' },
+      { t: 'user', at: 't4', content: 'E' },
+    ];
+
+    for (const budget of [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 20, 100]) {
+      const messages = window(events, budget);
+      if (messages.length > 0) {
+        expect(messages[0]!.role).toBe('user');
+      }
+      // The last user message ('E') must always survive.
+      expect(messages[messages.length - 1]).toEqual({ role: 'user', content: 'E' });
+    }
+  });
+
   test('the token estimate is injectable', () => {
     const events: ThreadEvent[] = [
       { t: 'user', at: 't0', content: 'one' },

--- a/runtime/src/threads/window.ts
+++ b/runtime/src/threads/window.ts
@@ -37,7 +37,10 @@ function toMessages(events: ThreadEvent[]): Message[] {
  * this thread: converts the event log to Messages, then drops the oldest
  * ones until the estimated token total fits `budgetTokens` — but never drops
  * the last user message (or anything after it), even if that alone puts the
- * window over budget.
+ * window over budget. The head of the returned array is always a user
+ * message (when there is one to keep) — Anthropic's API rejects a first
+ * message that isn't `user`, so a budget cut that stops mid-turn on an
+ * assistant message keeps shifting down to the same floor.
  */
 export function window(
   events: ThreadEvent[],
@@ -58,6 +61,13 @@ export function window(
   const tokensOf = (msgs: Message[]): number => msgs.reduce((sum, m) => sum + estimate(m.content), 0);
 
   while (messages.length > minKeep && tokensOf(messages) > budgetTokens) {
+    messages.shift();
+  }
+  // The budget cut above can stop as soon as it's under budget, which may
+  // leave a leading assistant message from a turn whose user message was
+  // just dropped. Keep shifting down to the same last-user-message floor
+  // until the head is a user turn.
+  while (messages.length > minKeep && messages[0]!.role !== 'user') {
     messages.shift();
   }
 

--- a/runtime/src/threads/window.ts
+++ b/runtime/src/threads/window.ts
@@ -5,7 +5,13 @@ const defaultEstimate = (s: string): number => Math.ceil(s.length / 4);
 
 /** `user` events become user Messages; consecutive `text` step-events merge
  * into one assistant Message. Everything else (tool calls/results, session,
- * done, error, proposal, step) is replay/audit-only and skipped here. */
+ * done, error, proposal, step) is replay/audit-only and skipped here.
+ *
+ * The merge is defensive, not load-bearing: `stream()` now coalesces a run of
+ * `text` deltas into one logged `text` event, so a log written by this
+ * runtime rarely has two in a row. It stays because logs written before that
+ * change still hold per-token events, and because nothing in the format
+ * forbids a future writer from appending two. */
 function toMessages(events: ThreadEvent[]): Message[] {
   const messages: Message[] = [];
   let textBuffer: string[] | null = null;

--- a/runtime/src/threads/window.ts
+++ b/runtime/src/threads/window.ts
@@ -1,0 +1,65 @@
+import type { Message } from '../core/types';
+import type { ThreadEvent } from './store';
+
+const defaultEstimate = (s: string): number => Math.ceil(s.length / 4);
+
+/** `user` events become user Messages; consecutive `text` step-events merge
+ * into one assistant Message. Everything else (tool calls/results, session,
+ * done, error, proposal, step) is replay/audit-only and skipped here. */
+function toMessages(events: ThreadEvent[]): Message[] {
+  const messages: Message[] = [];
+  let textBuffer: string[] | null = null;
+
+  const flush = (): void => {
+    if (textBuffer && textBuffer.length > 0) {
+      messages.push({ role: 'assistant', content: textBuffer.join('') });
+    }
+    textBuffer = null;
+  };
+
+  for (const ev of events) {
+    if ('type' in ev && ev.type === 'text') {
+      (textBuffer ??= []).push(ev.text);
+      continue;
+    }
+    flush();
+    if ('t' in ev && ev.t === 'user') {
+      messages.push({ role: 'user', content: ev.content });
+    }
+  }
+  flush();
+
+  return messages;
+}
+
+/**
+ * Builds the message window to send to a provider that has no session for
+ * this thread: converts the event log to Messages, then drops the oldest
+ * ones until the estimated token total fits `budgetTokens` — but never drops
+ * the last user message (or anything after it), even if that alone puts the
+ * window over budget.
+ */
+export function window(
+  events: ThreadEvent[],
+  budgetTokens: number,
+  estimate: (s: string) => number = defaultEstimate
+): Message[] {
+  const messages = toMessages(events);
+
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]!.role === 'user') {
+      lastUserIndex = i;
+      break;
+    }
+  }
+  const minKeep = lastUserIndex === -1 ? messages.length + 1 : messages.length - lastUserIndex;
+
+  const tokensOf = (msgs: Message[]): number => msgs.reduce((sum, m) => sum + estimate(m.content), 0);
+
+  while (messages.length > minKeep && tokensOf(messages) > budgetTokens) {
+    messages.shift();
+  }
+
+  return messages;
+}

--- a/runtime/src/tools/builtin.test.ts
+++ b/runtime/src/tools/builtin.test.ts
@@ -9,6 +9,33 @@ describe('builtinTools', () => {
     expect(sweep).toBeDefined();
     expect([...sweep!.platforms].sort()).toEqual(['hosted', 'linux', 'macos', 'windows']);
   });
+
+  test('adds the five docx script tools', () => {
+    const tools = builtinTools({ vaultRoot: '/tmp/v', repoRoot: '/tmp/repo' });
+    const names = tools.map(t => t.name).sort();
+    expect(names).toEqual([
+      'apply_redlines',
+      'check_document',
+      'clean_format',
+      'docket_sweep',
+      'extract_redlines',
+      'word_compare',
+    ]);
+  });
+
+  test('extract_redlines, check_document, clean_format, apply_redlines are available on all four platforms', () => {
+    const tools = builtinTools({ vaultRoot: '/tmp/v', repoRoot: '/tmp/repo' });
+    for (const name of ['extract_redlines', 'check_document', 'clean_format', 'apply_redlines']) {
+      const t = tools.find(x => x.name === name)!;
+      expect([...t.platforms].sort()).toEqual(['hosted', 'linux', 'macos', 'windows']);
+    }
+  });
+
+  test('word_compare is macOS only', () => {
+    const tools = builtinTools({ vaultRoot: '/tmp/v', repoRoot: '/tmp/repo' });
+    const wc = tools.find(t => t.name === 'word_compare')!;
+    expect([...wc.platforms]).toEqual(['macos']);
+  });
 });
 
 describe('docketSweepArgs', () => {

--- a/runtime/src/tools/builtin.test.ts
+++ b/runtime/src/tools/builtin.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { join } from 'node:path';
-import { builtinTools, docketSweepArgs } from './builtin';
+import { builtinTools, checkDocumentArgs, docketSweepArgs } from './builtin';
 
 describe('builtinTools', () => {
   test('returns docket_sweep, available on all four platforms', () => {
@@ -35,6 +35,23 @@ describe('builtinTools', () => {
     const tools = builtinTools({ vaultRoot: '/tmp/v', repoRoot: '/tmp/repo' });
     const wc = tools.find(t => t.name === 'word_compare')!;
     expect([...wc.platforms]).toEqual(['macos']);
+  });
+
+  test('check_document takes a `file` field, accepts non-docx, and always runs --json', async () => {
+    const tools = builtinTools({ vaultRoot: '/tmp/v', repoRoot: '/tmp/repo' });
+    const check = tools.find(t => t.name === 'check_document')!;
+    const parsed = check.inputSchema.parse({ file: 'draft.md' });
+    expect(parsed).toEqual({ file: 'draft.md' });
+    expect(check.description).toContain('.md');
+    expect(check.description).toContain('.txt');
+    expect(check.description).toContain('--json');
+  });
+});
+
+describe('checkDocumentArgs', () => {
+  test('always appends --json', () => {
+    expect(checkDocumentArgs('draft.docx')).toEqual(['draft.docx', '--json']);
+    expect(checkDocumentArgs('draft.md')).toEqual(['draft.md', '--json']);
   });
 });
 

--- a/runtime/src/tools/builtin.ts
+++ b/runtime/src/tools/builtin.ts
@@ -13,6 +13,12 @@ export function docketSweepArgs(vaultRoot: string, days: number): string[] {
   return [join(vaultRoot, 'matters'), '--window', String(days), '--format', 'json'];
 }
 
+/** `check_document` always runs `--json` — the `read` primitive's `--qa` mode
+ * consumes the machine-readable report, not the human-readable one. */
+export function checkDocumentArgs(file: string): string[] {
+  return [file, '--json'];
+}
+
 // Runs on all four platforms, same as docket_sweep — but reads/writes local
 // .docx files, which a `hosted` deployment may not have direct filesystem
 // access to. Recorded in each tool's description (below) rather than the
@@ -47,11 +53,11 @@ export function builtinTools(opts: { vaultRoot: string; repoRoot: string }): Too
     }),
     pythonScriptTool({
       name: 'check_document',
-      description: 'Deterministic mechanical QA for a contract draft (.docx, markdown, or text): cross-references, defined terms, exhibits. Reads a local file path — the document must already be on disk.',
+      description: 'Deterministic mechanical QA for a contract draft: cross-references, defined terms, exhibits. Accepts .docx, .md, or .txt. Always run with --json. Reads a local file path — the document must already be on disk.',
       script: resolve(opts.repoRoot, 'scripts/check_document.py'),
       platforms: [...DOCX_SCRIPT_PLATFORMS],
-      inputSchema: z.object({ docx: z.string().describe('Path to the document to check.') }),
-      args: ({ docx }) => [docx],
+      inputSchema: z.object({ file: z.string().describe('Path to the .docx, .md, or .txt document to check.') }),
+      args: ({ file }) => checkDocumentArgs(file),
       cwd: opts.repoRoot,
     }),
     pythonScriptTool({

--- a/runtime/src/tools/builtin.ts
+++ b/runtime/src/tools/builtin.ts
@@ -13,6 +13,13 @@ export function docketSweepArgs(vaultRoot: string, days: number): string[] {
   return [join(vaultRoot, 'matters'), '--window', String(days), '--format', 'json'];
 }
 
+// Runs on all four platforms, same as docket_sweep — but reads/writes local
+// .docx files, which a `hosted` deployment may not have direct filesystem
+// access to. Recorded in each tool's description (below) rather than the
+// platform set, since the constraint is about file transport, not the
+// script itself.
+const DOCX_SCRIPT_PLATFORMS = ['macos', 'linux', 'windows', 'hosted'] as const;
+
 /**
  * Tools shared by every entry point that runs a model against a vault
  * (`cli.ts`'s in-process run, `mcp/stdio.ts`'s server for Codex). Kept in one
@@ -27,6 +34,65 @@ export function builtinTools(opts: { vaultRoot: string; repoRoot: string }): Too
       platforms: ['macos', 'linux', 'windows', 'hosted'],
       inputSchema: z.object({ days: z.number().int().positive().default(60) }),
       args: ({ days }) => docketSweepArgs(opts.vaultRoot, days),
+      cwd: opts.repoRoot,
+    }),
+    pythonScriptTool({
+      name: 'extract_redlines',
+      description: 'Extract tracked changes and comments from a .docx file, as JSON. Reads a local file path — the docx must already be on disk.',
+      script: resolve(opts.repoRoot, 'scripts/extract_redlines.py'),
+      platforms: [...DOCX_SCRIPT_PLATFORMS],
+      inputSchema: z.object({ docx: z.string().describe('Path to the .docx file to read tracked changes and comments from.') }),
+      args: ({ docx }) => [docx],
+      cwd: opts.repoRoot,
+    }),
+    pythonScriptTool({
+      name: 'check_document',
+      description: 'Deterministic mechanical QA for a contract draft (.docx, markdown, or text): cross-references, defined terms, exhibits. Reads a local file path — the document must already be on disk.',
+      script: resolve(opts.repoRoot, 'scripts/check_document.py'),
+      platforms: [...DOCX_SCRIPT_PLATFORMS],
+      inputSchema: z.object({ docx: z.string().describe('Path to the document to check.') }),
+      args: ({ docx }) => [docx],
+      cwd: opts.repoRoot,
+    }),
+    pythonScriptTool({
+      name: 'clean_format',
+      description: 'Clean up a drafted .docx file’s formatting against the house style template. Reads and writes local file paths.',
+      script: resolve(opts.repoRoot, 'scripts/clean_format.py'),
+      platforms: [...DOCX_SCRIPT_PLATFORMS],
+      inputSchema: z.object({
+        input: z.string().describe('Path to the .docx file to clean up.'),
+        output: z.string().describe('Path to write the cleaned .docx file to.'),
+      }),
+      args: ({ input, output }) => [input, output],
+      cwd: opts.repoRoot,
+    }),
+    pythonScriptTool({
+      name: 'apply_redlines',
+      description: 'Apply a list of edits (as JSON) to a .docx file, optionally as tracked changes. Reads and writes local file paths.',
+      script: resolve(opts.repoRoot, 'scripts/apply_redlines.py'),
+      platforms: [...DOCX_SCRIPT_PLATFORMS],
+      inputSchema: z.object({
+        original: z.string().describe('Path to the original .docx file.'),
+        edits: z.string().describe('Path to the edits JSON file.'),
+        output: z.string().describe('Path to write the resulting .docx file to.'),
+        track: z.boolean().optional().describe('Apply the edits as tracked changes instead of direct replacements.'),
+      }),
+      args: ({ original, edits, output, track }) => (track ? ['--track', original, edits, output] : [original, edits, output]),
+      cwd: opts.repoRoot,
+    }),
+    pythonScriptTool({
+      name: 'word_compare',
+      description: 'Use Microsoft Word to compare two .docx files and produce a tracked-changes document, revisions attributed to the given author. macOS only — requires Microsoft Word for Mac.',
+      script: resolve(opts.repoRoot, 'scripts/word_compare.sh'),
+      command: ['bash', resolve(opts.repoRoot, 'scripts/word_compare.sh')],
+      platforms: ['macos'],
+      inputSchema: z.object({
+        original: z.string().describe('Path to the original .docx file.'),
+        modified: z.string().describe('Path to the modified .docx file.'),
+        author: z.string().describe('Author name to attribute the tracked changes to.'),
+        output: z.string().describe('Path to write the resulting tracked-changes .docx file to.'),
+      }),
+      args: ({ original, modified, author, output }) => [original, modified, author, output],
       cwd: opts.repoRoot,
     }),
   ];

--- a/runtime/src/tools/builtin.ts
+++ b/runtime/src/tools/builtin.ts
@@ -89,7 +89,8 @@ export function builtinTools(opts: { vaultRoot: string; repoRoot: string }): Too
     pythonScriptTool({
       name: 'word_compare',
       description: 'Use Microsoft Word to compare two .docx files and produce a tracked-changes document, revisions attributed to the given author. macOS only — requires Microsoft Word for Mac.',
-      script: resolve(opts.repoRoot, 'scripts/word_compare.sh'),
+      // `command` only: this is a shell script, so there is no `python3
+      // <script>` default to fall back to and no second path to drift.
       command: ['bash', resolve(opts.repoRoot, 'scripts/word_compare.sh')],
       platforms: ['macos'],
       inputSchema: z.object({

--- a/runtime/src/tools/subprocess.test.ts
+++ b/runtime/src/tools/subprocess.test.ts
@@ -30,6 +30,27 @@ describe('pythonScriptTool', () => {
     expect(r.exitCode).toBe(1);
   });
 
+  test('runs a `command` with no script at all', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'sh-'));
+    const script = join(dir, 'hello.sh');
+    writeFileSync(script, 'echo "hello $1"\n');
+    const tool = pythonScriptTool({
+      name: 'hello_sh', description: 'hello', command: ['bash', script], platforms: ['macos', 'linux'],
+      inputSchema: z.object({ who: z.string() }),
+      args: ({ who }) => [who],
+    });
+    const r = await tool.execute({ who: 'world' }, { tenant: 'default' });
+    expect(r.stdout.trim()).toBe('hello world');
+    expect(r.exitCode).toBe(0);
+  });
+
+  test('needs a script or a command', () => {
+    expect(() => pythonScriptTool({
+      name: 'nothing', description: 'nothing', platforms: ['macos'],
+      inputSchema: z.object({}), args: () => [],
+    })).toThrow(/needs a script or a command/);
+  });
+
   test('kills the process on timeout', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'py-'));
     const script = join(dir, 'sleep.py');

--- a/runtime/src/tools/subprocess.ts
+++ b/runtime/src/tools/subprocess.ts
@@ -6,23 +6,34 @@ export interface SubprocessResult { stdout: string; stderr: string; exitCode: nu
 export function pythonScriptTool<I>(opts: {
   name: string;
   description: string;
-  script: string;                 // absolute path to the .py file
+  /** Absolute path to the .py file. Optional only when `command` supplies the
+   * whole argv itself — otherwise there is nothing for `python3` to run. */
+  script?: string;
   platforms: Platform[];
   inputSchema: ZodType<I>;
   args: (input: I) => string[];
   cwd?: string;
   timeoutMs?: number;
   /** Overrides the spawned command; defaults to `['python3', script]`. Used
-   * for non-Python scripts, e.g. `['bash', script]` for a `.sh` file. */
+   * for non-Python scripts, e.g. `['bash', script]` for a `.sh` file. When
+   * this is given, `script` is not consulted at all — passing both invited a
+   * caller to keep two paths in sync while only one of them ran. */
   command?: string[];
 }): Tool<I, SubprocessResult> {
+  // One of the two has to name something to execute. Checked at construction
+  // (`builtinTools()` runs on every step) rather than at spawn time, so a
+  // miswired tool fails where it is defined, not mid-model-turn.
+  const command = opts.command ?? (opts.script === undefined ? undefined : ['python3', opts.script]);
+  if (command === undefined || command.length === 0) {
+    throw new Error(`${opts.name}: pythonScriptTool needs a script or a command`);
+  }
   return {
     name: opts.name,
     description: opts.description,
     inputSchema: opts.inputSchema,
     platforms: new Set(opts.platforms),
     async execute(input) {
-      const proc = Bun.spawn([...(opts.command ?? ['python3', opts.script]), ...opts.args(input)], {
+      const proc = Bun.spawn([...command, ...opts.args(input)], {
         cwd: opts.cwd,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/runtime/src/tools/subprocess.ts
+++ b/runtime/src/tools/subprocess.ts
@@ -12,6 +12,9 @@ export function pythonScriptTool<I>(opts: {
   args: (input: I) => string[];
   cwd?: string;
   timeoutMs?: number;
+  /** Overrides the spawned command; defaults to `['python3', script]`. Used
+   * for non-Python scripts, e.g. `['bash', script]` for a `.sh` file. */
+  command?: string[];
 }): Tool<I, SubprocessResult> {
   return {
     name: opts.name,
@@ -19,7 +22,7 @@ export function pythonScriptTool<I>(opts: {
     inputSchema: opts.inputSchema,
     platforms: new Set(opts.platforms),
     async execute(input) {
-      const proc = Bun.spawn(['python3', opts.script, ...opts.args(input)], {
+      const proc = Bun.spawn([...(opts.command ?? ['python3', opts.script]), ...opts.args(input)], {
         cwd: opts.cwd,
         stdout: 'pipe',
         stderr: 'pipe',

--- a/runtime/src/vault/fs-store.test.ts
+++ b/runtime/src/vault/fs-store.test.ts
@@ -33,6 +33,27 @@ describe('FsVaultStore', () => {
     expect(v2).not.toBe(v1);
   });
 
+  test('write with expectedVersion: null succeeds when the path does not exist yet', async () => {
+    const v = await store.write('default', 'new.md', 'brand new', { expectedVersion: null });
+    expect(v).toMatch(/^[0-9a-f]{64}$/);
+    expect(await store.read('default', 'new.md')).toBe('brand new');
+  });
+
+  test('write with expectedVersion: null conflicts when the path was created in the meantime', async () => {
+    await store.write('default', 'new.md', 'someone got there first');
+    const actual = await store.version('default', 'new.md');
+    let error: unknown;
+    try {
+      await store.write('default', 'new.md', 'my content', { expectedVersion: null });
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(VaultConflictError);
+    expect((error as VaultConflictError).expected).toBe('missing');
+    expect((error as VaultConflictError).actual).toBe(actual!);
+    expect(await store.read('default', 'new.md')).toBe('someone got there first');
+  });
+
   test('list returns files and dirs, history is newest first', async () => {
     await store.write('default', 'd/x.md', '1');
     await store.write('default', 'd/x.md', '2');

--- a/runtime/src/vault/fs-store.test.ts
+++ b/runtime/src/vault/fs-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeEach } from 'bun:test';
-import { mkdtempSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FsVaultStore } from './fs-store';
@@ -93,6 +93,40 @@ describe('FsVaultStore', () => {
 
   test('read from .counsel/ is rejected', async () => {
     await expect(store.read('default', '.counsel/anything')).rejects.toThrow(/reserved/);
+  });
+
+  test('the reserved check is case-insensitive — APFS and NTFS are', async () => {
+    // On a case-insensitive filesystem `.Counsel/` IS `.counsel/`, so a
+    // case-sensitive compare would hand a model the audit trail.
+    await expect(store.write('default', '.Counsel/history/default/x.jsonl', 'tampered')).rejects.toThrow(/reserved/);
+    await expect(store.read('default', '.COUNSEL/anything')).rejects.toThrow(/reserved/);
+  });
+
+  test('a symlink pointing out of the vault is rejected', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'outside-'));
+    writeFileSync(join(outside, 'secret.txt'), 'SECRET\n', 'utf8');
+    // Spells clean, resolves outside: the lexical check alone cannot see it.
+    symlinkSync(join(outside, 'secret.txt'), join(root, 'innocent.md'));
+
+    await expect(store.read('default', 'innocent.md')).rejects.toThrow(/symlink/);
+    await expect(store.write('default', 'innocent.md', 'overwritten')).rejects.toThrow(/symlink/);
+  });
+
+  test('a symlinked directory pointing out of the vault is rejected, even for a file that does not exist yet', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'outside-'));
+    symlinkSync(outside, join(root, 'escape'));
+    await expect(store.write('default', 'escape/new.md', 'planted')).rejects.toThrow(/symlink/);
+    await expect(store.list('default', 'escape')).rejects.toThrow(/symlink/);
+  });
+
+  test('a symlink that stays inside the vault still works', async () => {
+    mkdirSync(join(root, 'real'), { recursive: true });
+    writeFileSync(join(root, 'real', 'notes.md'), 'INSIDE\n', 'utf8');
+    symlinkSync(join(root, 'real'), join(root, 'alias'));
+
+    expect(await store.read('default', 'alias/notes.md')).toBe('INSIDE\n');
+    await store.write('default', 'alias/added.md', 'also inside');
+    expect(await store.read('default', 'real/added.md')).toBe('also inside');
   });
 
   test('the reserved check is on the whole first segment, not a prefix', async () => {

--- a/runtime/src/vault/fs-store.test.ts
+++ b/runtime/src/vault/fs-store.test.ts
@@ -70,6 +70,15 @@ describe('FsVaultStore', () => {
     await expect(store.read('default', '../etc/passwd')).rejects.toThrow(/outside vault/);
   });
 
+  test('backslash-separated paths are rejected — vault paths are forward-slash only on every host OS', async () => {
+    // On a Windows host, `resolve`/`relative` use `path.win32` and would
+    // otherwise resolve `a\b.md` *inside* `a/`, disagreeing with
+    // `normalizeVaultPath` (`knowledge-paths.ts`), which treats a backslash
+    // as one opaque, non-separator character.
+    await expect(store.read('default', 'a\\b.md')).rejects.toThrow(/backslash/);
+    await expect(store.write('default', 'a\\b.md', 'x')).rejects.toThrow(/backslash/);
+  });
+
   test('version of a missing file is null', async () => {
     expect(await store.version('default', 'missing.md')).toBeNull();
   });

--- a/runtime/src/vault/fs-store.test.ts
+++ b/runtime/src/vault/fs-store.test.ts
@@ -129,6 +129,20 @@ describe('FsVaultStore', () => {
     expect(await store.read('default', 'real/added.md')).toBe('also inside');
   });
 
+  test('a symlink into .counsel/ is rejected — the lexical ban only sees the first segment', async () => {
+    // `matters/x` spells clean: its first segment is `matters`, so `abs()`'s
+    // reserved-path check never fires. Following it lands on the runtime's
+    // own audit trail, which is exactly what the ban exists to stop.
+    mkdirSync(join(root, '.counsel', 'threads'), { recursive: true });
+    mkdirSync(join(root, 'matters'), { recursive: true });
+    symlinkSync(join('..', '.counsel', 'threads'), join(root, 'matters', 'x'));
+
+    await expect(store.read('default', 'matters/x')).rejects.toThrow(/reserved path/);
+    await expect(store.read('default', 'matters/x/default.json')).rejects.toThrow(/reserved path/);
+    await expect(store.write('default', 'matters/x/planted.md', 'planted')).rejects.toThrow(/reserved path/);
+    await expect(store.list('default', 'matters/x')).rejects.toThrow(/reserved path/);
+  });
+
   test('the reserved check is on the whole first segment, not a prefix', async () => {
     // `.counselor.md` is an ordinary vault file; only `.counsel` itself is reserved.
     const v = await store.write('default', '.counselor.md', 'fine');

--- a/runtime/src/vault/fs-store.ts
+++ b/runtime/src/vault/fs-store.ts
@@ -70,6 +70,12 @@ export class FsVaultStore implements VaultStore {
    * own, so the nearest existing ancestor is checked instead — that is the
    * directory the file would be created in, and a symlinked directory is the
    * escape that matters for writes.
+   *
+   * The `.counsel/` ban is re-applied here for the same reason. The lexical
+   * check in `abs()` only sees the path's FIRST segment, so a symlink at
+   * `matters/x` → `../.counsel/threads` spells clean and still lands the read
+   * or write squarely on the audit trail the ban exists to protect. Landing
+   * inside the vault is not enough; it has to land outside `.counsel/` too.
    */
   private assertInsideRealRoot(full: string, path: string): void {
     let realRoot: string;
@@ -90,6 +96,15 @@ export class FsVaultStore implements VaultStore {
     const real = realpathSync(existing);
     if (real !== realRoot && !real.startsWith(realRoot + sep)) {
       throw new Error(`path outside vault (symlink): ${path}`);
+    }
+    // Case-insensitively, like `abs()`: on APFS and NTFS `.Counsel` and
+    // `.counsel` are the same directory, and only this path's own segments
+    // vary in case — `realRoot` is a shared literal prefix on both sides, so
+    // lowercasing the whole string cannot make two different roots collide.
+    const reserved = join(realRoot, RESERVED_DIR).toLowerCase();
+    const lowered = real.toLowerCase();
+    if (lowered === reserved || lowered.startsWith(reserved + sep)) {
+      throw new Error(`reserved path (symlink): ${path}`);
     }
   }
 

--- a/runtime/src/vault/fs-store.ts
+++ b/runtime/src/vault/fs-store.ts
@@ -60,11 +60,15 @@ export class FsVaultStore implements VaultStore {
     }
   }
 
-  async write(tenant: Tenant, path: string, content: string, opts: { expectedVersion?: Version } = {}): Promise<Version> {
+  async write(tenant: Tenant, path: string, content: string, opts: { expectedVersion?: Version | null } = {}): Promise<Version> {
     const full = this.abs(tenant, path);
     if (opts.expectedVersion !== undefined) {
       const actual = await this.version(tenant, path);
-      if (actual !== opts.expectedVersion) {
+      if (opts.expectedVersion === null) {
+        // The proposal was made against a path that didn't exist yet; a
+        // write in the meantime — by anyone — is a conflict too.
+        if (actual !== null) throw new VaultConflictError(path, 'missing', actual);
+      } else if (actual !== opts.expectedVersion) {
         throw new VaultConflictError(path, opts.expectedVersion, actual ?? 'missing');
       }
     }

--- a/runtime/src/vault/fs-store.ts
+++ b/runtime/src/vault/fs-store.ts
@@ -25,6 +25,14 @@ export class FsVaultStore implements VaultStore {
 
   // Local runtime has one tenant; the parameter is threaded for hosted later.
   private abs(_tenant: Tenant, path: string): string {
+    // Vault paths are forward-slash only, on every host OS — see
+    // `normalizeVaultPath` in `knowledge-paths.ts`, which enforces the same
+    // rule so a knowledge-path check can never disagree with what this store
+    // actually resolves. On a Windows host, `resolve`/`relative` below use
+    // `path.win32` and would otherwise treat `practice\x.md` as a path
+    // *inside* `practice/`, silently reinterpreting a backslash as a
+    // directory separator that the guard never saw.
+    if (path.includes('\\')) throw new Error(`path outside vault: backslashes are not allowed: ${path}`);
     const full = resolve(this.root, path);
     const rel = relative(this.root, full);
     const head = rel.split(sep)[0];

--- a/runtime/src/vault/fs-store.ts
+++ b/runtime/src/vault/fs-store.ts
@@ -1,4 +1,5 @@
 import { createHash } from 'node:crypto';
+import { existsSync, realpathSync } from 'node:fs';
 import { mkdir, readdir, readFile, writeFile, appendFile, stat } from 'node:fs/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import type { Entry, Hit, Tenant, VaultStore, Version } from '../core/types';
@@ -47,8 +48,49 @@ export class FsVaultStore implements VaultStore {
     // own writes are recorded in. `list` already hides it; this closes read
     // and write too. `historyFile` builds its paths directly and so is
     // unaffected.
-    if (head === RESERVED_DIR) throw new Error(`reserved path: ${path}`);
+    // Case-insensitively: APFS and NTFS are case-INsensitive, so `.Counsel/`
+    // and `.counsel/` are the same directory on the hosts this actually runs
+    // on. A case-sensitive compare would let `.Counsel/history/...` through
+    // to rewrite the very audit trail this ban exists to protect. Rejecting
+    // `.Counsel` on a case-sensitive filesystem too is a harmless
+    // over-rejection — nothing legitimate lives there.
+    if (head?.toLowerCase() === RESERVED_DIR) throw new Error(`reserved path: ${path}`);
+    this.assertInsideRealRoot(full, path);
     return full;
+  }
+
+  /**
+   * The lexical check above proves the *spelling* stays inside the vault; it
+   * says nothing about where the filesystem actually points. A symlink at
+   * `matters/acme/notes.md` → `~/.ssh/id_rsa` spells clean and reads
+   * someone's key. So the resolved path is checked again against the real
+   * root, following links.
+   *
+   * A path that does not exist yet (every new write) has no real path of its
+   * own, so the nearest existing ancestor is checked instead — that is the
+   * directory the file would be created in, and a symlinked directory is the
+   * escape that matters for writes.
+   */
+  private assertInsideRealRoot(full: string, path: string): void {
+    let realRoot: string;
+    try {
+      realRoot = realpathSync(this.root);
+    } catch {
+      // No vault root on disk: nothing can be inside it, and every real
+      // operation is about to fail with ENOENT anyway. The lexical check
+      // stands on its own.
+      return;
+    }
+    let existing = full;
+    while (!existsSync(existing)) {
+      const parent = dirname(existing);
+      if (parent === existing) return;
+      existing = parent;
+    }
+    const real = realpathSync(existing);
+    if (real !== realRoot && !real.startsWith(realRoot + sep)) {
+      throw new Error(`path outside vault (symlink): ${path}`);
+    }
   }
 
   private historyFile(tenant: Tenant, path: string): string {

--- a/runtime/src/vault/knowledge-paths.test.ts
+++ b/runtime/src/vault/knowledge-paths.test.ts
@@ -30,6 +30,17 @@ describe('normalizeVaultPath', () => {
   test('leaves an already-normal path alone', () => {
     expect(normalizeVaultPath('practice/standards/x.md')).toBe('practice/standards/x.md');
   });
+
+  test('rejects a backslash-separated path outright, rather than treating it as one opaque segment', () => {
+    // On a Windows host, `FsVaultStore.abs()` uses `path.win32` and would
+    // resolve `practice\x.md` *inside* `practice/` — but `posix.normalize`
+    // here would see it as a single filename, invisible to the `practice/`
+    // prefix check. Rejecting backslashes outright keeps the two in
+    // agreement on every host OS.
+    expect(() => normalizeVaultPath('practice\\x.md')).toThrow(/backslash/);
+    expect(() => normalizeVaultPath('practice\\standards\\x.md')).toThrow(/backslash/);
+    expect(() => normalizeVaultPath('a\\b.md')).toThrow(/backslash/);
+  });
 });
 
 describe('isKnowledgePath', () => {
@@ -74,5 +85,9 @@ describe('isKnowledgePath', () => {
     expect(isKnowledgePath('./practice/standards/x.md', defaults)).toBe(true);
     expect(isKnowledgePath('matters/../practice/x.md', defaults)).toBe(true);
     expect(isKnowledgePath('matters/../matters/a.md', defaults)).toBe(false);
+  });
+
+  test('a backslash-separated path throws instead of silently reading as "not a knowledge path"', () => {
+    expect(() => isKnowledgePath('practice\\standards\\x.md', defaults)).toThrow(/backslash/);
   });
 });

--- a/runtime/src/vault/knowledge-paths.test.ts
+++ b/runtime/src/vault/knowledge-paths.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { isKnowledgePath } from './knowledge-paths';
+import type { VaultConfig } from './resolve-root';
+
+const defaults: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+
+describe('isKnowledgePath', () => {
+  test('practice/ is a knowledge path', () => {
+    expect(isKnowledgePath('practice/standards/x.md', defaults)).toBe(true);
+  });
+
+  test('memory/ is a knowledge path', () => {
+    expect(isKnowledgePath('memory/decisions.md', defaults)).toBe(true);
+  });
+
+  test('law/ is a knowledge path', () => {
+    expect(isKnowledgePath('law/gdpr/breach-notification.md', defaults)).toBe(true);
+  });
+
+  test('matters/ is not a knowledge path', () => {
+    expect(isKnowledgePath('matters/acme/notes.md', defaults)).toBe(false);
+  });
+
+  test('the default entities/ path is a knowledge path', () => {
+    expect(isKnowledgePath('entities/acme.md', defaults)).toBe(true);
+  });
+
+  test('an overridden entities_path is honored as a knowledge path', () => {
+    expect(isKnowledgePath('clients/acme.md', { entitiesPath: 'clients', mattersPath: 'matters' })).toBe(true);
+  });
+
+  test('the default entities/ path is not a knowledge path once overridden away', () => {
+    expect(isKnowledgePath('entities/acme.md', { entitiesPath: 'clients', mattersPath: 'matters' })).toBe(false);
+  });
+
+  test('an unrelated top-level path is not a knowledge path', () => {
+    expect(isKnowledgePath('README.md', defaults)).toBe(false);
+  });
+
+  test('a name that merely starts with a knowledge prefix is not matched', () => {
+    // "lawsuit-tracker.md" begins with "law" but is not under "law/".
+    expect(isKnowledgePath('lawsuit-tracker.md', defaults)).toBe(false);
+  });
+});

--- a/runtime/src/vault/knowledge-paths.test.ts
+++ b/runtime/src/vault/knowledge-paths.test.ts
@@ -91,3 +91,15 @@ describe('isKnowledgePath', () => {
     expect(() => isKnowledgePath('practice\\standards\\x.md', defaults)).toThrow(/backslash/);
   });
 });
+
+describe('isKnowledgePath — case', () => {
+  test('a knowledge path spelled with capitals is still a knowledge path', () => {
+    // On APFS `Practice/standards/x.md` IS `practice/standards/x.md`, so a
+    // case-sensitive prefix test would be a way around the `remember` gate.
+    const cfg = { entitiesPath: 'entities', mattersPath: 'matters' };
+    expect(isKnowledgePath('Practice/standards/x.md', cfg)).toBe(true);
+    expect(isKnowledgePath('MEMORY/notes.md', cfg)).toBe(true);
+    expect(isKnowledgePath('Entities/acme.md', cfg)).toBe(true);
+    expect(isKnowledgePath('Matters/acme/draft.md', cfg)).toBe(false);
+  });
+});

--- a/runtime/src/vault/knowledge-paths.test.ts
+++ b/runtime/src/vault/knowledge-paths.test.ts
@@ -1,8 +1,36 @@
 import { describe, expect, test } from 'bun:test';
-import { isKnowledgePath } from './knowledge-paths';
+import { isKnowledgePath, normalizeVaultPath } from './knowledge-paths';
 import type { VaultConfig } from './resolve-root';
 
 const defaults: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+
+describe('normalizeVaultPath', () => {
+  test('strips a leading ./', () => {
+    expect(normalizeVaultPath('./practice/x.md')).toBe('practice/x.md');
+  });
+
+  test('collapses a doubled leading slash', () => {
+    expect(normalizeVaultPath('.//practice/x.md')).toBe('practice/x.md');
+  });
+
+  test('resolves internal .. segments that stay inside the vault', () => {
+    expect(normalizeVaultPath('matters/../practice/x.md')).toBe('practice/x.md');
+    expect(normalizeVaultPath('matters/../matters/a.md')).toBe('matters/a.md');
+  });
+
+  test('rejects an absolute path', () => {
+    expect(() => normalizeVaultPath('/etc/passwd')).toThrow(/outside vault/);
+  });
+
+  test('rejects a path that escapes the vault root', () => {
+    expect(() => normalizeVaultPath('../etc/passwd')).toThrow(/outside vault/);
+    expect(() => normalizeVaultPath('..')).toThrow(/outside vault/);
+  });
+
+  test('leaves an already-normal path alone', () => {
+    expect(normalizeVaultPath('practice/standards/x.md')).toBe('practice/standards/x.md');
+  });
+});
 
 describe('isKnowledgePath', () => {
   test('practice/ is a knowledge path', () => {
@@ -40,5 +68,11 @@ describe('isKnowledgePath', () => {
   test('a name that merely starts with a knowledge prefix is not matched', () => {
     // "lawsuit-tracker.md" begins with "law" but is not under "law/".
     expect(isKnowledgePath('lawsuit-tracker.md', defaults)).toBe(false);
+  });
+
+  test('a spelled-around path is normalized before the prefix check', () => {
+    expect(isKnowledgePath('./practice/standards/x.md', defaults)).toBe(true);
+    expect(isKnowledgePath('matters/../practice/x.md', defaults)).toBe(true);
+    expect(isKnowledgePath('matters/../matters/a.md', defaults)).toBe(false);
   });
 });

--- a/runtime/src/vault/knowledge-paths.ts
+++ b/runtime/src/vault/knowledge-paths.ts
@@ -1,4 +1,23 @@
+import { posix } from 'node:path';
 import type { VaultConfig } from './resolve-root';
+
+/**
+ * Normalizes a vault-relative path the way `FsVaultStore` ultimately
+ * resolves it, so a spelling like `./practice/x.md` or
+ * `matters/../practice/x.md` can't be used to slip past a string-prefix
+ * check (`isKnowledgePath`, the `vault_write` guard) that a plain
+ * `path.startsWith(...)` would miss. Throws on anything that would escape
+ * the vault root — absolute paths, or a path that still starts with `..`
+ * after normalizing — mirroring `FsVaultStore.abs()`'s own escape check.
+ */
+export function normalizeVaultPath(path: string): string {
+  let normalized = posix.normalize(path);
+  if (normalized.startsWith('./')) normalized = normalized.slice(2);
+  if (normalized.startsWith('/') || normalized === '..' || normalized.startsWith('../')) {
+    throw new Error('path outside vault');
+  }
+  return normalized;
+}
 
 /** Vault-relative path prefixes that hold Counsel OS knowledge-system content,
  * as opposed to matter workspaces. `entities_path` is config-driven; the rest
@@ -8,7 +27,10 @@ function knowledgePrefixes(cfg: VaultConfig): string[] {
 }
 
 /** True when `path` (vault-relative) falls under a knowledge-system directory:
- * `practice/`, `memory/`, `law/`, or the configured `{entitiesPath}/`. */
+ * `practice/`, `memory/`, `law/`, or the configured `{entitiesPath}/`. Path
+ * spelling is normalized first (see `normalizeVaultPath`) so `./practice/x.md`
+ * and `matters/../practice/x.md` are recognized the same as `practice/x.md`. */
 export function isKnowledgePath(path: string, cfg: VaultConfig): boolean {
-  return knowledgePrefixes(cfg).some(prefix => path.startsWith(prefix));
+  const normalized = normalizeVaultPath(path);
+  return knowledgePrefixes(cfg).some(prefix => normalized.startsWith(prefix));
 }

--- a/runtime/src/vault/knowledge-paths.ts
+++ b/runtime/src/vault/knowledge-paths.ts
@@ -41,6 +41,11 @@ function knowledgePrefixes(cfg: VaultConfig): string[] {
  * spelling is normalized first (see `normalizeVaultPath`) so `./practice/x.md`
  * and `matters/../practice/x.md` are recognized the same as `practice/x.md`. */
 export function isKnowledgePath(path: string, cfg: VaultConfig): boolean {
-  const normalized = normalizeVaultPath(path);
-  return knowledgePrefixes(cfg).some(prefix => normalized.startsWith(prefix));
+  // Case-insensitively, for the same reason `FsVaultStore.abs()` treats
+  // `.Counsel` as reserved: APFS and NTFS are case-insensitive, so
+  // `Practice/standards/x.md` IS `practice/standards/x.md` on the hosts this
+  // runs on. A case-sensitive prefix test would let a model spell its way
+  // around the `remember` gate and write a knowledge file with `vault_write`.
+  const normalized = normalizeVaultPath(path).toLowerCase();
+  return knowledgePrefixes(cfg).some(prefix => normalized.startsWith(prefix.toLowerCase()));
 }

--- a/runtime/src/vault/knowledge-paths.ts
+++ b/runtime/src/vault/knowledge-paths.ts
@@ -8,9 +8,19 @@ import type { VaultConfig } from './resolve-root';
  * check (`isKnowledgePath`, the `vault_write` guard) that a plain
  * `path.startsWith(...)` would miss. Throws on anything that would escape
  * the vault root — absolute paths, or a path that still starts with `..`
- * after normalizing — mirroring `FsVaultStore.abs()`'s own escape check.
+ * after normalizing.
+ *
+ * Vault paths are forward-slash only, on every host OS: a backslash is
+ * rejected outright, before `posix.normalize` gets a chance to treat it as
+ * one opaque path segment (which would hide `practice\x.md` from the
+ * `practice/` prefix check here, while `FsVaultStore.abs()` on a Windows
+ * host — using `path.win32` — resolves the very same string *inside*
+ * `practice/`). This function and `FsVaultStore.abs()` enforce that
+ * backslash rule independently, in the same words, so the two can never
+ * disagree about which path is inside the vault.
  */
 export function normalizeVaultPath(path: string): string {
+  if (path.includes('\\')) throw new Error('path outside vault: backslashes are not allowed');
   let normalized = posix.normalize(path);
   if (normalized.startsWith('./')) normalized = normalized.slice(2);
   if (normalized.startsWith('/') || normalized === '..' || normalized.startsWith('../')) {

--- a/runtime/src/vault/knowledge-paths.ts
+++ b/runtime/src/vault/knowledge-paths.ts
@@ -1,0 +1,14 @@
+import type { VaultConfig } from './resolve-root';
+
+/** Vault-relative path prefixes that hold Counsel OS knowledge-system content,
+ * as opposed to matter workspaces. `entities_path` is config-driven; the rest
+ * are fixed. */
+function knowledgePrefixes(cfg: VaultConfig): string[] {
+  return ['practice/', 'memory/', 'law/', `${cfg.entitiesPath}/`];
+}
+
+/** True when `path` (vault-relative) falls under a knowledge-system directory:
+ * `practice/`, `memory/`, `law/`, or the configured `{entitiesPath}/`. */
+export function isKnowledgePath(path: string, cfg: VaultConfig): boolean {
+  return knowledgePrefixes(cfg).some(prefix => path.startsWith(prefix));
+}

--- a/runtime/src/vault/resolve-root.test.ts
+++ b/runtime/src/vault/resolve-root.test.ts
@@ -174,4 +174,15 @@ describe('readVaultConfig', () => {
     mkdirSync(root, { recursive: true });
     expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
   });
+
+  test('trims a trailing slash from entities_path and matters_path', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'config.md'),
+      `counsel-os-config: true\nlegal_root: ${root}\nentities_path: entities/\nmatters_path: cases/\n`,
+      'utf8',
+    );
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'cases' });
+  });
 });

--- a/runtime/src/vault/resolve-root.test.ts
+++ b/runtime/src/vault/resolve-root.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readVaultConfig, resolveLegalRoot } from './resolve-root';
+
+function tmpDir(prefix: string): string {
+  return mkdtempSync(join(tmpdir(), prefix));
+}
+
+function markRoot(dir: string, legalRoot?: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, 'config.md'),
+    `# Counsel OS Configuration\n\ncounsel-os-config: true\nlegal_root: ${legalRoot ?? dir}\n`,
+    'utf8',
+  );
+}
+
+function unmarkedDir(dir: string): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.md'), '# just a markdown file, not a Counsel OS config\n', 'utf8');
+}
+
+describe('resolveLegalRoot', () => {
+  test('(a) COUNSEL_OS_LEGAL_ROOT set to a marked dir resolves ok', () => {
+    const root = tmpDir('root-');
+    markRoot(root);
+    const result = resolveLegalRoot({
+      env: { COUNSEL_OS_LEGAL_ROOT: root },
+      cwd: tmpDir('cwd-'),
+      home: tmpDir('home-'),
+      conventional: [],
+    });
+    expect(result).toEqual({ ok: true, root });
+  });
+
+  test('(a) COUNSEL_OS_LEGAL_ROOT set to an unmarked dir is code 1, no fallthrough', () => {
+    const root = tmpDir('root-');
+    unmarkedDir(root);
+    // A separately marked root sits in the cwd walk and the conventional list,
+    // proving the invalid env var short-circuits rather than falling through.
+    const cwd = tmpDir('cwd-');
+    markRoot(cwd);
+    const home = tmpDir('home-');
+    const conventionalRoot = tmpDir('conv-');
+    markRoot(conventionalRoot);
+    const result = resolveLegalRoot({
+      env: { COUNSEL_OS_LEGAL_ROOT: root },
+      cwd,
+      home,
+      conventional: [conventionalRoot],
+    });
+    expect(result).toEqual({ ok: false, code: 1, candidates: [] });
+  });
+
+  test('(b) pointer file at <home>/.counsel-os/legal-root resolves ok', () => {
+    const home = tmpDir('home-');
+    const root = tmpDir('root-');
+    markRoot(root);
+    mkdirSync(join(home, '.counsel-os'), { recursive: true });
+    writeFileSync(join(home, '.counsel-os', 'legal-root'), root, 'utf8');
+    const result = resolveLegalRoot({ env: {}, cwd: tmpDir('cwd-'), home, conventional: [] });
+    expect(result).toEqual({ ok: true, root });
+  });
+
+  test('(b) an unmarked pointer target falls through to further search', () => {
+    const home = tmpDir('home-');
+    const bogus = tmpDir('bogus-');
+    unmarkedDir(bogus);
+    mkdirSync(join(home, '.counsel-os'), { recursive: true });
+    writeFileSync(join(home, '.counsel-os', 'legal-root'), bogus, 'utf8');
+    const cwd = tmpDir('cwd-');
+    markRoot(cwd);
+    const result = resolveLegalRoot({ env: {}, cwd, home, conventional: [] });
+    expect(result).toEqual({ ok: true, root: cwd });
+  });
+
+  test('(c) cwd three levels below a marked root resolves ok', () => {
+    const root = tmpDir('root-');
+    markRoot(root);
+    const cwd = join(root, 'a', 'b', 'c');
+    mkdirSync(cwd, { recursive: true });
+    const result = resolveLegalRoot({ env: {}, cwd, home: tmpDir('home-'), conventional: [] });
+    expect(result).toEqual({ ok: true, root });
+  });
+
+  test('(c) cwd four levels below a marked root is not found', () => {
+    const root = tmpDir('root-');
+    markRoot(root);
+    const cwd = join(root, 'a', 'b', 'c', 'd');
+    mkdirSync(cwd, { recursive: true });
+    const result = resolveLegalRoot({ env: {}, cwd, home: tmpDir('home-'), conventional: [] });
+    expect(result).toEqual({ ok: false, code: 1, candidates: [] });
+  });
+
+  test('(d) two marked roots in the conventional list is code 2 with both candidates', () => {
+    const base = tmpDir('conv-');
+    const rootA = join(base, 'vault-a');
+    const rootB = join(base, 'vault-b');
+    markRoot(rootA);
+    markRoot(rootB);
+    const result = resolveLegalRoot({
+      env: {},
+      cwd: tmpDir('cwd-'),
+      home: tmpDir('home-'),
+      conventional: [base],
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.code).toBe(2);
+    expect(result.candidates.slice().sort()).toEqual([rootA, rootB].sort());
+  });
+
+  test('scans the conventional list up to three levels deep, not four', () => {
+    // find -maxdepth 3 caps at base/a/b/config.md (three path components below
+    // base); base/a/b/c/config.md is a fourth component and is excluded.
+    const base = tmpDir('conv-');
+    const shallow = join(base, 'a', 'b');
+    const deep = join(base, 'a', 'b', 'c');
+    markRoot(shallow);
+    markRoot(deep);
+    const result = resolveLegalRoot({
+      env: {},
+      cwd: tmpDir('cwd-'),
+      home: tmpDir('home-'),
+      conventional: [base],
+    });
+    expect(result).toEqual({ ok: true, root: shallow });
+  });
+
+  test('no marked root anywhere is code 1 with no candidates', () => {
+    const result = resolveLegalRoot({
+      env: {},
+      cwd: tmpDir('cwd-'),
+      home: tmpDir('home-'),
+      conventional: [tmpDir('conv-')],
+    });
+    expect(result).toEqual({ ok: false, code: 1, candidates: [] });
+  });
+});
+
+describe('readVaultConfig', () => {
+  test('defaults to entities/ and matters/ when config.md has no overrides', () => {
+    const root = tmpDir('root-');
+    markRoot(root);
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+  });
+
+  test('honors entities_path and matters_path overrides in config.md', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'config.md'),
+      `counsel-os-config: true\nlegal_root: ${root}\nentities_path: clients\nmatters_path: deals\n`,
+      'utf8',
+    );
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'clients', mattersPath: 'deals' });
+  });
+
+  test('ignores commented-out override lines', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(
+      join(root, 'config.md'),
+      `counsel-os-config: true\nlegal_root: ${root}\n# entities_path: entities\n# matters_path: matters\n`,
+      'utf8',
+    );
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+  });
+
+  test('defaults when config.md is missing entirely', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+  });
+});

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -1,0 +1,185 @@
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * Port of `scripts/resolve_legal_root.sh` — the canonical, non-interactive
+ * Counsel OS legal-root discovery algorithm. Keep this in lockstep with the
+ * shell script; it owns the search order, the "marked root" rule, the depth
+ * limits, and the conventional-paths list.
+ */
+
+export interface ResolveRootOptions {
+  env?: NodeJS.ProcessEnv;
+  cwd?: string;
+  home?: string;
+  /** Overrides the conventional vault locations scanned in step 4. */
+  conventional?: string[];
+}
+
+export type ResolveRootResult = { ok: true; root: string } | { ok: false; code: 1 | 2; candidates: string[] };
+
+export interface VaultConfig {
+  entitiesPath: string;
+  mattersPath: string;
+}
+
+const CWD_WALK_MAX_DEPTH = 3;
+const CONVENTIONAL_SCAN_MAX_DEPTH = 3;
+
+/** The conventional local vault locations, verbatim from resolve_legal_root.sh's `known_roots`. */
+function defaultConventionalRoots(home: string): string[] {
+  return [
+    join(home, 'Documents', 'Obsidian Vault'),
+    join(home, 'Library', 'Mobile Documents', 'iCloud~md~obsidian', 'Documents'),
+    join(home, 'Dropbox', 'Obsidian'),
+    join(home, 'legal'),
+    join(home, 'counsel-os'),
+    join(home, 'Documents', 'Counsel OS'),
+  ];
+}
+
+/** A marked legal root is a directory containing config.md with both
+ * `counsel-os-config: true` and a `legal_root:` line — mirrors `is_marked_root`. */
+function isMarkedRoot(root: string): boolean {
+  let stat;
+  try {
+    stat = statSync(root);
+  } catch {
+    return false;
+  }
+  if (!stat.isDirectory()) return false;
+
+  let text: string;
+  try {
+    text = readFileSync(join(root, 'config.md'), 'utf8');
+  } catch {
+    return false;
+  }
+  const lines = text.split('\n');
+  const hasConfigMarker = lines.some(l => l === 'counsel-os-config: true');
+  const hasLegalRoot = lines.some(l => l.startsWith('legal_root:'));
+  return hasConfigMarker && hasLegalRoot;
+}
+
+/** Finds config.md files under `base`, up to `maxDepth` levels deep —
+ * mirrors `find "$base" -maxdepth <maxDepth> -type f -name config.md`. */
+function findConfigFiles(base: string, maxDepth: number): string[] {
+  const results: string[] = [];
+  const walk = (dir: string, depth: number) => {
+    let entries;
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isFile() && entry.name === 'config.md') {
+        results.push(full);
+      } else if (entry.isDirectory() && depth < maxDepth) {
+        walk(full, depth + 1);
+      }
+    }
+  };
+  walk(base, 1);
+  return results;
+}
+
+/**
+ * Resolves the Counsel OS legal root using the same search order as
+ * `scripts/resolve_legal_root.sh`:
+ *   1. COUNSEL_OS_LEGAL_ROOT, when set — resolves immediately either way
+ *      (ok if marked, code 1 if not; no fallthrough to later steps).
+ *   2. ~/.counsel-os/legal-root pointer, when present and marked — resolves
+ *      immediately; an unmarked or empty pointer falls through.
+ *   3. The current working directory and up to three parents.
+ *   4. Conventional local vault locations, scanning up to three levels deep.
+ *
+ * Exit-code contract (mirrors the script's 0/1/2):
+ *   ok:true          — exactly one marked legal root was found.
+ *   ok:false, code:1  — no marked legal root was found, or
+ *                        COUNSEL_OS_LEGAL_ROOT pointed at an invalid root.
+ *   ok:false, code:2  — multiple marked legal roots were found; `candidates`
+ *                        lists them.
+ */
+export function resolveLegalRoot(opts: ResolveRootOptions = {}): ResolveRootResult {
+  const env = opts.env ?? process.env;
+  const cwd = opts.cwd ?? process.cwd();
+  const home = opts.home ?? env.HOME ?? homedir();
+  const conventional = opts.conventional ?? defaultConventionalRoots(home);
+
+  const envRoot = env.COUNSEL_OS_LEGAL_ROOT;
+  if (envRoot) {
+    if (isMarkedRoot(envRoot)) return { ok: true, root: envRoot };
+    return { ok: false, code: 1, candidates: [] };
+  }
+
+  const pointerPath = join(home, '.counsel-os', 'legal-root');
+  if (existsSync(pointerPath)) {
+    let pointer = '';
+    try {
+      pointer = readFileSync(pointerPath, 'utf8').replace(/\n/g, '');
+    } catch {
+      pointer = '';
+    }
+    if (pointer && isMarkedRoot(pointer)) return { ok: true, root: pointer };
+  }
+
+  const matches: string[] = [];
+  const addMatch = (root: string) => {
+    if (isMarkedRoot(root) && !matches.includes(root)) matches.push(root);
+  };
+
+  let dir = cwd;
+  let depth = 0;
+  while (dir !== '/' && depth <= CWD_WALK_MAX_DEPTH) {
+    addMatch(dir);
+    const parent = dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+    depth++;
+  }
+
+  for (const base of conventional) {
+    if (!existsSync(base)) continue;
+    let baseStat;
+    try {
+      baseStat = statSync(base);
+    } catch {
+      continue;
+    }
+    if (!baseStat.isDirectory()) continue;
+    for (const configPath of findConfigFiles(base, CONVENTIONAL_SCAN_MAX_DEPTH)) {
+      addMatch(dirname(configPath));
+    }
+  }
+
+  if (matches.length === 1) return { ok: true, root: matches[0]! };
+  if (matches.length > 1) return { ok: false, code: 2, candidates: matches };
+  return { ok: false, code: 1, candidates: [] };
+}
+
+/** Reads `entities_path` / `matters_path` overrides from `{root}/config.md`,
+ * defaulting to `entities` / `matters` when unset or config.md is missing. */
+export function readVaultConfig(root: string): VaultConfig {
+  let text = '';
+  try {
+    text = readFileSync(join(root, 'config.md'), 'utf8');
+  } catch {
+    text = '';
+  }
+  const lines = text.split('\n');
+  const findOverride = (key: string): string | undefined => {
+    const prefix = `${key}:`;
+    for (const line of lines) {
+      if (line.startsWith(prefix)) return line.slice(prefix.length).trim();
+    }
+    return undefined;
+  };
+
+  return {
+    entitiesPath: findOverride('entities_path') || 'entities',
+    mattersPath: findOverride('matters_path') || 'matters',
+  };
+}

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -173,7 +173,11 @@ export function readVaultConfig(root: string): VaultConfig {
   const findOverride = (key: string): string | undefined => {
     const prefix = `${key}:`;
     for (const line of lines) {
-      if (line.startsWith(prefix)) return line.slice(prefix.length).trim();
+      // Trim a trailing slash — `entities_path: entities/` and
+      // `entities_path: entities` must resolve to the same prefix; a stray
+      // slash otherwise turns `isKnowledgePath`'s `${entitiesPath}/` prefix
+      // into `entities//`, which matches nothing.
+      if (line.startsWith(prefix)) return line.slice(prefix.length).trim().replace(/\/+$/, '');
     }
     return undefined;
   };

--- a/runtime/src/vault/vault-tools.test.ts
+++ b/runtime/src/vault/vault-tools.test.ts
@@ -71,4 +71,46 @@ describe('guardedVaultTools', () => {
     expect(r.isError).toBe(false);
     expect((r.output as any).content).toBe('profile content');
   });
+
+  test('vault_write description states the gate and names the real knowledge-system dirs', () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    const tools = guardedVaultTools(store, { entitiesPath: 'clients', mattersPath: 'deals' });
+    const write = tools.find(t => t.name === 'vault_write')!;
+    expect(write.description).toMatch(/propose_update/);
+    expect(write.description).toContain('practice/');
+    expect(write.description).toContain('memory/');
+    expect(write.description).toContain('law/');
+    expect(write.description).toContain('clients/');
+  });
+
+  describe('a spelled-around knowledge path does not bypass the gate', () => {
+    for (const spelling of ['./practice/standards/x.md', 'matters/../practice/x.md', './/practice/x.md']) {
+      test(`vault_write to "${spelling}" is refused with a propose_update pointer`, async () => {
+        const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+        const tools = guardedVaultTools(store, defaultCfg);
+        const r = await runToolDef(tools, 'vault_write', { path: spelling, content: 'hi' }, 'default');
+        expect(r.isError).toBe(true);
+        expect(String(r.output)).toMatch(/propose_update/);
+        expect(await store.version('default', 'practice/standards/x.md')).toBeNull();
+        expect(await store.version('default', 'practice/x.md')).toBeNull();
+      });
+    }
+
+    test('vault_write to "matters/../matters/a.md" is still allowed — it normalizes to a matter path', async () => {
+      const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+      const tools = guardedVaultTools(store, defaultCfg);
+      const r = await runToolDef(tools, 'vault_write', { path: 'matters/../matters/a.md', content: 'hi' }, 'default');
+      expect(r.isError).toBe(false);
+      expect(await store.read('default', 'matters/a.md')).toBe('hi');
+    });
+  });
+
+  test('vault_read normalizes its path before hitting the store, same as vault_write', async () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    await store.write('default', 'matters/a.md', 'hi');
+    const tools = guardedVaultTools(store, defaultCfg);
+    const r = await runToolDef(tools, 'vault_read', { path: 'matters/../matters/a.md' }, 'default');
+    expect(r.isError).toBe(false);
+    expect((r.output as any).content).toBe('hi');
+  });
 });

--- a/runtime/src/vault/vault-tools.test.ts
+++ b/runtime/src/vault/vault-tools.test.ts
@@ -103,6 +103,18 @@ describe('guardedVaultTools', () => {
       expect(r.isError).toBe(false);
       expect(await store.read('default', 'matters/a.md')).toBe('hi');
     });
+
+    test('vault_write to a backslash-separated path is an error result, not a silent write outside the gate', async () => {
+      // On a Windows host, `practice\x.md` would resolve *inside* `practice/`
+      // via `path.win32`, while `posix.normalize` would see it as a single
+      // opaque filename and never trip the knowledge-path check. Vault paths
+      // are forward-slash only precisely so this can't happen.
+      const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+      const tools = guardedVaultTools(store, defaultCfg);
+      const r = await runToolDef(tools, 'vault_write', { path: 'practice\\x.md', content: 'hi' }, 'default');
+      expect(r.isError).toBe(true);
+      expect(String(r.output)).toMatch(/backslash/);
+    });
   });
 
   test('vault_read normalizes its path before hitting the store, same as vault_write', async () => {

--- a/runtime/src/vault/vault-tools.test.ts
+++ b/runtime/src/vault/vault-tools.test.ts
@@ -3,8 +3,11 @@ import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FsVaultStore } from './fs-store';
-import { vaultTools } from './vault-tools';
+import { guardedVaultTools, vaultTools } from './vault-tools';
 import { runToolDef } from '../core/fake-provider';
+import type { VaultConfig } from './resolve-root';
+
+const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
 
 describe('vault tools', () => {
   test('exposes four tools and round-trips through runToolDef', async () => {
@@ -31,5 +34,41 @@ describe('vault tools', () => {
       expect(t.description).toContain('relative to the vault root');
       expect(t.description).toContain('use `.` for the root');
     }
+  });
+});
+
+describe('guardedVaultTools', () => {
+  test('exposes the same four tools as vaultTools', () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    const tools = guardedVaultTools(store, defaultCfg);
+    expect(tools.map(t => t.name).sort()).toEqual(['vault_list', 'vault_read', 'vault_search', 'vault_write']);
+  });
+
+  test('vault_write to a knowledge-system path is refused with a propose_update pointer', async () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    const tools = guardedVaultTools(store, defaultCfg);
+    const r = await runToolDef(tools, 'vault_write', { path: 'practice/standards/x.md', content: 'hi' }, 'default');
+    expect(r.isError).toBe(true);
+    expect(String(r.output)).toMatch(/propose_update/);
+
+    const readBack = await store.version('default', 'practice/standards/x.md');
+    expect(readBack).toBeNull();
+  });
+
+  test('vault_write to a matter path still writes directly', async () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    const tools = guardedVaultTools(store, defaultCfg);
+    const r = await runToolDef(tools, 'vault_write', { path: 'matters/a.md', content: 'hi' }, 'default');
+    expect(r.isError).toBe(false);
+    expect(await store.read('default', 'matters/a.md')).toBe('hi');
+  });
+
+  test('vault_read/vault_list/vault_search are unaffected by the guard', async () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    await store.write('default', 'practice/profile.md', 'profile content');
+    const tools = guardedVaultTools(store, defaultCfg);
+    const r = await runToolDef(tools, 'vault_read', { path: 'practice/profile.md' }, 'default');
+    expect(r.isError).toBe(false);
+    expect((r.output as any).content).toBe('profile content');
   });
 });

--- a/runtime/src/vault/vault-tools.ts
+++ b/runtime/src/vault/vault-tools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ToolDef, VaultStore } from '../core/types';
-import { isKnowledgePath } from './knowledge-paths';
+import { isKnowledgePath, normalizeVaultPath } from './knowledge-paths';
 import type { VaultConfig } from './resolve-root';
 
 // Every vault path is relative to the vault root, and an absolute-looking one
@@ -47,25 +47,57 @@ export function vaultTools(store: VaultStore): ToolDef[] {
   return [read, write, list, search] as ToolDef[];
 }
 
+/** Vault-relative knowledge-system directories, for user-facing text (tool
+ * descriptions, error messages) — the fixed three plus the configured
+ * entities dir, matching `isKnowledgePath`'s own prefix list. */
+function knowledgeDirsList(cfg: VaultConfig): string {
+  return `practice/, memory/, law/, ${cfg.entitiesPath}/`;
+}
+
 /**
  * Same tools as `vaultTools`, except `vault_write` refuses knowledge-system
  * paths (`practice/`, `memory/`, `law/`, the configured entities dir — see
  * `isKnowledgePath`). The `remember` gate: those writes must go through
  * `propose_update` and founder/user approval; matter paths stay directly
  * writable.
+ *
+ * Every path argument (`vault_write`'s `path`, and — for consistency, since
+ * a normalized path is what actually reaches the store — `vault_read`'s
+ * `path` and `vault_list`'s `dir`) is run through `normalizeVaultPath` first,
+ * so a spelling like `./practice/x.md` or `matters/../practice/x.md` can't
+ * be used to dodge the knowledge-path check that a plain string-prefix test
+ * would miss.
  */
 export function guardedVaultTools(store: VaultStore, cfg: VaultConfig): ToolDef[] {
   return vaultTools(store).map(tool => {
-    if (tool.name !== 'vault_write') return tool;
-    const write = tool as ToolDef<{ path: string; content: string; expectedVersion?: string }, { version: string }>;
-    return {
-      ...write,
-      execute: async (input: { path: string; content: string; expectedVersion?: string }, ctx) => {
-        if (isKnowledgePath(input.path, cfg)) {
-          throw new Error(`${input.path} is a knowledge-system path — use propose_update instead of vault_write.`);
-        }
-        return write.execute(input, ctx);
-      },
-    };
+    if (tool.name === 'vault_write') {
+      const write = tool as ToolDef<{ path: string; content: string; expectedVersion?: string }, { version: string }>;
+      return {
+        ...write,
+        description: `${write.description} Knowledge-system paths (${knowledgeDirsList(cfg)}) must go through propose_update instead.`,
+        execute: async (input: { path: string; content: string; expectedVersion?: string }, ctx) => {
+          const path = normalizeVaultPath(input.path);
+          if (isKnowledgePath(path, cfg)) {
+            throw new Error(`${path} is a knowledge-system path (${knowledgeDirsList(cfg)}) — use propose_update instead of vault_write.`);
+          }
+          return write.execute({ ...input, path }, ctx);
+        },
+      };
+    }
+    if (tool.name === 'vault_read') {
+      const read = tool as ToolDef<{ path: string }, { content: string; version: string | null }>;
+      return {
+        ...read,
+        execute: async (input: { path: string }, ctx) => read.execute({ ...input, path: normalizeVaultPath(input.path) }, ctx),
+      };
+    }
+    if (tool.name === 'vault_list') {
+      const list = tool as ToolDef<{ dir: string }, unknown>;
+      return {
+        ...list,
+        execute: async (input: { dir: string }, ctx) => list.execute({ ...input, dir: normalizeVaultPath(input.dir) }, ctx),
+      };
+    }
+    return tool;
   });
 }

--- a/runtime/src/vault/vault-tools.ts
+++ b/runtime/src/vault/vault-tools.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import type { ToolDef, VaultStore } from '../core/types';
+import { isKnowledgePath } from './knowledge-paths';
+import type { VaultConfig } from './resolve-root';
 
 // Every vault path is relative to the vault root, and an absolute-looking one
 // is rejected by `FsVaultStore`. Models do not infer that: both Codex spike
@@ -43,4 +45,27 @@ export function vaultTools(store: VaultStore): ToolDef[] {
     execute: async ({ query }, { tenant }) => store.search(tenant, query),
   };
   return [read, write, list, search] as ToolDef[];
+}
+
+/**
+ * Same tools as `vaultTools`, except `vault_write` refuses knowledge-system
+ * paths (`practice/`, `memory/`, `law/`, the configured entities dir — see
+ * `isKnowledgePath`). The `remember` gate: those writes must go through
+ * `propose_update` and founder/user approval; matter paths stay directly
+ * writable.
+ */
+export function guardedVaultTools(store: VaultStore, cfg: VaultConfig): ToolDef[] {
+  return vaultTools(store).map(tool => {
+    if (tool.name !== 'vault_write') return tool;
+    const write = tool as ToolDef<{ path: string; content: string; expectedVersion?: string }, { version: string }>;
+    return {
+      ...write,
+      execute: async (input: { path: string; content: string; expectedVersion?: string }, ctx) => {
+        if (isKnowledgePath(input.path, cfg)) {
+          throw new Error(`${input.path} is a knowledge-system path — use propose_update instead of vault_write.`);
+        }
+        return write.execute(input, ctx);
+      },
+    };
+  });
 }

--- a/scripts/runtime_step.sh
+++ b/scripts/runtime_step.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Hands a request off to the local counsel-os runtime (spec §4.7), when one
+# is running. Called by the plugin skill before it does anything else; a
+# non-zero exit means "no runtime, proceed with the skill as usual" and must
+# stay silent, so a missing/optional runtime is never visible to the user.
+#
+#   exit 0  the runtime handled it; its text is already on stdout
+#   exit 1  the runtime reported an error; the message is on stderr
+#   exit 3  no runtime available (missing deps, no runtime.json, dead
+#           server, or anything else that stops us before a step could
+#           even start) — always silent: no stdout, no stderr
+
+REQUEST="${1:-}"
+
+command -v curl >/dev/null 2>&1 || exit 3
+command -v jq >/dev/null 2>&1 || exit 3
+
+# `runtime.json` may live under an explicit COUNSEL_OS_HOME override (what
+# the tests use) or the real default; check both, in that order.
+runtime_file=""
+if [[ -n "${COUNSEL_OS_HOME:-}" && -f "${COUNSEL_OS_HOME}/runtime.json" ]]; then
+  runtime_file="${COUNSEL_OS_HOME}/runtime.json"
+elif [[ -f "${HOME}/.counsel-os/runtime.json" ]]; then
+  runtime_file="${HOME}/.counsel-os/runtime.json"
+fi
+[[ -n "$runtime_file" && -r "$runtime_file" ]] || exit 3
+
+port="$(jq -r '.port // empty' "$runtime_file" 2>/dev/null)"
+token="$(jq -r '.token // empty' "$runtime_file" 2>/dev/null)"
+[[ -n "$port" && -n "$token" ]] || exit 3
+
+base="http://127.0.0.1:${port}"
+
+# A dead/unreachable server (stale runtime.json, crashed process) is exactly
+# like no runtime at all.
+curl -sf --max-time 1 -H "Authorization: Bearer ${token}" "${base}/health" >/dev/null 2>&1 || exit 3
+
+cache_file="${TMPDIR:-/tmp}/counsel-os-thread-${CLAUDE_SESSION_ID:-$PPID}"
+
+create_thread() {
+  curl -sf --max-time 5 -X POST -H "Authorization: Bearer ${token}" "${base}/threads" 2>/dev/null \
+    | jq -r '.id // empty' 2>/dev/null
+}
+
+thread_id=""
+[[ -f "$cache_file" ]] && thread_id="$(cat "$cache_file" 2>/dev/null)"
+
+# A cached thread the runtime no longer knows about (restarted server, vault
+# moved) gets replaced rather than failed on.
+if [[ -n "$thread_id" ]]; then
+  status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 -H "Authorization: Bearer ${token}" "${base}/threads/${thread_id}" 2>/dev/null)"
+  [[ "$status" == "200" ]] || thread_id=""
+fi
+
+if [[ -z "$thread_id" ]]; then
+  thread_id="$(create_thread)"
+  [[ -n "$thread_id" ]] || exit 3
+  printf '%s' "$thread_id" > "$cache_file" 2>/dev/null || exit 3
+fi
+
+step_body="$(jq -n --arg msg "$REQUEST" '{message: $msg}')"
+
+current_event=""
+saw_terminal=0
+exit_code=3
+
+while IFS= read -r line; do
+  case "$line" in
+    "event: "*)
+      current_event="${line#event: }"
+      ;;
+    "data: "*)
+      payload="${line#data: }"
+      case "$current_event" in
+        text)
+          printf '%s' "$(jq -rn --unbuffered --argjson d "$payload" '$d.text')"
+          ;;
+        tool_call)
+          name="$(jq -rn --unbuffered --argjson d "$payload" '$d.name')"
+          echo "→ tool ${name}" >&2
+          ;;
+        error)
+          message="$(jq -rn --unbuffered --argjson d "$payload" '$d.message')"
+          echo "⚠ ${message}" >&2
+          saw_terminal=1
+          exit_code=1
+          break
+          ;;
+        done)
+          saw_terminal=1
+          exit_code=0
+          break
+          ;;
+      esac
+      ;;
+  esac
+done < <(curl -sN --max-time 120 -X POST \
+  -H "Authorization: Bearer ${token}" \
+  -H "Content-Type: application/json" \
+  --data-binary "$step_body" \
+  "${base}/threads/${thread_id}/steps")
+
+# The stream closed without a terminal event (transport failure, server
+# killed mid-step) — not a runtime we can trust the answer from.
+[[ "$saw_terminal" == "1" ]] || exit 3
+
+exit "$exit_code"

--- a/scripts/runtime_step.sh
+++ b/scripts/runtime_step.sh
@@ -1,14 +1,26 @@
 #!/usr/bin/env bash
 # Hands a request off to the local counsel-os runtime (spec §4.7), when one
 # is running. Called by the plugin skill before it does anything else; a
-# non-zero exit means "no runtime, proceed with the skill as usual" and must
-# stay silent, so a missing/optional runtime is never visible to the user.
+# non-zero exit means "no runtime, proceed with the skill as usual".
 #
 #   exit 0  the runtime handled it; its text is already on stdout
-#   exit 1  the runtime reported an error; the message is on stderr
-#   exit 3  no runtime available (missing deps, no runtime.json, dead
-#           server, or anything else that stops us before a step could
-#           even start) — always silent: no stdout, no stderr
+#   exit 1  the runtime reported an `error` event, OR the stream ended
+#           without a terminal event AFTER some text had already reached
+#           stdout — the message is on stderr ("⚠ ...")
+#   exit 3  no runtime available, and NOTHING has been printed yet (missing
+#           deps, no runtime.json, dead server, a step that ended before
+#           its first byte of text) — always silent: no stdout, no stderr
+#
+# The silent exit-3 contract holds ONLY until the first byte of text has
+# gone to stdout. Once text has been relayed to the user, a failure can no
+# longer be swallowed silently — the caller already has partial output on
+# screen — so from that point on a broken stream is reported (exit 1 + a
+# stderr warning) instead.
+#
+# A malformed `data:` line (bad JSON) is skipped, not fatal: the loop keeps
+# reading for the terminal event that follows it.
+
+set -euo pipefail
 
 REQUEST="${1:-}"
 
@@ -20,47 +32,59 @@ command -v jq >/dev/null 2>&1 || exit 3
 runtime_file=""
 if [[ -n "${COUNSEL_OS_HOME:-}" && -f "${COUNSEL_OS_HOME}/runtime.json" ]]; then
   runtime_file="${COUNSEL_OS_HOME}/runtime.json"
-elif [[ -f "${HOME}/.counsel-os/runtime.json" ]]; then
-  runtime_file="${HOME}/.counsel-os/runtime.json"
+elif [[ -f "${HOME:-}/.counsel-os/runtime.json" ]]; then
+  runtime_file="${HOME:-}/.counsel-os/runtime.json"
 fi
 [[ -n "$runtime_file" && -r "$runtime_file" ]] || exit 3
 
-port="$(jq -r '.port // empty' "$runtime_file" 2>/dev/null)"
-token="$(jq -r '.token // empty' "$runtime_file" 2>/dev/null)"
-[[ -n "$port" && -n "$token" ]] || exit 3
+port="$(jq -r '.port // empty' "$runtime_file" 2>/dev/null)" || true
+token="$(jq -r '.token // empty' "$runtime_file" 2>/dev/null)" || true
+[[ -n "${port:-}" && -n "${token:-}" ]] || exit 3
 
 base="http://127.0.0.1:${port}"
 
+# Every request authenticates through a curl config file handed in via
+# process substitution (`header = "..."`), never `-H` on the command line,
+# so the bearer token never lands in this process's argv — and so never in
+# `ps`. `printf` here is the bash builtin, not an external binary, so the
+# token never appears as an exec'd process's argv either.
+curl_auth() {
+  curl -K <(printf 'header = "Authorization: Bearer %s"\n' "$token") "$@"
+}
+
 # A dead/unreachable server (stale runtime.json, crashed process) is exactly
 # like no runtime at all.
-curl -sf --max-time 1 -H "Authorization: Bearer ${token}" "${base}/health" >/dev/null 2>&1 || exit 3
+curl_auth -sf --max-time 1 "${base}/health" >/dev/null 2>&1 || exit 3
 
 cache_file="${TMPDIR:-/tmp}/counsel-os-thread-${CLAUDE_SESSION_ID:-$PPID}"
 
 create_thread() {
-  curl -sf --max-time 5 -X POST -H "Authorization: Bearer ${token}" "${base}/threads" 2>/dev/null \
+  curl_auth -sf --max-time 5 -X POST "${base}/threads" 2>/dev/null \
     | jq -r '.id // empty' 2>/dev/null
 }
 
 thread_id=""
-[[ -f "$cache_file" ]] && thread_id="$(cat "$cache_file" 2>/dev/null)"
+if [[ -f "$cache_file" ]]; then
+  thread_id="$(cat "$cache_file" 2>/dev/null)" || true
+fi
 
 # A cached thread the runtime no longer knows about (restarted server, vault
 # moved) gets replaced rather than failed on.
 if [[ -n "$thread_id" ]]; then
-  status="$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 -H "Authorization: Bearer ${token}" "${base}/threads/${thread_id}" 2>/dev/null)"
-  [[ "$status" == "200" ]] || thread_id=""
+  status="$(curl_auth -s -o /dev/null -w '%{http_code}' --max-time 3 "${base}/threads/${thread_id}" 2>/dev/null)" || true
+  [[ "${status:-}" == "200" ]] || thread_id=""
 fi
 
 if [[ -z "$thread_id" ]]; then
-  thread_id="$(create_thread)"
+  thread_id="$(create_thread)" || true
   [[ -n "$thread_id" ]] || exit 3
   printf '%s' "$thread_id" > "$cache_file" 2>/dev/null || exit 3
 fi
 
-step_body="$(jq -n --arg msg "$REQUEST" '{message: $msg}')"
+step_body="$(jq -n --arg msg "$REQUEST" '{message: $msg}')" || exit 3
 
 current_event=""
+printed=0
 saw_terminal=0
 exit_code=3
 
@@ -73,18 +97,24 @@ while IFS= read -r line; do
       payload="${line#data: }"
       case "$current_event" in
         text)
-          printf '%s' "$(jq -rn --unbuffered --argjson d "$payload" '$d.text')"
+          # Written directly (no `$(...)`) so every fragment reaches stdout
+          # byte-exact, with no trailing newline appended.
+          if jq -j -n --argjson d "$payload" '$d.text' 2>/dev/null; then
+            printed=1
+          fi
           ;;
         tool_call)
-          name="$(jq -rn --unbuffered --argjson d "$payload" '$d.name')"
-          echo "→ tool ${name}" >&2
+          if name="$(jq -rn --argjson d "$payload" '$d.name' 2>/dev/null)"; then
+            echo "→ tool ${name}" >&2
+          fi
           ;;
         error)
-          message="$(jq -rn --unbuffered --argjson d "$payload" '$d.message')"
-          echo "⚠ ${message}" >&2
-          saw_terminal=1
-          exit_code=1
-          break
+          if message="$(jq -rn --argjson d "$payload" '$d.message' 2>/dev/null)"; then
+            echo "⚠ ${message}" >&2
+            saw_terminal=1
+            exit_code=1
+            break
+          fi
           ;;
         done)
           saw_terminal=1
@@ -94,14 +124,17 @@ while IFS= read -r line; do
       esac
       ;;
   esac
-done < <(curl -sN --max-time 120 -X POST \
-  -H "Authorization: Bearer ${token}" \
+done < <(curl_auth -sN --max-time 120 -X POST \
   -H "Content-Type: application/json" \
   --data-binary "$step_body" \
   "${base}/threads/${thread_id}/steps")
 
-# The stream closed without a terminal event (transport failure, server
-# killed mid-step) — not a runtime we can trust the answer from.
-[[ "$saw_terminal" == "1" ]] || exit 3
+if [[ "$saw_terminal" != "1" ]]; then
+  if [[ "$printed" == "1" ]]; then
+    echo "⚠ runtime stream ended unexpectedly" >&2
+    exit 1
+  fi
+  exit 3
+fi
 
 exit "$exit_code"

--- a/scripts/runtime_step.sh
+++ b/scripts/runtime_step.sh
@@ -19,6 +19,14 @@
 #
 # A malformed `data:` line (bad JSON) is skipped, not fatal: the loop keeps
 # reading for the terminal event that follows it.
+#
+# The step POST carries NO `--max-time`. A counsel step is a whole model turn
+# and can legitimately run for many minutes (a long document review, a slow
+# local model); a wall-clock deadline on it would cut a healthy stream off
+# mid-answer and report it as a broken one. Liveness is covered where it is
+# cheap instead: `--connect-timeout` bounds reaching a dead server on every
+# request, and the `/health` probe above still has a 1 s deadline, so an
+# unreachable or wedged runtime is caught before any step is sent.
 
 set -euo pipefail
 
@@ -124,7 +132,7 @@ while IFS= read -r line; do
       esac
       ;;
   esac
-done < <(curl_auth -sN --max-time 120 -X POST \
+done < <(curl_auth -sN --connect-timeout 2 -X POST \
   -H "Content-Type: application/json" \
   --data-binary "$step_body" \
   "${base}/threads/${thread_id}/steps")

--- a/scripts/runtime_step.test.ts
+++ b/scripts/runtime_step.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { FakeModelProvider } from '../runtime/src/core/fake-provider';
+import { Router } from '../runtime/src/router/router';
+import { createApp, type App, type ServerDeps } from '../runtime/src/server/routes';
+import { ThreadStore } from '../runtime/src/threads/store';
+import { FsVaultStore } from '../runtime/src/vault/fs-store';
+
+const TOKEN = 'test-token-0123456789';
+const SCRIPT = join(import.meta.dir, 'runtime_step.sh');
+
+type BunServer = ReturnType<typeof Bun.serve>;
+
+let servers: BunServer[] = [];
+
+afterEach(() => {
+  for (const server of servers) server.stop(true);
+  servers = [];
+});
+
+/** Serves `createApp(...)` on a random loopback port — no `startServer`, so
+ * no live provider ever gets a chance to run. */
+function serveFake(script: ConstructorParameters<typeof FakeModelProvider>[0]): { url: string; token: string } {
+  const vaultRoot = mkdtempSync(join(tmpdir(), 'runtime-step-vault-'));
+  const pluginRoot = mkdtempSync(join(tmpdir(), 'runtime-step-plugin-'));
+  mkdirSync(join(pluginRoot, 'skills', 'counsel'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'skills', 'counsel', 'SKILL.md'), '---\nname: counsel\n---\n\nBODY.\n', 'utf8');
+  mkdirSync(join(pluginRoot, 'primitives'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'primitives', 'draft.md'), 'DRAFT.\n', 'utf8');
+
+  const provider = new FakeModelProvider(script);
+  const deps: ServerDeps = {
+    token: TOKEN,
+    tenant: 'default',
+    vaultRoot,
+    pluginRoot,
+    vault: new FsVaultStore(vaultRoot),
+    store: new ThreadStore(vaultRoot, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'runtime-step-codex-')) }),
+    providers: [provider],
+    router: new Router({ default: provider.id }, [provider]),
+    platform: 'macos',
+  };
+  const app: App = createApp(deps);
+  const server = Bun.serve({ hostname: '127.0.0.1', port: 0, fetch: app });
+  servers.push(server);
+  return { url: `http://127.0.0.1:${server.port}`, token: TOKEN };
+}
+
+/** Writes a fresh `COUNSEL_OS_HOME` with `runtime.json` pointing at `url`
+ * (or an arbitrary dead port when `url` is omitted). Returns the dir to use
+ * as both `COUNSEL_OS_HOME` and `TMPDIR` for the spawned script, so the
+ * thread-id cache file lives inside it too. */
+function homeFor(opts: { url?: string; token?: string } = {}): string {
+  const home = mkdtempSync(join(tmpdir(), 'runtime-step-home-'));
+  const port = opts.url ? Number(new URL(opts.url).port) : 1; // port 1: nothing listens there
+  writeFileSync(
+    join(home, 'runtime.json'),
+    JSON.stringify({ port, token: opts.token ?? TOKEN, vault: home, pid: process.pid, startedAt: new Date().toISOString() }),
+    'utf8',
+  );
+  return home;
+}
+
+interface RunResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+async function run(env: Record<string, string | undefined>, request = 'what is a force majeure clause?'): Promise<RunResult> {
+  const proc = Bun.spawn(['bash', SCRIPT, request], {
+    env: { ...process.env, ...env },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+describe('runtime_step.sh', () => {
+  test('relays the fake provider text to stdout and exits 0', async () => {
+    const { url } = serveFake([{ text: 'a force majeure clause excuses non-performance.' }]);
+    const home = homeFor({ url });
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.stdout).toContain('a force majeure clause excuses non-performance.');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('no runtime.json means exit 3 with empty stdout', async () => {
+    const home = mkdtempSync(join(tmpdir(), 'runtime-step-home-'));
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stdout).toBe('');
+  });
+
+  test('a runtime.json pointing at a dead port means exit 3', async () => {
+    const home = homeFor(); // no server started at all — the port is unreachable
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.exitCode).toBe(3);
+    expect(result.stdout).toBe('');
+  });
+
+  test('a provider error exits 1 and prints a warning to stderr', async () => {
+    const { url } = serveFake([{ error: 'model exploded' }]);
+    const home = homeFor({ url });
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('⚠');
+    expect(result.stderr).toContain('model exploded');
+  });
+
+  test('a second run reuses the cached thread', async () => {
+    const { url } = serveFake([{ text: 'first answer' }, { text: 'second answer' }]);
+    const home = homeFor({ url });
+
+    const first = await run({ COUNSEL_OS_HOME: home, TMPDIR: home }, 'first question');
+    expect(first.exitCode).toBe(0);
+    expect(first.stdout).toContain('first answer');
+
+    const second = await run({ COUNSEL_OS_HOME: home, TMPDIR: home }, 'second question');
+    expect(second.exitCode).toBe(0);
+    expect(second.stdout).toContain('second answer');
+
+    const listRes = await fetch(`${url}/threads`, { headers: { authorization: `Bearer ${TOKEN}` } });
+    const threads = (await listRes.json()) as Array<{ id: string }>;
+    expect(threads.length).toBe(1);
+
+    const oneRes = await fetch(`${url}/threads/${threads[0]!.id}`, { headers: { authorization: `Bearer ${TOKEN}` } });
+    const one = (await oneRes.json()) as { events: Array<Record<string, unknown>> };
+    const userEvents = one.events.filter(ev => ev['t'] === 'user');
+    expect(userEvents.length).toBe(2);
+    expect(userEvents.map(ev => ev['content'])).toEqual(['first question', 'second question']);
+  });
+});

--- a/scripts/runtime_step.test.ts
+++ b/scripts/runtime_step.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -83,6 +83,57 @@ async function run(env: Record<string, string | undefined>, request = 'what is a
   return { stdout, stderr, exitCode };
 }
 
+/** One SSE frame, formatted the way `runtime/src/server/sse.ts` writes them. */
+function sseFrame(type: string, data: unknown): string {
+  return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+/**
+ * A hand-rolled server exposing just enough of the real HTTP surface
+ * (`/health`, `POST /threads`, `GET /threads/:id`, `POST
+ * /threads/:id/steps`) to drive the adapter, but with the steps response
+ * built by the caller — raw bytes, not `sseFromEvents` — so a test can hand
+ * the script malformed frames, timed chunks, or a stream that ends with no
+ * terminal event at all. No `createApp`, no provider, live or fake.
+ */
+function serveThreadShaped(threadId: string, respondSteps: () => Response): { url: string } {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === '/health') return Response.json({});
+      if (url.pathname === '/threads' && req.method === 'POST') return Response.json({ id: threadId }, { status: 201 });
+      if (url.pathname === `/threads/${threadId}` && req.method === 'GET') {
+        return Response.json({ header: { id: threadId }, events: [] });
+      }
+      if (url.pathname === `/threads/${threadId}/steps` && req.method === 'POST') return respondSteps();
+      return new Response('not found', { status: 404 });
+    },
+  });
+  servers.push(server);
+  return { url: `http://127.0.0.1:${server.port}` };
+}
+
+/** Runs the script and timestamps every chunk that reaches its stdout, so a
+ * test can assert *when* text arrived, not just that it eventually did. */
+async function runStreaming(
+  env: Record<string, string | undefined>,
+  request = 'what is a force majeure clause?',
+): Promise<{ chunks: Array<{ text: string; at: number }>; exitCode: number }> {
+  const proc = Bun.spawn(['bash', SCRIPT, request], { env: { ...process.env, ...env }, stdout: 'pipe', stderr: 'pipe' });
+  const chunks: Array<{ text: string; at: number }> = [];
+  const reader = proc.stdout.getReader();
+  const decoder = new TextDecoder();
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    chunks.push({ text: decoder.decode(value), at: Date.now() });
+  }
+  const exitCode = await proc.exited;
+  return { chunks, exitCode };
+}
+
 describe('runtime_step.sh', () => {
   test('relays the fake provider text to stdout and exits 0', async () => {
     const { url } = serveFake([{ text: 'a force majeure clause excuses non-performance.' }]);
@@ -144,5 +195,78 @@ describe('runtime_step.sh', () => {
     const userEvents = one.events.filter(ev => ev['t'] === 'user');
     expect(userEvents.length).toBe(2);
     expect(userEvents.map(ev => ev['content'])).toEqual(['first question', 'second question']);
+  });
+
+  test('a malformed data line is skipped, not fatal — text and done around it still work', async () => {
+    const threadId = 'aaaaaaaa-0000-0000-0000-000000000001';
+    const body =
+      'event: text\ndata: not-json-at-all\n\n' + // malformed on purpose — not valid JSON at all
+      sseFrame('text', { type: 'text', text: 'hello' }) +
+      sseFrame('done', { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } });
+    const { url } = serveThreadShaped(
+      threadId,
+      () => new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } }),
+    );
+    const home = homeFor({ url });
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.stdout).toBe('hello');
+    expect(result.stderr).toBe('');
+    expect(result.exitCode).toBe(0);
+  });
+
+  test('text arrives incrementally, not buffered until the stream ends', async () => {
+    const threadId = 'aaaaaaaa-0000-0000-0000-000000000002';
+    const { url } = serveThreadShaped(threadId, () => {
+      const encoder = new TextEncoder();
+      const streamBody = new ReadableStream<Uint8Array>({
+        async start(controller) {
+          controller.enqueue(encoder.encode(sseFrame('text', { type: 'text', text: 'A' })));
+          await new Promise(resolve => setTimeout(resolve, 300));
+          controller.enqueue(encoder.encode(sseFrame('text', { type: 'text', text: 'B' })));
+          controller.enqueue(
+            encoder.encode(sseFrame('done', { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } })),
+          );
+          controller.close();
+        },
+      });
+      return new Response(streamBody, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    });
+    const home = homeFor({ url });
+
+    const { chunks, exitCode } = await runStreaming({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(exitCode).toBe(0);
+    const combined = chunks.map(c => c.text).join('');
+    expect(combined).toBe('AB');
+    const aArrival = chunks.find(c => c.text.includes('A'))?.at;
+    const bArrival = chunks.find(c => c.text.includes('B'))?.at;
+    expect(aArrival).toBeDefined();
+    expect(bArrival).toBeDefined();
+    // The server held 'B' back for 300ms; a script that buffered until the
+    // stream closed would deliver both in the same chunk, ~0ms apart.
+    expect(bArrival! - aArrival!).toBeGreaterThanOrEqual(250);
+  });
+
+  test('text printed, then the stream is cut short with no terminal event: exit 1, not silent exit 3', async () => {
+    const threadId = 'aaaaaaaa-0000-0000-0000-000000000003';
+    const { url } = serveThreadShaped(threadId, () => {
+      const encoder = new TextEncoder();
+      const streamBody = new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseFrame('text', { type: 'text', text: 'partial' })));
+          controller.close(); // no `done`, no `error` — simulates a provider that threw mid-stream
+        },
+      });
+      return new Response(streamBody, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+    });
+    const home = homeFor({ url });
+
+    const result = await run({ COUNSEL_OS_HOME: home, TMPDIR: home });
+
+    expect(result.stdout).toBe('partial');
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain('⚠');
   });
 });

--- a/skills/counsel/SKILL.md
+++ b/skills/counsel/SKILL.md
@@ -10,6 +10,8 @@ when_to_use: "Trigger phrases: 'can we do X', 'is X legal/compliant/allowed', 'w
 
 Counsel OS is a legal practice system. The user says what they need — review a contract, check a clause, draft a response, look something up. You figure out how to do it using the primitives below. There are no phases, no pipeline, no slash commands for legal work. Just capabilities you compose based on the request.
 
+**Runtime hand-off (Claude Code only).** Before any other step, run `bash "${CLAUDE_PLUGIN_ROOT}/scripts/runtime_step.sh" "<the user's request, verbatim>"`. Exit 0 means the local counsel-os runtime handled the request: relay its output to the user and stop. Exit 3 means no runtime is running: continue with this skill exactly as below. Exit 1 means the runtime hit an error: show the message and continue with this skill.
+
 ### The 5 Primitives
 
 These are your capabilities. For each request, decide which ones to use and in what combination. Read the full primitive file (`primitives/{name}.md`) when you need the detailed instructions for a mode.


### PR DESCRIPTION
## Why

Step 2 of the runtime (spec: `docs/superpowers/specs/2026-08-28-counsel-loop-api-adapter-design.md`). PR #21 gave counsel-os an engine; this makes it something a lawyer can talk to — from the plugin today and from the web UI next — with one shared, vault-resident conversation history.

## What

- **Threads** — `.counsel/threads/<tenant>/<id>.{json,jsonl}` (model-unwritable); vendor sessions mapped underneath: Claude `resume`, Codex `resumeThread` from a persistent per-thread isolated home (`$COUNSEL_OS_HOME/codex/<id>`, 0700, credential copy 0600, removed with the thread). Resume failure → warning event, clear id, replay once.
- **Counsel loop** — system prompt = host preamble + `skills/counsel/SKILL.md` body + practice profile + matter; primitives via `read_primitive`; scripts as tools (`extract_redlines`, `check_document --json`, `clean_format`, `apply_redlines`, `word_compare` macOS); `vault_write` refuses knowledge-system paths (normalized: `./`, `..`, backslash, case) → `propose_update` + approval with expected-version/expect-missing semantics; run logs with whole-turn timing; coalesced text in the log, flushed on disconnect.
- **Providers** — `~/.counsel-os/providers.yaml` registry (`openai-compatible/<name>` + `baseURL`/`apiKeyEnv`), `withRetry` (status-shaped errors only; closes abandoned iterators). Vault-root resolution ported from `resolve_legal_root.sh`.
- **Server** — `counsel-os serve`: loopback, 256-bit bearer token (constant-time), `runtime.json` (0600, tmp+rename, pid-owned removal), `/health`, `/threads`, `/threads/:id/steps` (SSE, coalesced, always terminal), `/threads/:id/approve` (409 on conflict), `/vault/read|list` (read-only; realpath containment; `.counsel` excluded, case-insensitive), per-thread locks on steps/approve/delete, providers closed on client disconnect.
- **Plugin adapter** — `scripts/runtime_step.sh` + one paragraph in `skills/counsel/SKILL.md`: uses the server when `runtime.json` exists and `/health` answers; otherwise exit 3, silent, and the skill runs exactly as today. **No change for users without the runtime.**

Plan: `docs/superpowers/plans/2026-08-28-counsel-loop-api-adapter.md`. Live findings: `docs/superpowers/spikes/2026-08-28-runtime-spikes.md` (Step 2 section).

## Verified live (8 subscription calls)
Claude resume across two steps ✓ · Codex resume (no tool calls) ✓ · Ollama tools through the server ✓ · proposal → file unchanged → approve → written, second approve 409 ✓ · adapter exit 0 / 3 / 3 (stale file) ✓.

## Follow-ups (not in this PR)
- **Step timeout** on the server (a hung provider holds its thread lock and blocks DELETE) — first task of step 3.
- `proposal` SSE frame (clients currently re-GET the thread) — first API change for the UI.
- Retry regex now ignores bare mid-sentence codes; `overloaded_error` underscore; `apiKeyEnv` unset warns at step time; document the `jq` requirement; re-seed TOCTOU (same-user race in a 0700 dir).

## Test plan
- [x] `bun test` — 395 pass, 0 fail (+218 since #21)
- [x] `bun run typecheck:runtime` clean · `shellcheck scripts/runtime_step.sh` clean
- [x] Live scenarios above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ut4d53ULi5851bsvrbLiFz