### PR TITLE
ui: v2 is the default; classic design stays one switch away

### DIFF
--- a/docs/superpowers/specs/2026-08-29-ui-design-pass-design.md
+++ b/docs/superpowers/specs/2026-08-29-ui-design-pass-design.md
@@ -12,13 +12,14 @@ contract-shaped structure. This pass changes how the four surfaces read, not wha
 A lawyer opens the page and it reads like counsel, not a developer tool: the answer first, the
 work counsel did one glance away, a proposal as a redline they can decide on in place, the vault
 beside the thread. Shipped **behind a toggle** so the founder can compare it with the plain
-surfaces before it becomes the default.
+surfaces before it becomes the default. That comparison happened: **v2 became the default on
+2026-08-30**, and the toggle now turns it off rather than on.
 
 ## 2. Decisions
 
 | Decision | Choice | Why |
 |---|---|---|
-| Rollout | `ui.v2` flag in `localStorage['counsel-os.ui']` (`'v2'` / absent); Settings shows a "Try the new design" switch; `#/?ui=v2` in the fragment also turns it on for one load. Default **off** | Founder rule: ship redesigns as an opt-in toggle |
+| Rollout | Shipped opt-in: `ui.v2` flag in `localStorage['counsel-os.ui']`, a Settings switch, `#/?ui=v2` in the fragment. **Default flipped to v2 on 2026-08-30 by founder decision**, after the comparison the toggle existed for. v1 stays reachable — the switch (now labelled "New design", on by default) and `ui=v1` in the fragment. Only the non-default choice is stored, so the key is `'v1'` or absent | Founder rule: ship redesigns as an opt-in toggle — then decide |
 | Code layout | v2 is a second set of surfaces under `runtime/ui/src/v2/`, sharing `api/`, `chat/turns.ts`, `vault/sanitize.ts`, `vault/markdown.ts`, `settings/registry-form.ts`. v1 components untouched. `app.tsx` picks the shell by the flag | Both must keep passing their tests; no API change |
 | Visual system | Tokens in `styles.css` under `[data-ui="v2"]`: warm paper (`--bg #fbfaf7`, `--fg #1f1d1a`, sunken `#f4f1ea`, border `#e8e3d9`), accent brown `#b45309` (proposals), status green `#2f7a3e` / amber `#b45309` / red `#b42318`; dark counterpart under `prefers-color-scheme: dark`; `--serif: "Iowan Old Style", Charter, Georgia, serif` for assistant prose only; `--sans` system; 4/8/12/16/24/32 px spacing; radius 8 px; one shadow | Warm tone chosen; no component library |
 | Shell | Top bar (brand · Chat / Vault / Settings · vault path · active model). Left rail: threads. Main: chat. Right: **vault drawer**, 320 px, closable, opened by the nav "Vault" link inside chat, a step's file link, or a proposal's "open in vault"; it renders `Tree` + `FileView`. `#/vault` and `#/settings` full pages stay | Workbench chosen: check a file without leaving the thread |
@@ -61,7 +62,7 @@ Dependencies added: `diff` (^8.0.4) to `runtime/ui`. Nothing added to the runtim
 
 ## 4. Interfaces
 
-- `readUiFlag(): 'v1' | 'v2'` — fragment `?ui=v2` wins for the load and is persisted; else `localStorage['counsel-os.ui'] === 'v2'`.
+- `readUiFlag(): 'v1' | 'v2'` — fragment `?ui=v1` / `?ui=v2` wins for the load and is persisted; else `localStorage['counsel-os.ui'] === 'v1' ? 'v1' : 'v2'` (v2 is the default since 2026-08-30; only the `'v1'` opt-out is stored).
 - `verbFor(tool: ToolCallView): { verb: string; object?: string }` — object is the `path` input when present.
 - `summarize(tools: ToolCallView[]): string` — "read 2 files, ran 1 tool" / "no tools".
 - `unifiedHunks(before: string, after: string): Hunk[]` where `Hunk = { kind: 'ctx' | 'add' | 'del'; text: string }[]`, 3 lines of context.
@@ -76,7 +77,7 @@ Same as step 4: 401 page, stream `error` → red strip, 409 on approve → reloa
 
 - Unit: `ui-flag` (fragment, storage, absent); `verbs` (table + fallback); `diff.ts` hunks; `Steps` (streaming lines, ms appears with result, show toggle); `Strip` (collapsed summary text; expanded record; error/timeout pills); `ProposalCard` v2 (diff renders del/add lines; preview flip goes through the sanitizer — script stripped; approve → status; 409 → reload prompt; fetch failure fallback); `Rail` titles; draft-create-on-send (one `POST /threads` with the title, then the step); Drawer open/close/Esc.
 - Existing v1 tests unchanged and green.
-- Playwright: the step-4 flow runs twice — v1 and v2 (`?ui=v2`); v2 adds: proposal diff visible → approve → drawer opens the file → strip shows `done`.
+- Playwright: the step-4 flow runs twice — v1 (`?ui=v1`, since the default flip) and v2 (the printed URL, no flag); v2 adds: proposal diff visible → approve → drawer opens the file → strip shows `done`.
 - Screenshots of v2 (chat with strip expanded, proposal card, drawer, settings) under `docs/superpowers/spikes/img/` + a "## Step 5 — design pass" section in the spikes doc; one live Ollama step, no subscription calls.
 
 ## 7. Build order

--- a/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
+++ b/docs/superpowers/spikes/2026-08-28-runtime-spikes.md
@@ -1682,6 +1682,7 @@ and `ui-flag.test.ts` covers the token-then-flag ordering.
 
 ### What the next plan should assume — Step 5
 
+- **The founder flipped the default to v2 on 2026-08-30** (after this run, and on the strength of the comparison below): an untouched browser opens v2, the switch reads "New design" and is on, and the classic page is `ui=v1` or that switch — so everything below that says "default off" describes how it shipped, not how it stands.
 - **v2 is behind the flag, default off, and both stories pass.** `?ui=v2` on a
   page LOAD turns it on and `localStorage['counsel-os.ui']` keeps it; the
   Settings switch flips either way without a reload. `bun run e2e` is now the

--- a/e2e/ui.spec.ts
+++ b/e2e/ui.spec.ts
@@ -9,6 +9,10 @@ import { RUNTIME_FILE, VAULT_DIR } from './paths';
  * proposal, approving it, reading the written file in the vault, the run
  * record, and settings.
  *
+ * This is the CLASSIC design, which is no longer what the printed URL opens
+ * on — v2 became the default on 2026-08-30 — so the story asks for v1 by
+ * name in the fragment. Both designs are still regression-gated here.
+ *
  * One test, not seven. The steps are a single story — there is no thread to
  * approve a proposal in until the step before it has run — and splitting it
  * would either re-run the whole prefix per test or leave tests depending on
@@ -52,14 +56,17 @@ async function openDir(page: Page, name: string): Promise<void> {
   await expect(dir).toHaveAttribute('aria-expanded', 'true');
 }
 
-test('a step runs tools, raises a proposal, and approving it writes the vault', async ({ page }) => {
-  await test.step('the token in the fragment becomes the tab\'s credential', async () => {
-    await page.goto(`/#token=${await token()}`);
+test('the classic design: a step runs tools, raises a proposal, and approving it writes the vault', async ({ page }) => {
+  await test.step('the token in the fragment becomes the tab\'s credential, and ?ui=v1 asks for the classic design', async () => {
+    await page.goto(`/#token=${await token()}&/?ui=v1`);
+    await expect(page.locator('html')).toHaveAttribute('data-ui', 'v1');
     // The header only renders once `/health` answered — which it could only
     // do with the token the fragment carried.
     await expect(page.getByRole('heading', { name: 'counsel-os' })).toBeVisible();
-    // And the credential is out of the URL by the time anything can screenshot it.
+    // And neither the credential nor the flag is in the URL by the time
+    // anything can screenshot it.
     await expect.poll(() => page.url()).not.toContain('token=');
+    await expect.poll(() => page.url()).not.toContain('ui=');
     await expect(page.locator('nav[aria-label="Threads"]')).toContainText('No threads yet.');
   });
 
@@ -121,28 +128,31 @@ test('a step runs tools, raises a proposal, and approving it writes the vault', 
     const facts = page.locator('.settings-health .facts');
     await expect(facts).toContainText('fake/fake');
     await expect(page.locator('.providers-table')).toContainText('fake/fake');
+    // The switch still means "new design"; this tab turned it off by URL.
+    await expect(page.getByRole('switch', { name: 'New design' })).not.toBeChecked();
   });
 });
 
 /**
- * The same story in the new design (spec 2026-08-29-ui-design-pass §6),
- * turned on by `?ui=v2` in the fragment. It runs AFTER the v1 test on the
- * same server and vault, which the v1 approval has already written — so it
- * starts by putting a different "before" on disk, which is what makes the
- * redline show a deletion and an addition rather than nothing at all.
+ * The same story in the new design (spec 2026-08-29-ui-design-pass §6) —
+ * which is what the printed URL opens on since 2026-08-30, so this story
+ * asks for nothing. It runs AFTER the v1 test on the same server and vault,
+ * which the v1 approval has already written — so it starts by putting a
+ * different "before" on disk, which is what makes the redline show a
+ * deletion and an addition rather than nothing at all.
  *
  * The flag is per browser CONTEXT (`localStorage`), and Playwright gives
- * each test a fresh one — so this test turning v2 on cannot leak back into
- * the v1 story above, whatever order they run in.
+ * each test a fresh one — so the v1 story's `?ui=v1` cannot leak into this
+ * one, whatever order they run in.
  */
 test('the new design: a draft names its thread, the proposal is a redline, the drawer shows the file, the strip says done', async ({ page }) => {
   writeFileSync(join(VAULT_DIR, 'practice', 'standards', 'nda.md'), '# NDA\nTerm: 2 years\n');
 
-  await test.step('?ui=v2 in the fragment turns the design on and leaves the URL', async () => {
-    await page.goto(`/#token=${await token()}&/?ui=v2`);
+  await test.step('the printed URL alone opens the new design', async () => {
+    // No `ui=` at all: a browser that has never been told anything gets v2.
+    await page.goto(`/#token=${await token()}`);
     await expect(page.locator('html')).toHaveAttribute('data-ui', 'v2');
     await expect.poll(() => page.url()).not.toContain('token=');
-    await expect.poll(() => page.url()).not.toContain('ui=');
     await expect(page.locator('.v2-top-model')).toHaveText('fake/fake');
   });
 
@@ -209,7 +219,7 @@ test('the new design: a draft names its thread, the proposal is a redline, the d
 
   await test.step('the vault page and settings are the new design too', async () => {
     await nav(page, 'Settings').click();
-    await expect(page.getByRole('switch', { name: 'Try the new design' })).toBeChecked();
+    await expect(page.getByRole('switch', { name: 'New design' })).toBeChecked();
     await expect(page.locator('.settings-health .facts')).toContainText('fake/fake');
 
     await nav(page, 'Vault').click();

--- a/runtime/ui/src/main.tsx
+++ b/runtime/ui/src/main.tsx
@@ -11,7 +11,7 @@ import './styles.css';
 // bookmark or a screenshot carries is the route and not the credential.
 bootstrapToken();
 
-// Likewise before React renders: `?ui=v2` is read out of the fragment and
+// Likewise before React renders: `?ui=v1` / `?ui=v2` is read out of the fragment and
 // stripped here, so no component has to mutate the URL from its render phase.
 bootstrapUiFlag();
 

--- a/runtime/ui/src/settings/DesignToggle.test.tsx
+++ b/runtime/ui/src/settings/DesignToggle.test.tsx
@@ -22,31 +22,50 @@ function blockWrites(): () => void {
 
 afterEach(() => {
   cleanup();
+  // `setUiFlag('v2')` FIRST, then clear: v2 is the default, so setting it
+  // removes the key and drops `ui-flag`'s session copy. The other order
+  // would leave `'v1'` stored for the next test.
+  setUiFlag('v2');
   localStorage.clear();
-  setUiFlag('v1');
 });
 
 describe('DesignToggle', () => {
-  test('is off by default and turns v2 on', async () => {
+  test('is on by default and turning it off goes back to v1', async () => {
     render(<DesignToggle />);
-    const toggle = screen.getByRole('switch', { name: 'Try the new design' }) as HTMLInputElement;
+    const toggle = screen.getByRole('switch', { name: 'New design' }) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+    // On is the default, so there is nothing stored to say so.
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBeNull();
+
+    await userEvent.click(toggle);
+
+    expect(toggle.checked).toBe(false);
+    expect(readUiFlag()).toBe('v1');
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v1');
+    expect(screen.queryByText(/this tab only/)).toBeNull();
+  });
+
+  test('and turning it back on clears the opt-out', async () => {
+    setUiFlag('v1');
+    render(<DesignToggle />);
+    const toggle = screen.getByRole('switch', { name: 'New design' }) as HTMLInputElement;
     expect(toggle.checked).toBe(false);
 
     await userEvent.click(toggle);
 
     expect(toggle.checked).toBe(true);
     expect(readUiFlag()).toBe('v2');
-    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v2');
-    expect(screen.queryByText(/this tab only/)).toBeNull();
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBeNull();
   });
 
   test('says so when the choice could not be saved', async () => {
     const unblock = blockWrites();
     try {
       render(<DesignToggle />);
-      await userEvent.click(screen.getByRole('switch', { name: 'Try the new design' }));
+      // Turning it OFF is the write now — the opt-out is the stored value.
+      await userEvent.click(screen.getByRole('switch', { name: 'New design' }));
       expect(screen.getByText(/this tab only/)).toBeTruthy();
-      expect(readUiFlag()).toBe('v2');
+      expect(readUiFlag()).toBe('v1');
     } finally {
       unblock();
     }
@@ -60,11 +79,11 @@ describe('DesignToggle', () => {
     const unblock = blockWrites();
     try {
       const first = render(<DesignToggle />);
-      await userEvent.click(screen.getByRole('switch', { name: 'Try the new design' }));
+      await userEvent.click(screen.getByRole('switch', { name: 'New design' }));
       first.unmount();
 
       render(<DesignToggle />);
-      expect((screen.getByRole('switch', { name: 'Try the new design' }) as HTMLInputElement).checked).toBe(true);
+      expect((screen.getByRole('switch', { name: 'New design' }) as HTMLInputElement).checked).toBe(false);
       expect(screen.getByText(/this tab only/)).toBeTruthy();
     } finally {
       unblock();

--- a/runtime/ui/src/settings/DesignToggle.tsx
+++ b/runtime/ui/src/settings/DesignToggle.tsx
@@ -2,10 +2,14 @@ import { useState } from 'react';
 import { isSessionOnly, readUiFlag, setUiFlag, type UiFlag } from '../ui-flag';
 
 /**
- * The "Try the new design" switch (spec §2, "Rollout"). Rendered by the v1
- * settings page and by the v2 one, so the founder can flip either way from
- * wherever they are. Flipping it remounts the shell (`Root` in `app.tsx`
- * listens); no reload.
+ * The "New design" switch (spec §2, "Rollout"). Rendered by the v1 settings
+ * page and by the v2 one, so the founder can flip either way from wherever
+ * they are. Flipping it remounts the shell (`Root` in `app.tsx` listens); no
+ * reload.
+ *
+ * It is ON by default since 2026-08-30 — the switch still means "new
+ * design", the DEFAULT moved. Turning it off stores `'v1'` and gives back
+ * the classic page; nothing is stored while it is on.
  */
 export function DesignToggle(): JSX.Element {
   const [flag, setFlag] = useState<UiFlag>(() => readUiFlag());
@@ -26,9 +30,12 @@ export function DesignToggle(): JSX.Element {
       <h2>Design</h2>
       <label className="design-switch">
         <input type="checkbox" role="switch" checked={flag === 'v2'} onChange={e => change(e.target.checked)} />{' '}
-        Try the new design
+        New design
       </label>
-      <p className="muted">Answer-first turns, a redline for every proposal, and the vault beside the thread.</p>
+      <p className="muted">
+        Answer-first turns, a redline for every proposal, and the vault beside the thread. Turn it off for the classic
+        design.
+      </p>
       {sessionOnly ? (
         <p className="notice notice-warning" role="status">
           The choice could not be saved (storage is blocked), so it applies to this tab only.

--- a/runtime/ui/src/ui-flag.test.ts
+++ b/runtime/ui/src/ui-flag.test.ts
@@ -24,24 +24,39 @@ function blockWrites(): () => void {
 }
 
 afterEach(() => {
+  // `setUiFlag('v2')` FIRST, then clear: v2 is the default, so setting it
+  // removes the key and drops the module's session copy. Clearing first and
+  // setting after would leave `'v1'` stored and every later test reading the
+  // wrong default.
+  setUiFlag('v2');
   localStorage.clear();
-  setUiFlag('v1');
   clearToken();
   sessionStorage.clear();
   history.replaceState(null, '', '/#/');
 });
 
 describe('readUiFlag', () => {
-  test('nothing stored and no fragment is v1', () => {
+  test('nothing stored and no fragment is v2 — the default since 2026-08-30', () => {
+    expect(readUiFlag()).toBe('v2');
+  });
+
+  test('a stored v1 is v1', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
     expect(readUiFlag()).toBe('v1');
   });
 
-  test('a stored v2 is v2', () => {
+  test('a stored v2 is still v2 — tabs that opted in early keep working', () => {
     localStorage.setItem(UI_FLAG_KEY, 'v2');
     expect(readUiFlag()).toBe('v2');
   });
 
+  test('a stored value that names neither design is the default', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v3');
+    expect(readUiFlag()).toBe('v2');
+  });
+
   test('is pure — a fragment it has not been handed changes nothing', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
     history.replaceState(null, '', '/#/?ui=v2');
     expect(readUiFlag()).toBe('v1');
     expect(location.hash).toBe('#/?ui=v2');
@@ -49,73 +64,83 @@ describe('readUiFlag', () => {
 });
 
 describe('bootstrapUiFlag', () => {
-  test('?ui=v2 in the fragment wins for this load, is persisted, and leaves the fragment', () => {
+  test('?ui=v1 in the fragment wins for this load, is persisted, and leaves the fragment', () => {
+    history.replaceState(null, '', '/#/?ui=v1');
+    expect(bootstrapUiFlag()).toBe('v1');
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v1');
+    expect(location.hash).toBe('#/');
+  });
+
+  test('?ui=v2 is obeyed too, and persists as the absent key the default is', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
     history.replaceState(null, '', '/#/?ui=v2');
     expect(bootstrapUiFlag()).toBe('v2');
-    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v2');
+    // Nothing stored: v2 is what an untouched browser gets, so the choice is
+    // recorded by REMOVING the opt-out, not by writing the default down.
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBeNull();
     expect(location.hash).toBe('#/');
   });
 
   test('a fragment with other params keeps them', () => {
-    history.replaceState(null, '', '/#/vault?path=a.md&ui=v2');
-    expect(bootstrapUiFlag()).toBe('v2');
+    history.replaceState(null, '', '/#/vault?path=a.md&ui=v1');
+    expect(bootstrapUiFlag()).toBe('v1');
     expect(location.hash).toBe('#/vault?path=a.md');
   });
 
-  test('a ui value that is not v2 is dropped, not obeyed and not left behind', () => {
-    localStorage.setItem(UI_FLAG_KEY, 'v2');
-    history.replaceState(null, '', '/#/settings?ui=v1');
-    expect(bootstrapUiFlag()).toBe('v2');
+  test('a ui value that names neither design is dropped, not obeyed and not left behind', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
+    history.replaceState(null, '', '/#/settings?ui=v3');
+    expect(bootstrapUiFlag()).toBe('v1');
     expect(location.hash).toBe('#/settings');
   });
 
   test('the &-pair form a reader types after the printed URL is obeyed', () => {
-    history.replaceState(null, '', '/#ui=v2');
-    expect(bootstrapUiFlag()).toBe('v2');
-    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v2');
+    history.replaceState(null, '', '/#ui=v1');
+    expect(bootstrapUiFlag()).toBe('v1');
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v1');
     // Nothing of the flag is left in the address bar.
     expect(location.hash).toBe('');
   });
 
   test('a bare route is not read as pairs', () => {
     history.replaceState(null, '', '/#/vault');
-    expect(bootstrapUiFlag()).toBe('v1');
+    expect(bootstrapUiFlag()).toBe('v2');
     expect(location.hash).toBe('#/vault');
   });
 
   test('no ui param leaves the fragment and the stored choice alone', () => {
-    localStorage.setItem(UI_FLAG_KEY, 'v2');
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
     history.replaceState(null, '', '/#/vault?path=a.md');
-    expect(bootstrapUiFlag()).toBe('v2');
+    expect(bootstrapUiFlag()).toBe('v1');
     expect(location.hash).toBe('#/vault?path=a.md');
   });
 });
 
 describe('setUiFlag', () => {
-  test('v2 stores the key, v1 removes it, and listeners hear both', () => {
+  test('v1 stores the key, v2 removes it, and listeners hear both', () => {
     const seen: string[] = [];
     const off = onUiFlagChange(flag => seen.push(flag));
-    expect(setUiFlag('v2')).toEqual({ persisted: true });
-    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v2');
     expect(setUiFlag('v1')).toEqual({ persisted: true });
+    expect(localStorage.getItem(UI_FLAG_KEY)).toBe('v1');
+    expect(setUiFlag('v2')).toEqual({ persisted: true });
     expect(localStorage.getItem(UI_FLAG_KEY)).toBeNull();
     off();
-    setUiFlag('v2');
-    expect(seen).toEqual(['v2', 'v1']);
+    setUiFlag('v1');
+    expect(seen).toEqual(['v1', 'v2']);
   });
 
   test('blocked storage still switches for the session and reports it', () => {
     const unblock = blockWrites();
     try {
-      expect(setUiFlag('v2')).toEqual({ persisted: false });
-      expect(readUiFlag()).toBe('v2');
+      expect(setUiFlag('v1')).toEqual({ persisted: false });
+      expect(readUiFlag()).toBe('v1');
       // The fact outlives the component that caused it — see `isSessionOnly`.
       expect(isSessionOnly()).toBe(true);
     } finally {
       unblock();
     }
     // And a write that lands clears it again.
-    expect(setUiFlag('v2')).toEqual({ persisted: true });
+    expect(setUiFlag('v1')).toEqual({ persisted: true });
     expect(isSessionOnly()).toBe(false);
   });
 });
@@ -124,47 +149,70 @@ describe('setUiFlag', () => {
  * The order the page actually runs them in (`main.tsx`): the token is taken
  * out of the fragment first, then the flag is read from what is left. Both
  * forms of the printed URL are tested here, because the one that reads best
- * to a person — `&ui=v2` — is the one that used to be dropped, and the
- * near miss — `?ui=v2` after the token — corrupts the credential.
+ * to a person — `&ui=v1` — is the one that used to be dropped, and the
+ * near miss — `?ui=v1` after the token — corrupts the credential.
+ *
+ * `ui=v1` is now the interesting value: v2 is what the printed URL opens on
+ * its own, so the only thing left to ask the URL for is the classic design.
  */
 describe('the printed URL with the flag appended', () => {
-  test('#token=…&ui=v2 gives the tab its token AND the new design', () => {
-    history.replaceState(null, '', '/#token=abc123&ui=v2');
+  test('#token=…&ui=v1 gives the tab its token AND the classic design', () => {
+    history.replaceState(null, '', '/#token=abc123&ui=v1');
     expect(bootstrapToken()).toBe('abc123');
-    expect(bootstrapUiFlag()).toBe('v2');
+    expect(bootstrapUiFlag()).toBe('v1');
     expect(sessionStorage.getItem(TOKEN_KEY)).toBe('abc123');
     // Neither the credential nor the flag survives in the address bar.
     expect(location.hash).toBe('');
   });
 
-  test('#token=…&/?ui=v2 — the form the e2e types — works too', () => {
-    history.replaceState(null, '', '/#token=abc123&/?ui=v2');
+  test('#token=…&/?ui=v1 — the form the e2e types — works too', () => {
+    history.replaceState(null, '', '/#token=abc123&/?ui=v1');
     expect(bootstrapToken()).toBe('abc123');
-    expect(bootstrapUiFlag()).toBe('v2');
+    expect(bootstrapUiFlag()).toBe('v1');
     expect(location.hash).toBe('#/');
   });
 
-  test('#token=…?ui=v2 is the spelling that eats the token, and is still not obeyed', () => {
-    history.replaceState(null, '', '/#token=abc123?ui=v2');
+  test('#token=…&ui=v2 still works, and still leaves nothing behind', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
+    history.replaceState(null, '', '/#token=abc123&ui=v2');
+    expect(bootstrapToken()).toBe('abc123');
+    expect(bootstrapUiFlag()).toBe('v2');
+    expect(location.hash).toBe('');
+  });
+
+  test('#token=…?ui=v1 is the spelling that eats the token, and is still not obeyed', () => {
+    localStorage.setItem(UI_FLAG_KEY, 'v1');
+    // The stored opt-out is what makes this readable: the page shows v1
+    // because of the KEY, not because of the fragment, which never arrived.
+    history.replaceState(null, '', '/#token=abc123?ui=v1');
     // `token=` runs to the end of the pair, so the `?` and everything after
     // it is taken for part of the credential. Documented, not fixed: the
     // fragment is pairs, and a `?` inside one is not a separator.
-    expect(bootstrapToken()).toBe('abc123?ui=v2');
+    expect(bootstrapToken()).toBe('abc123?ui=v1');
+    // v1 because of the STORED key — the fragment contributed nothing; it
+    // left with the credential.
     expect(bootstrapUiFlag()).toBe('v1');
+  });
+
+  test('#token=…?ui=v1 with nothing stored stays on the default', () => {
+    history.replaceState(null, '', '/#token=abc123?ui=v1');
+    expect(bootstrapToken()).toBe('abc123?ui=v1');
+    expect(bootstrapUiFlag()).toBe('v2');
   });
 });
 
 describe('stripUiParam', () => {
   test('removes only the ui param', () => {
     expect(stripUiParam('#/?ui=v2')).toBe('/');
-    expect(stripUiParam('#/vault?path=a.md&ui=v2')).toBe('/vault?path=a.md');
+    expect(stripUiParam('#/?ui=v1')).toBe('/');
+    expect(stripUiParam('#/vault?path=a.md&ui=v1')).toBe('/vault?path=a.md');
     expect(stripUiParam('#/settings')).toBe('/settings');
     expect(stripUiParam('')).toBe('');
   });
 
   test('removes it from the &-pair form, and keeps every other pair verbatim', () => {
-    expect(stripUiParam('#ui=v2')).toBe('');
-    expect(stripUiParam('#token=abc&ui=v2')).toBe('token=abc');
+    expect(stripUiParam('#ui=v1')).toBe('');
+    expect(stripUiParam('#token=abc&ui=v1')).toBe('token=abc');
     expect(stripUiParam('#/vault?path=a%2Fb.md&ui=v2')).toBe('/vault?path=a%2Fb.md');
   });
 });

--- a/runtime/ui/src/ui-flag.ts
+++ b/runtime/ui/src/ui-flag.ts
@@ -1,23 +1,29 @@
 /**
- * The design-pass rollout flag (spec §2, "Rollout"). Default off.
+ * The design flag (spec §2, "Rollout"). **v2 is the default** — the founder
+ * flipped it on 2026-08-30; v1 is still one switch away and never went away.
  *
- * Two sources, in order: the in-memory copy set this session, then
- * `localStorage['counsel-os.ui']`. The memory copy is what makes the switch
- * work in a tab whose storage is blocked — it holds for the session and the
- * toggle says so.
+ * Only the NON-default choice is stored, so the key is absent for everybody
+ * who has not asked for the classic design: `localStorage['counsel-os.ui']`
+ * is `'v1'` or missing. A stored `'v2'` is still read as v2 — tabs that
+ * opted in while v2 was the option keep working — but nothing writes it any
+ * more.
  *
- * `ui=v2` in the fragment is a THIRD source, but it is consumed once by
- * `bootstrapUiFlag` before React renders — beside `bootstrapToken()` and for
- * the same reason. A fragment that has to be read and then rewritten is not
- * something a component may do from its render phase, and `readUiFlag` is a
- * pure read so that a `useState` initializer can call it.
+ * Two sources, in order: the in-memory copy set this session, then storage.
+ * The memory copy is what makes the switch work in a tab whose storage is
+ * blocked — it holds for the session and the toggle says so.
+ *
+ * `ui=v1` / `ui=v2` in the fragment is a THIRD source, but it is consumed
+ * once by `bootstrapUiFlag` before React renders — beside `bootstrapToken()`
+ * and for the same reason. A fragment that has to be read and then rewritten
+ * is not something a component may do from its render phase, and
+ * `readUiFlag` is a pure read so that a `useState` initializer can call it.
  *
  * Both spellings work, and both leave the address bar afterwards:
  *
- *   http://127.0.0.1:7431/#/?ui=v2                 (a page already open)
- *   http://127.0.0.1:7431/#token=<token>&ui=v2     (the URL `serve` prints)
+ *   http://127.0.0.1:7431/#/?ui=v1                 (a page already open)
+ *   http://127.0.0.1:7431/#token=<token>&ui=v1     (the URL `serve` prints)
  *
- * Do NOT write `#token=<token>?ui=v2`: `token=` is split off at the `&`, so
+ * Do NOT write `#token=<token>?ui=v1`: `token=` is split off at the `&`, so
  * a `?` there becomes part of the credential and the page answers 401.
  */
 
@@ -57,17 +63,23 @@ const PAIRS = /(?:^|&)ui=/;
 
 /**
  * The `ui` param of a fragment, in either form it arrives in:
- * `#/?ui=v2` (the route's query half) and `#token=…&ui=v2` (pairs, no `?`).
+ * `#/?ui=v1` (the route's query half) and `#token=…&ui=v1` (pairs, no `?`).
  *
  * The second is the one a reader produces by hand, and it used to be
- * ignored — which sent them to `#token=…?ui=v2` instead, where the token
- * splitter took `…?ui=v2` for the credential and the page answered 401.
+ * ignored — which sent them to `#token=…?ui=v1` instead, where the token
+ * splitter took `…?ui=v1` for the credential and the page answered 401.
+ *
+ * BOTH designs are nameable here. `ui=v2` was the only useful value while v2
+ * was opt-in; now that v2 is the default, `ui=v1` is the one a reader needs
+ * — and a link that names the design it wants should not depend on which one
+ * happens to be the default.
  */
 function fragmentFlag(hash: string): UiFlag | null {
   const raw = hash.replace(/^#/, '');
   const cut = raw.indexOf('?');
   if (cut === -1 && !PAIRS.test(raw)) return null;
-  return new URLSearchParams(cut === -1 ? raw : raw.slice(cut + 1)).get('ui') === 'v2' ? 'v2' : null;
+  const value = new URLSearchParams(cut === -1 ? raw : raw.slice(cut + 1)).get('ui');
+  return value === 'v1' || value === 'v2' ? value : null;
 }
 
 /** The fragment (without its `#`) with the `ui` param removed. Pure.
@@ -104,6 +116,10 @@ export function onUiFlagChange(fn: Listener): () => void {
  * Records the choice. `persisted` is false when storage refused it; the
  * memory copy still applies for this session. The `ui` fragment param, if
  * present, is removed so a later reload obeys the stored choice.
+ *
+ * Only `'v1'` is written. v2 is what an untouched browser gets, so choosing
+ * it is choosing the default — and the honest way to record that is to leave
+ * no key behind rather than to stamp the default into every profile.
  */
 export function setUiFlag(flag: UiFlag): { persisted: boolean } {
   memory = flag;
@@ -111,7 +127,7 @@ export function setUiFlag(flag: UiFlag): { persisted: boolean } {
   try {
     const store = storage();
     if (store !== null) {
-      if (flag === 'v2') store.setItem(UI_FLAG_KEY, 'v2');
+      if (flag === 'v1') store.setItem(UI_FLAG_KEY, 'v1');
       else store.removeItem(UI_FLAG_KEY);
       persisted = true;
     }
@@ -141,9 +157,10 @@ function stripFromLocation(): void {
 }
 
 /**
- * Consumes `?ui=v2` from the fragment, once, before React renders. Returns
- * the flag now in force. The strip runs either way, so a `ui` value that is
- * not `v2` does not sit in the URL forever waiting to be misread.
+ * Consumes `?ui=v1` / `?ui=v2` from the fragment, once, before React renders.
+ * Returns the flag now in force. The strip runs either way, so a `ui` value
+ * that names neither design does not sit in the URL forever waiting to be
+ * misread.
  */
 export function bootstrapUiFlag(): UiFlag {
   const fromFragment = fragmentFlag(globalThis.location?.hash ?? '');
@@ -152,12 +169,17 @@ export function bootstrapUiFlag(): UiFlag {
   return readUiFlag();
 }
 
-/** The flag in force. Pure — the fragment is `bootstrapUiFlag`'s job. */
+/**
+ * The flag in force. Pure — the fragment is `bootstrapUiFlag`'s job.
+ *
+ * v2 unless the classic design was asked for by name: a missing key, and a
+ * value that is neither design's name, both mean the default.
+ */
 export function readUiFlag(): UiFlag {
   if (memory !== null) return memory;
   try {
-    return storage()?.getItem(UI_FLAG_KEY) === 'v2' ? 'v2' : 'v1';
+    return storage()?.getItem(UI_FLAG_KEY) === 'v1' ? 'v1' : 'v2';
   } catch {
-    return 'v1';
+    return 'v2';
   }
 }

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -13,9 +13,12 @@ function noop(): void {}
 afterEach(cleanup);
 
 describe('railLabel', () => {
-  test('is the title, or the creation date', () => {
+  test('is the title, or Untitled', () => {
     expect(railLabel(titled)).toBe('Acme NDA term');
-    expect(railLabel(untitled)).toBe(new Date(at).toLocaleDateString());
+    // Not a date: the row's second line is already the date, and a title
+    // that repeats it names nothing.
+    expect(railLabel(untitled)).toBe('Untitled');
+    expect(railLabel({ ...titled, title: '   ' })).toBe('Untitled');
   });
 });
 
@@ -38,10 +41,10 @@ describe('Rail', () => {
     expect(screen.getByText('Acme NDA term')).toBeTruthy();
     expect(document.querySelector('li.v2-thread[aria-current="true"]')?.textContent).toContain('Acme NDA term');
 
-    // By the title span: the fixtures share a day, so the bare date string
-    // also appears as every row's `updatedAt`.
-    await userEvent.click(screen.getByText(new Date(at).toLocaleDateString(), { selector: '.v2-thread-title' }));
+    // The untitled row reads `Untitled`, and its date line still says when.
+    await userEvent.click(screen.getByText('Untitled', { selector: '.v2-thread-title' }));
     expect(picked).toEqual(['t-2']);
+    expect(document.querySelectorAll('.v2-thread-date')).toHaveLength(2);
 
     await userEvent.click(screen.getByRole('button', { name: 'New' }));
     expect(created).toBe(1);

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -12,10 +12,17 @@ export interface RailProps {
   onDelete: (id: string) => void;
 }
 
-/** The title the first send gave the thread, or the day it was made. */
+/**
+ * The title the first send gave the thread, or `Untitled`.
+ *
+ * A thread made by v1 or by the CLI has no title, and the row already prints
+ * a date on its second line — so falling back to a date said the same thing
+ * twice and told the reader nothing about which thread this is. `Untitled`
+ * at least reads as a missing name rather than as a name.
+ */
 export function railLabel(thread: ThreadHeader): string {
   const title = thread.title?.trim() ?? '';
-  return title !== '' ? title : new Date(thread.createdAt).toLocaleDateString();
+  return title !== '' ? title : 'Untitled';
 }
 
 export function Rail({ threads, selected, draft, busy = false, onSelect, onNew, onDelete }: RailProps): JSX.Element {

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -48,8 +48,10 @@ afterEach(() => {
   globalThis.fetch = realFetch;
   clearToken();
   sessionStorage.clear();
+  // `setUiFlag('v2')` FIRST, then clear: v2 is the default, so setting it
+  // removes the key and drops `ui-flag`'s session copy.
+  setUiFlag('v2');
   localStorage.clear();
-  setUiFlag('v1');
 });
 
 describe('SettingsPage', () => {
@@ -62,7 +64,7 @@ describe('SettingsPage', () => {
     // heading inside their own section, one level under the group card.
     const headings = Array.from(document.querySelectorAll('.v2-group h2'), el => el.textContent);
     expect(headings).toEqual(['Design', 'Default provider', 'Step timeout', 'Providers', 'Task routes', 'Test', 'Runtime']);
-    expect(screen.getByRole('switch', { name: 'Try the new design' })).toBeTruthy();
+    expect(screen.getByRole('switch', { name: 'New design' })).toBeTruthy();
     // The Test group keeps the step-4 confirm, word for word.
     await userEvent.click(screen.getByRole('button', { name: 'Test' }));
     expect(screen.getByText('This uses one call on fake/fake.')).toBeTruthy();


### PR DESCRIPTION
Founder decision 2026-08-30 after a side-by-side A/B of the same thread: v2 (workbench shell, answer-first turns, redline proposals) becomes the default.

- `localStorage['counsel-os.ui']`: only the non-default choice is stored (`'v1'`); a legacy `'v2'` still reads as v2. Fragment accepts `ui=v1` and `ui=v2` in both spellings.
- Settings switch is now **New design**, on by default; off = classic.
- Rail: untitled threads (v1/CLI-created) show `Untitled` instead of the date twice.
- e2e: the v1 story opts in with `ui=v1`; the v2 story is the bare printed URL. 2/2.
- Docs: spec §2 rollout row + spikes Step 5 note.

Tests: root 576 pass / 2 skip, ui 228 pass, typechecks clean, e2e 2/2.