### PR TITLE
ui: a running step survives navigation; abandoned reads as disconnected

### DIFF
--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -4,6 +4,12 @@
  * one, and nothing here is a component library.
  */
 
+/* `hidden` is how a surface leaves the screen WITHOUT unmounting — the v2
+   chat workspace keeps its step stream alive that way. The user agent's own
+   rule for it is weaker than any class the element carries (`.v2-work` sets
+   `display: grid`), so it is stated here, and it wins. */
+[hidden] { display: none !important; }
+
 :root {
   color-scheme: light dark;
 

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -1,8 +1,8 @@
-import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '../test/dom';
+import { act, cleanup, fireEvent, render, screen, userEvent, waitFor } from '../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { TOKEN_KEY } from '../api/token';
-import type { Health, Thread, ThreadHeader } from '../api/types';
+import type { Health, SettingsView, Thread, ThreadHeader } from '../api/types';
 import { Shell } from './Shell';
 
 const realFetch = globalThis.fetch;
@@ -30,6 +30,12 @@ const beta: ThreadHeader = {
   sessions: {},
 };
 
+const settings: SettingsView = {
+  file: '/tmp/providers.yaml',
+  registry: { default: 'fake/fake', providers: [] },
+  effective: { default: 'fake/fake', stepTimeoutMs: 600_000, providers: [] },
+};
+
 function json(body: unknown): Response {
   return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
 }
@@ -53,6 +59,23 @@ function install(): void {
 /** The mounted v2 `Chat`. Its identity is the test: a remount replaces the node. */
 function chatNode(): Element | null {
   return document.querySelector('section.v2-chat');
+}
+
+/** The chat workspace — rail, thread and drawer. It is hidden off `#/`. */
+function workNode(): Element | null {
+  return document.querySelector('.v2-work');
+}
+
+/**
+ * A click on a nav link, as far as the shell is concerned: the fragment
+ * changes and `hashchange` fires. `replaceState` is what the other tests
+ * use, and it does not fire the event by itself.
+ */
+function goTo(hash: string): void {
+  act(() => {
+    history.replaceState(null, '', `/${hash}`);
+    globalThis.dispatchEvent(new Event('hashchange'));
+  });
 }
 
 beforeEach(() => {
@@ -226,5 +249,98 @@ describe('Shell', () => {
 
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(document.querySelector('aside[aria-label="Vault drawer"]')).toBeNull();
+  });
+
+  test('a step in flight survives a trip to the vault page and back', async () => {
+    // A step that never answers: what the reader does while it runs is the
+    // whole test. The signal it was given says whether anything killed it.
+    const step: { signal: AbortSignal | null } = { signal: null };
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith('/steps')) {
+        step.signal = init?.signal ?? null;
+        return await new Promise<Response>(() => {});
+      }
+      if (url.startsWith('/vault/list')) return json([]);
+      return await (base as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.type(await screen.findByLabelText('Message'), 'Is the cap mutual?');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+    // Streaming: Stop stands where Send was, and the step is in flight.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy());
+    expect(step.signal).not.toBeNull();
+    const before = chatNode();
+
+    goTo('#/vault');
+    await waitFor(() => expect(document.querySelector('.v2-vault')).toBeTruthy());
+    // The page is up and the workspace is out of sight — but still MOUNTED.
+    expect(workNode()?.hasAttribute('hidden')).toBe(true);
+    expect(chatNode()).toBe(before);
+    expect(document.contains(before)).toBe(true);
+    // The point of all of it: nobody aborted the step, so the run is not
+    // recorded `abandoned` for the crime of looking at a file.
+    expect(step.signal?.aborted).toBe(false);
+
+    goTo('#/');
+    await waitFor(() => expect(document.querySelector('.v2-vault')).toBeNull());
+    expect(workNode()?.hasAttribute('hidden')).toBe(false);
+    expect(chatNode()).toBe(before);
+    expect(step.signal?.aborted).toBe(false);
+    // And the composer came back exactly as it was left: still streaming.
+    expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy();
+  });
+
+  test('on #/vault the chat is hidden, not gone', async () => {
+    history.replaceState(null, '', '/#/vault');
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input).startsWith('/vault/list')) return json([]);
+      return await (base as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(document.querySelector('.v2-vault')).toBeTruthy());
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+
+    expect(workNode()?.hasAttribute('hidden')).toBe(true);
+    // `hidden` takes the block out of the accessibility tree, so nothing in
+    // there answers a query, takes focus, or is read out while the page is
+    // up — a hidden workspace is not a focus trap.
+    expect(screen.queryByRole('textbox', { name: 'Message' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'New' })).toBeNull();
+    // It is there all the same, holding whatever the chat was doing.
+    expect(document.contains(chatNode())).toBe(true);
+  });
+
+  test('the drawer is still open after a trip to settings', async () => {
+    history.replaceState(null, '', '/#/');
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/health')) return json(health);
+      if (url.startsWith('/runs')) return json([]);
+      if (url === '/threads') return json([]);
+      if (url.startsWith('/vault/list')) return json([]);
+      if (url.startsWith('/settings')) return json(settings);
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(document.querySelector('li.v2-draft[aria-current="true"]')).toBeTruthy());
+    await userEvent.click(screen.getByRole('link', { name: 'Vault' }));
+    expect(document.querySelector('aside[aria-label="Vault drawer"]')).toBeTruthy();
+
+    goTo('#/settings');
+    await waitFor(() => expect(document.querySelector('.v2-page')).toBeTruthy());
+    expect(workNode()?.hasAttribute('hidden')).toBe(true);
+
+    goTo('#/');
+    await waitFor(() => expect(workNode()?.hasAttribute('hidden')).toBe(false));
+    // The drawer belongs to the workspace and was hidden with it, not
+    // closed: the file someone was reading is still on screen.
+    expect(document.querySelector('aside[aria-label="Vault drawer"]')).toBeTruthy();
   });
 });

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -34,6 +34,11 @@ function byRecent(a: ThreadHeader, b: ThreadHeader): number {
  * The chat is keyed by `chatKey`, which changes when the reader PICKS a
  * different thread or starts a draft — never when a draft becomes a thread
  * on its first send. Re-keying then would remount the chat mid-stream.
+ *
+ * A full page HIDES the workspace, it does not replace it. The chat owns
+ * the step stream, and unmounting the chat aborts that stream — a step left
+ * running while someone looks at a file would be recorded `abandoned`. So
+ * the workspace renders on every route and the page renders beside it.
  */
 export function Shell(): JSX.Element {
   const [route, setRoute] = useState<Route>(() => parseHash(globalThis.location.hash).route);
@@ -232,53 +237,63 @@ export function Shell(): JSX.Element {
         </p>
       )}
 
-      {route === 'chat' ? (
-        <div className={drawer.open ? 'v2-work v2-drawer-open' : 'v2-work'}>
-          <Rail
-            threads={threads}
-            selected={selected}
-            draft={draft}
-            busy={busy}
-            onSelect={selectThread}
-            onNew={newDraft}
-            onDelete={id => void deleteThread(id)}
-          />
-          <main className="v2-main">
-            {health === null || (!draft && !listed) ? (
-              <p className="muted v2-empty">Loading…</p>
-            ) : (
-              <Chat
-                key={chatKey}
-                threadId={draft ? null : selected}
-                health={health}
-                onThreadCreated={header => {
-                  // The draft is now a thread; select it without re-keying.
-                  setSelected(header.id);
-                  setDraft(false);
-                  void loadThreads();
-                }}
-                onThreadTouched={() => void loadThreads()}
-                onFileDecided={fileDecided}
-                onOpenFile={openDrawer}
-              />
-            )}
-          </main>
-          {drawer.open ? (
-            <Drawer path={drawer.path} revision={drawerRevision} onOpen={path => openDrawer(path)} onClose={closeDrawer} />
-          ) : null}
-        </div>
-      ) : route === 'vault' ? (
+      {/* The chat workspace stays MOUNTED on every route and is only
+          HIDDEN off `#/`. Unmounting it would tear down `Chat`, and that
+          teardown aborts the step in flight: the runtime finishes the work
+          anyway, but the record it writes reads `abandoned`. `hidden` also
+          takes the block out of the accessibility tree, so nothing in here
+          is reachable — or focusable — while a full page is up. The rail
+          and the drawer go with it: they belong to the workspace, and a
+          full page owns the width. */}
+      <div className={drawer.open ? 'v2-work v2-drawer-open' : 'v2-work'} hidden={route !== 'chat'}>
+        <Rail
+          threads={threads}
+          selected={selected}
+          draft={draft}
+          busy={busy}
+          onSelect={selectThread}
+          onNew={newDraft}
+          onDelete={id => void deleteThread(id)}
+        />
+        <main className="v2-main">
+          {health === null || (!draft && !listed) ? (
+            <p className="muted v2-empty">Loading…</p>
+          ) : (
+            <Chat
+              key={chatKey}
+              threadId={draft ? null : selected}
+              health={health}
+              onThreadCreated={header => {
+                // The draft is now a thread; select it without re-keying.
+                setSelected(header.id);
+                setDraft(false);
+                void loadThreads();
+              }}
+              onThreadTouched={() => void loadThreads()}
+              onFileDecided={fileDecided}
+              onOpenFile={openDrawer}
+            />
+          )}
+        </main>
+        {drawer.open ? (
+          <Drawer path={drawer.path} revision={drawerRevision} onOpen={path => openDrawer(path)} onClose={closeDrawer} />
+        ) : null}
+      </div>
+
+      {route === 'vault' ? (
         <VaultPage
           path={vaultPath}
           onOpen={path => {
             globalThis.location.hash = `#/vault?path=${encodeURIComponent(path)}`;
           }}
         />
-      ) : (
+      ) : null}
+
+      {route === 'settings' ? (
         <main className="v2-page">
           <SettingsPage health={health} />
         </main>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/runtime/ui/src/v2/chat/Strip.test.tsx
+++ b/runtime/ui/src/v2/chat/Strip.test.tsx
@@ -46,6 +46,25 @@ describe('pillFor', () => {
     expect(pillFor({ ...turn, status: 'error' })).toEqual({ kind: 'error', label: 'error' });
     expect(pillFor({ ...turn, status: 'streaming' })).toEqual({ kind: 'running', label: 'running' });
   });
+
+  test('an abandoned run reads as disconnected, and says what that means', () => {
+    // The record on disk stays `abandoned`. "Abandoned" reads as though
+    // somebody gave up on the question; what happened is that the page went
+    // away mid-step, and the answer may well be waiting on a reload.
+    expect(pillFor(turn, { ...run, status: 'abandoned' })).toEqual({
+      kind: 'abandoned',
+      label: 'disconnected',
+      title: 'the page disconnected mid-step; the answer may still have completed',
+    });
+
+    render(<Strip turn={turn} run={{ ...run, status: 'abandoned' }} ms={{}} />);
+    const pill = document.querySelector('summary .v2-pill');
+    expect(pill?.textContent).toBe('disconnected');
+    expect(pill?.getAttribute('title')).toBe('the page disconnected mid-step; the answer may still have completed');
+    // The class still carries the status the runtime recorded, so the
+    // styling — and anything reading the DOM — sees the real thing.
+    expect(pill?.className).toBe('v2-pill v2-pill-abandoned');
+  });
 });
 
 describe('Strip', () => {

--- a/runtime/ui/src/v2/chat/Strip.tsx
+++ b/runtime/ui/src/v2/chat/Strip.tsx
@@ -15,12 +15,29 @@ export interface StripProps {
 export interface Pill {
   kind: RunStatus;
   label: string;
+  /** Hover text, for a label that needs one. */
+  title?: string;
 }
+
+/** Where the status the runtime records is not the word to show a reader. */
+const PILL_LABEL: Partial<Record<RunStatus, string>> = {
+  timeout: 'timed out',
+  // On disk the run is `abandoned`, which reads as "nobody wanted it". What
+  // happened is that the page went away mid-step — the runtime may well have
+  // finished the answer, and a reload can show it.
+  abandoned: 'disconnected',
+};
+
+const PILL_TITLE: Partial<Record<RunStatus, string>> = {
+  abandoned: 'the page disconnected mid-step; the answer may still have completed',
+};
 
 /** The status pill: the record when there is one, else the turn's own state. */
 export function pillFor(turn: AssistantTurn, run?: RunRecord): Pill {
   const kind: RunStatus = run?.status ?? (turn.status === 'error' ? 'error' : turn.status === 'done' ? 'done' : 'running');
-  return { kind, label: kind === 'timeout' ? 'timed out' : kind };
+  const label = PILL_LABEL[kind] ?? kind;
+  const title = PILL_TITLE[kind];
+  return title === undefined ? { kind, label } : { kind, label, title };
 }
 
 export function formatMs(ms: number): string {
@@ -61,7 +78,9 @@ export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
   return (
     <details className="v2-strip" data-status={pill.kind} data-testid={run === undefined ? undefined : `run-${run.runId}`}>
       <summary>
-        <span className={`v2-pill v2-pill-${pill.kind}`}>{pill.label}</span>
+        <span className={`v2-pill v2-pill-${pill.kind}`} title={pill.title}>
+          {pill.label}
+        </span>
         <span className="v2-strip-summary">{summarize(turn.tools)}</span>
         {failed === 0 ? null : <span className="v2-strip-failed">{failed === 1 ? '1 failed' : `${failed} failed`}</span>}
         {empty === 0 ? null : <span className="v2-strip-empty">{empty === 1 ? '1 empty' : `${empty} empty`}</span>}


### PR DESCRIPTION
Fixes cou-77, found in the founder's first real session: clicking Vault/Settings mid-answer unmounted Chat, whose cleanup aborted the stream — the runtime finished the work but the run was recorded 'abandoned'.

- The chat workspace (rail + main + drawer) stays mounted, `hidden` when the route is Vault/Settings; Chat never remounts on navigation, so the stream survives. Thread switch / delete / Stop behavior unchanged.
- Strip: an `abandoned` record now reads **disconnected** with an explanatory title; the recorded status is unchanged on disk.
- Known trade-offs (in-code): deep-linking to #/vault mounts Chat behind the page (same cheap fetches as the chat route); the drawer's Esc listener stays active while hidden.

Tests: ui 232 pass (+4), typechecks clean, e2e 2/2. Root suite: one failure in `scripts/runtime_step.test.ts` that also fails on clean main right now — environmental (a live `counsel-os serve` on this machine publishes `~/.counsel-os/runtime.json`, which that test assumes absent); not caused by this change, CI will confirm.