### PR TITLE
runtime: finalize the run record before yielding the terminal event; adapter isolation; CI timing slack

### DIFF
--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -125,8 +125,10 @@ describe('runStep', () => {
 
     expect(unwound).toBe(true);
     // Not "eventually": the close budget alone is 2 s, so a pass here is the
-    // abort and nothing else.
-    expect(Date.now() - startedAt).toBeLessThan(100);
+    // abort and nothing else. The bound is 1 s, not the close budget: shared
+    // CI runners jitter — this measured 117 ms on a GitHub runner and failed
+    // — and 1 s is still 2x under the budget it has to tell apart.
+    expect(Date.now() - startedAt).toBeLessThan(1000);
     expect(readRun(vaultRoot, 'default', first.value!.runId)!.status).toBe('abandoned');
   });
 
@@ -1364,6 +1366,61 @@ describe('runStep — the run record', () => {
       readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${runId}.log.jsonl`), 'utf8').trim(),
     ) as RunLogEntry;
     expect(log.provider).toBe('fake/fake');
+  });
+
+  test('a caller that cancels the INSTANT it has the `done` records a done run, not an abandoned one', async () => {
+    // What a real browser does: it cancels the SSE response the moment the
+    // `done` frame lands, and never asks for another event. The cancel
+    // reaches the generator as `return()` parked AT the yield of that `done`,
+    // so anything the loop leaves until after that yield never runs — which
+    // is how five finished steps on a live vault came back `abandoned`.
+    const fake = new FakeModelProvider([{ text: 'hi', usage: { inputTokens: 12, outputTokens: 34, costUsd: 0.5 } }]);
+    const { id } = await store.create('default', {});
+
+    const it = runStep(deps([fake]), { threadId: id, message: 'hello' })[Symbol.asyncIterator]();
+    let last: (StepEvent & { runId: string }) | undefined;
+    for (;;) {
+      const step = await it.next();
+      if (step.done) throw new Error('the step ended without a terminal event');
+      last = step.value;
+      if (last.type === 'done' || last.type === 'error') break;
+    }
+    expect(last!.type).toBe('done');
+    // The browser shape: hang up on the terminal frame, never pull again.
+    await it.return?.(undefined);
+
+    const rec = readRun(vaultRoot, 'default', last!.runId)!;
+    expect(rec.status).toBe('done');
+    expect(rec.error).toBeUndefined();
+    // The telemetry the step actually earned, not an empty husk.
+    expect(rec.usage).toEqual({ inputTokens: 12, outputTokens: 34, costUsd: 0.5 });
+    expect(rec.costUsd).toBe(0.5);
+    expect(typeof rec.finishedAt).toBe('string');
+    // The run log is written on the same path, so it lands too.
+    const log = JSON.parse(
+      readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${last!.runId}.log.jsonl`), 'utf8').trim(),
+    ) as RunLogEntry;
+    expect(log.inputTokens).toBe(12);
+  });
+
+  test('a caller that cancels the instant it has the `error` records an error run, not an abandoned one', async () => {
+    const fake = new FakeModelProvider([{ error: 'the model gave up' }]);
+    const { id } = await store.create('default', {});
+
+    const it = runStep(deps([fake]), { threadId: id, message: 'hello' })[Symbol.asyncIterator]();
+    let last: (StepEvent & { runId: string }) | undefined;
+    for (;;) {
+      const step = await it.next();
+      if (step.done) throw new Error('the step ended without a terminal event');
+      last = step.value;
+      if (last.type === 'done' || last.type === 'error') break;
+    }
+    expect(last!.type).toBe('error');
+    await it.return?.(undefined);
+
+    const rec = readRun(vaultRoot, 'default', last!.runId)!;
+    expect(rec.status).toBe('error');
+    expect(rec.error).toBe('the model gave up');
   });
 
   test('a caller that hangs up mid-step leaves an abandoned record, not one stuck at running', async () => {

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -877,17 +877,14 @@ async function* stream(
         sawTerminal = true;
       }
 
-      yield { ...ev, runId };
-
-      // Synthesized, never logged: the `proposal` ThreadEvent the tool
-      // itself appended (during `execute`, before this `tool_result` was
-      // even produced) is the durable record. This is the caller-facing
-      // signal — SSE clients, the adapter — that a proposal now exists.
-      if (proposalToYield) yield { ...proposalToYield, runId };
-
       // Telemetry — the run log and the run record's final state — is written
-      // AFTER the terminal event reached the caller, and its failures go to
-      // stderr: neither may cost a caller its `done`.
+      // BEFORE the terminal event reaches the caller, and its failures go to
+      // stderr: neither may cost a caller its `done`. It CANNOT be written
+      // after the yield. A real SSE client cancels the response the instant
+      // it has the `done` frame; the cancel reaches this generator as
+      // `return()` AT that yield, so nothing past it ever runs and the
+      // record is left for `runStep`'s `finally` to stamp `abandoned` —
+      // a step that finished, filed as one the caller walked away from.
       if (ev.type === 'done') {
         // One tally, two readers: the run log's entry and the record's.
         // Tallying twice would walk the same still-pending calls again for no
@@ -919,6 +916,15 @@ async function* stream(
           ...(ev.text === undefined ? {} : { errorText: ev.text }),
         });
       }
+
+      yield { ...ev, runId };
+
+      // Synthesized, never logged: the `proposal` ThreadEvent the tool
+      // itself appended (during `execute`, before this `tool_result` was
+      // even produced) is the durable record. This is the caller-facing
+      // signal — SSE clients, the adapter — that a proposal now exists.
+      // Terminals never carry one, so the telemetry above cannot displace it.
+      if (proposalToYield) yield { ...proposalToYield, runId };
     }
 
     // A stream that ends on text (no terminal event) still has to leave that

--- a/scripts/runtime_step.sh
+++ b/scripts/runtime_step.sh
@@ -35,14 +35,20 @@ REQUEST="${1:-}"
 command -v curl >/dev/null 2>&1 || exit 3
 command -v jq >/dev/null 2>&1 || exit 3
 
-# `runtime.json` may live under an explicit COUNSEL_OS_HOME override (what
-# the tests use) or the real default; check both, in that order.
+# COUNSEL_OS_HOME, when set, is the WHOLE answer — never a first guess with
+# the real default behind it. A scratch home with no `runtime.json` means "no
+# runtime here", not "fall through to ~/.counsel-os": that fallback let a test
+# with an isolated home reach whatever runtime the machine happens to be
+# running, and send its steps to a live server. The default applies only when
+# the variable is unset.
 runtime_file=""
-if [[ -n "${COUNSEL_OS_HOME:-}" && -f "${COUNSEL_OS_HOME}/runtime.json" ]]; then
+if [[ -n "${COUNSEL_OS_HOME:-}" ]]; then
   runtime_file="${COUNSEL_OS_HOME}/runtime.json"
-elif [[ -f "${HOME:-}/.counsel-os/runtime.json" ]]; then
-  runtime_file="${HOME:-}/.counsel-os/runtime.json"
+elif [[ -n "${HOME:-}" ]]; then
+  runtime_file="${HOME}/.counsel-os/runtime.json"
 fi
+# `-r` covers both "missing" and "unreadable" — a runtime.json that is not
+# there fails this exactly as one we cannot open does.
 [[ -n "$runtime_file" && -r "$runtime_file" ]] || exit 3
 
 port="$(jq -r '.port // empty' "$runtime_file" 2>/dev/null)" || true


### PR DESCRIPTION
Three fixes from the founder's first live session:

1. **Completed steps were recorded `abandoned`.** `stream()` yielded the terminal `done`/`error` and only finalized the record when resumed afterward — but a browser cancels the SSE stream the moment it has the terminal frame, so the generator was unwound at that yield and the outer `finally` stamped `abandoned`. Five consecutive live runs hit it. Telemetry now writes before the yield (both writers swallow failures by design, so the caller can never lose its `done`). New tests reproduce the browser-cancel shape and failed pre-fix (`Received: "abandoned"`).
2. **`runtime_step.sh` escaped test isolation**: with `COUNSEL_OS_HOME` set but empty it fell back to `~/.counsel-os/runtime.json`, so tests on a machine with a live runtime talked to it (reproduced: the isolation test timed out and reached the live server). `COUNSEL_OS_HOME`, when set, is now the only home consulted.
3. **Flaky CI bound**: `counsel-loop.test.ts:129` asserted an abort completed in <100 ms; a GitHub runner measured 117. Loosened to <1000 (still 2× under the 2 s close budget it guards).

Root `bun run test` 578 pass / 2 skip / 0 fail — including with a live `serve` running, which previously broke the suite. Typecheck clean.