### PR TITLE
UI polish round: SVG chevrons, headless provider combobox, anchored askbar, hidden config.md, single empty state, humanized deadlines (cou-82)

### DIFF
--- a/runtime/ui/bun.lock
+++ b/runtime/ui/bun.lock
@@ -8,10 +8,13 @@
         "diff": "^8.0.4",
         "marked": "^18.0.11",
         "react": "^18.3.1",
+        "react-aria": "^3.51.0",
         "react-dom": "^18.3.1",
+        "react-stately": "^3.49.0",
       },
       "devDependencies": {
         "@happy-dom/global-registrator": "^20.0.0",
+        "@react-types/shared": "^3.36.1",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
@@ -120,6 +123,12 @@
 
     "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.12.0", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.12.0" } }, "sha512-BUE55Rew3oMwBzwCwmUnV+Oxk51V3xolM39Ts6kGiBXNELjujiESwk9qc99JRr6cVrj3OTd9MJ5zQ2fpn+jy6g=="],
 
+    "@internationalized/date": ["@internationalized/date@3.12.3", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-fuLX+3ZKLsxI73y8b01EG/WjHb6gE6weCqlfawPO27kBWGMh9G1yH6Csv1uU7/cac9H2GHmOMt6CjmuQ1aia4Q=="],
+
+    "@internationalized/number": ["@internationalized/number@3.6.7", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg=="],
+
+    "@internationalized/string": ["@internationalized/string@3.2.10", "", { "dependencies": { "@swc/helpers": "^0.5.0" } }, "sha512-PDx6//vHSpRnHfxqMqto11zQvhsaU74O3mKv2F/0eicGZcl9NLjQmGlbHz/LsJh5tLKp4A4L7ZVTzN1/MmMTvA=="],
+
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
     "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
@@ -131,6 +140,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@napi-rs/lzma-linux-x64-gnu": ["@napi-rs/lzma-linux-x64-gnu@1.5.1", "", { "os": "linux", "cpu": "x64" }, "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ=="],
+
+    "@react-types/shared": ["@react-types/shared@3.36.1", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-AzsuD9OfxTOZMMvTRhlN3oHBwOmFN7tDh27LzqmHt4+uOgPhJT7ZM7/kVs/8/o0WxayMUIk3hBmCFRHv1FUoag=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
@@ -184,6 +195,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.63.1", "", { "os": "win32", "cpu": "x64" }, "sha512-at8QVep6S3h5Y6gSbdGU06bRY5WJkf6WUduM9YtvYMbYhB1MOFfUgc6kehitQXzOtMSaT70q7f9ydPhpqu821w=="],
 
+    "@swc/helpers": ["@swc/helpers@0.5.23", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw=="],
+
     "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
 
     "@testing-library/react": ["@testing-library/react@16.3.3", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg=="],
@@ -222,6 +235,8 @@
 
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
+    "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
     "aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.11.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw=="],
@@ -233,6 +248,8 @@
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001810", "", {}, "sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
@@ -292,11 +309,15 @@
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
+    "react-aria": ["react-aria@3.51.0", "", { "dependencies": { "@internationalized/date": "^3.12.3", "@internationalized/number": "^3.6.7", "@internationalized/string": "^3.2.10", "@react-types/shared": "^3.36.1", "@swc/helpers": "^0.5.0", "aria-hidden": "^1.2.3", "clsx": "^2.0.0", "react-stately": "3.49.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1", "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-AyWLw0XR38cFPwBu/ErgGaVrc5dupLEKmRlMXTGvFKOtbaGRQ2+yQJkjVhpdHhoRhU4+G+tJDFeHDTS8tK3bfQ=="],
+
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
     "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-stately": ["react-stately@3.49.0", "", { "dependencies": { "@internationalized/date": "^3.12.3", "@internationalized/number": "^3.6.7", "@internationalized/string": "^3.2.10", "@react-types/shared": "^3.36.1", "@swc/helpers": "^0.5.0", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1" } }, "sha512-13iNq2KzBrRAzxRc+n53hgROfIistiYY/sPtIhCw1qUB7/kmo+X1xEU2uiS5zcCIrc55AUPwoHqOIIpKWSwB9A=="],
 
     "rollup": ["rollup@4.63.1", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@napi-rs/lzma-linux-x64-gnu": "1.5.1", "@rollup/rollup-android-arm-eabi": "4.63.1", "@rollup/rollup-android-arm64": "4.63.1", "@rollup/rollup-darwin-arm64": "4.63.1", "@rollup/rollup-darwin-x64": "4.63.1", "@rollup/rollup-freebsd-arm64": "4.63.1", "@rollup/rollup-freebsd-x64": "4.63.1", "@rollup/rollup-linux-arm-gnueabihf": "4.63.1", "@rollup/rollup-linux-arm-musleabihf": "4.63.1", "@rollup/rollup-linux-arm64-gnu": "4.63.1", "@rollup/rollup-linux-arm64-musl": "4.63.1", "@rollup/rollup-linux-loong64-gnu": "4.63.1", "@rollup/rollup-linux-loong64-musl": "4.63.1", "@rollup/rollup-linux-ppc64-gnu": "4.63.1", "@rollup/rollup-linux-ppc64-musl": "4.63.1", "@rollup/rollup-linux-riscv64-gnu": "4.63.1", "@rollup/rollup-linux-riscv64-musl": "4.63.1", "@rollup/rollup-linux-s390x-gnu": "4.63.1", "@rollup/rollup-linux-x64-gnu": "4.63.1", "@rollup/rollup-linux-x64-musl": "4.63.1", "@rollup/rollup-openbsd-x64": "4.63.1", "@rollup/rollup-openharmony-arm64": "4.63.1", "@rollup/rollup-win32-arm64-msvc": "4.63.1", "@rollup/rollup-win32-ia32-msvc": "4.63.1", "@rollup/rollup-win32-x64-gnu": "4.63.1", "@rollup/rollup-win32-x64-msvc": "4.63.1", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-3Df9jsstwhccuEfmAMi9l8XUh/GOkVObmFTU7CCVBysEbcOZLl84jCtaAZMcPiMz2EGKsATzQcU+Xr3n/wU6cg=="],
 
@@ -308,11 +329,15 @@
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.3.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw=="],
+
+    "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "vite": ["vite@6.4.3", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A=="],
 

--- a/runtime/ui/package.json
+++ b/runtime/ui/package.json
@@ -13,10 +13,13 @@
     "diff": "^8.0.4",
     "marked": "^18.0.11",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-aria": "^3.51.0",
+    "react-dom": "^18.3.1",
+    "react-stately": "^3.49.0"
   },
   "devDependencies": {
     "@happy-dom/global-registrator": "^20.0.0",
+    "@react-types/shared": "^3.36.1",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",

--- a/runtime/ui/src/settings/ProviderCombo.test.tsx
+++ b/runtime/ui/src/settings/ProviderCombo.test.tsx
@@ -1,0 +1,38 @@
+import { cleanup, render, screen, userEvent } from '../test/dom';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { useState } from 'react';
+import { ProviderCombo } from './ProviderCombo';
+
+function Harness({ options }: { options: string[] }): JSX.Element {
+  const [value, setValue] = useState('fake/fake');
+  return <ProviderCombo id="combo" label="Default provider" value={value} options={options} onChange={setValue} />;
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ProviderCombo', () => {
+  test('the toggle opens a listbox of the loaded ids; a click fills the field', async () => {
+    render(<Harness options={['fake/fake', 'ollama/gemma4:e4b']} />);
+    expect(document.querySelector('.v2-combo-pop')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show providers' }));
+    const listed = Array.from(document.querySelectorAll('.v2-combo-item'), el => el.textContent);
+    expect(listed).toEqual(['fake/fake', 'ollama/gemma4:e4b']);
+
+    await userEvent.click(screen.getByText('ollama/gemma4:e4b'));
+    expect((screen.getByLabelText('Default provider') as HTMLInputElement).value).toBe('ollama/gemma4:e4b');
+    expect(document.querySelector('.v2-combo-pop')).toBeNull();
+  });
+
+  test('typing keeps a value no loaded provider matches — the datalist contract', async () => {
+    render(<Harness options={['fake/fake']} />);
+    const user = userEvent.setup({ document });
+    const input = screen.getByLabelText('Default provider') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'openai/gpt-5.6');
+    expect(input.value).toBe('openai/gpt-5.6');
+  });
+});

--- a/runtime/ui/src/settings/ProviderCombo.tsx
+++ b/runtime/ui/src/settings/ProviderCombo.tsx
@@ -1,0 +1,107 @@
+import { useRef } from 'react';
+import { useButton, useComboBox, useFilter, useListBox, useOption, type AriaListBoxOptions } from 'react-aria';
+import { Item, useComboBoxState, type ComboBoxState } from 'react-stately';
+import type { Node } from '@react-types/shared';
+import { Chevron } from '../v2/icons';
+
+export interface ProviderComboProps {
+  id: string;
+  label: string;
+  value: string;
+  /** The loaded provider ids — suggestions, never a constraint: the default
+   * may legitimately name a provider that is not loaded right now, the one
+   * you are about to add. */
+  options: string[];
+  onChange(value: string): void;
+}
+
+/**
+ * The default-provider field: a combobox over the loaded provider ids that
+ * still takes any typed value (cou-82 — the native `datalist` it replaces
+ * could not be styled at all, and its dropdown drew in the platform's own
+ * chrome). Headless react-aria hooks under our own markup and tokens — no
+ * styled component library, and no portal: the list is an absolutely
+ * positioned sibling of the input, which keeps it inside the form's DOM for
+ * tests and screen readers alike.
+ */
+export function ProviderCombo({ id, label, value, options, onChange }: ProviderComboProps): JSX.Element {
+  const { contains } = useFilter({ sensitivity: 'base' });
+  const items = options.map(option => ({ id: option }));
+  const children = (item: { id: string }): JSX.Element => <Item textValue={item.id}>{item.id}</Item>;
+  const props = {
+    id,
+    label,
+    inputValue: value,
+    onInputChange: onChange,
+    // The typed text IS the value; picking from the list is a shortcut.
+    allowsCustomValue: true,
+    menuTrigger: 'focus' as const,
+    items,
+    children,
+  };
+  const state = useComboBoxState({ ...props, defaultFilter: contains });
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listBoxRef = useRef<HTMLUListElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const { inputProps, listBoxProps, labelProps, buttonProps } = useComboBox(
+    { ...props, inputRef, listBoxRef, popoverRef, buttonRef },
+    state,
+  );
+  const { buttonProps: toggleProps } = useButton(buttonProps, buttonRef);
+
+  return (
+    <>
+      <label {...labelProps}>{label}</label>
+      <div className="v2-combo">
+        <input {...inputProps} ref={inputRef} />
+        {/* Its own name only: react-aria labels the toggle by the field
+            label too, which would make it a second `Default provider` for
+            anything (or anyone) looking the field up by its label. */}
+        <button
+          {...toggleProps}
+          ref={buttonRef}
+          type="button"
+          className="v2-combo-toggle"
+          aria-label="Show providers"
+          aria-labelledby={undefined}
+        >
+          <Chevron open={state.isOpen} />
+        </button>
+        {state.isOpen ? (
+          <div className="v2-combo-pop" ref={popoverRef}>
+            <ProviderList listBoxProps={listBoxProps} listBoxRef={listBoxRef} state={state} />
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+interface ProviderListProps {
+  listBoxProps: AriaListBoxOptions<{ id: string }>;
+  listBoxRef: React.RefObject<HTMLUListElement>;
+  state: ComboBoxState<{ id: string }>;
+}
+
+function ProviderList({ listBoxProps, listBoxRef, state }: ProviderListProps): JSX.Element {
+  const { listBoxProps: props } = useListBox(listBoxProps, state, listBoxRef);
+  return (
+    <ul {...props} ref={listBoxRef} className="v2-combo-list">
+      {[...state.collection].map(item => (
+        <ProviderOption key={item.key} item={item} state={state} />
+      ))}
+    </ul>
+  );
+}
+
+function ProviderOption({ item, state }: { item: Node<{ id: string }>; state: ComboBoxState<{ id: string }> }): JSX.Element {
+  const ref = useRef<HTMLLIElement | null>(null);
+  const { optionProps, isFocused } = useOption({ key: item.key }, state, ref);
+  return (
+    <li {...optionProps} ref={ref} className="v2-combo-item" data-focused={isFocused ? true : undefined}>
+      {item.rendered}
+    </li>
+  );
+}

--- a/runtime/ui/src/settings/ProviderCombo.tsx
+++ b/runtime/ui/src/settings/ProviderCombo.tsx
@@ -67,7 +67,9 @@ export function ProviderCombo({ id, label, value, options, onChange }: ProviderC
           aria-label="Show providers"
           aria-labelledby={undefined}
         >
-          <Chevron open={state.isOpen} />
+          {/* Always down: a dropdown trigger points down open or closed —
+              the open/closed rotation is tree-fold semantics, not this. */}
+          <Chevron />
         </button>
         {state.isOpen ? (
           <div className="v2-combo-pop" ref={popoverRef}>

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -286,6 +286,12 @@ a { color: var(--accent); }
 .v2-nav a[aria-current="page"] { background: var(--bg-hover); color: var(--fg); }
 .v2-nav a:hover { background: var(--bg-raised); }
 .v2-nav-icon { width: 16px; height: 16px; opacity: 0.75; flex-shrink: 0; }
+/* The shared expander chevron (icons.tsx `Chevron`): sized to the cap height
+   and pulled onto the text baseline, which the old `⌄`/`▸` glyphs never sat
+   on. In flex rows the wrapper centers it instead and vertical-align is
+   moot. */
+.v2-chev-svg { width: 10px; height: 10px; display: inline-block; vertical-align: -0.06em; flex-shrink: 0; }
+.v2-chev-closed { transform: rotate(-90deg); }
 .v2-rail-section {
   margin-top: 20px;
   padding: 0 10px 6px;
@@ -454,7 +460,13 @@ a { color: var(--accent); }
 
 /* Reading pane (mock-vault.html .doc): ~68ch serif measure. */
 .v2-vault-main { flex: 1; min-width: 0; overflow-y: auto; position: relative; }
-.v2-doc { max-width: 760px; margin: 0 auto; padding: 44px 48px 90px; position: relative; }
+/* A flex column at full pane height: `.v2-doc-flow` (the document) takes
+   the slack, so the ask bar under it anchors to the pane bottom on a short
+   document instead of floating just under the last line. The flow block is
+   its own formatting context, which keeps the outline's right float
+   working — floats are ignored by a flex container's direct layout. */
+.v2-doc { max-width: 760px; margin: 0 auto; padding: 44px 48px 90px; position: relative; min-height: 100%; display: flex; flex-direction: column; }
+.v2-doc-flow { flex: 1 0 auto; }
 .v2-drawer-file .v2-doc { padding: 8px 4px 40px; }
 .v2-doc-crumbs { font: 12.5px var(--mono); color: var(--fg-faint); margin-bottom: 8px; }
 .v2-doc-crumbs b { color: var(--fg-muted); font-weight: 500; }
@@ -491,6 +503,16 @@ a { color: var(--accent); }
 }
 .v2-registry { display: contents; }
 .v2-save { display: flex; flex-direction: column; gap: var(--s2); }
+/* The default-provider combobox (ProviderCombo): headless react-aria under
+ * our tokens. The list is an absolute sibling of the input, not a portal. */
+.v2-combo { position: relative; display: flex; align-items: center; }
+.v2-combo input { flex: 1; padding-right: 30px; }
+.v2-combo-toggle { position: absolute; right: 2px; background: none; border: none; color: var(--fg-faint); padding: 6px 8px; cursor: pointer; display: flex; align-items: center; }
+.v2-combo-pop { position: absolute; top: calc(100% + 4px); left: 0; right: 0; z-index: 30; background: var(--bg-raised); border: 1px solid var(--border-strong); border-radius: var(--radius); box-shadow: var(--shadow); max-height: 14rem; overflow-y: auto; }
+.v2-combo-list { list-style: none; margin: 0; padding: 4px; }
+.v2-combo-item { padding: 6px 10px; border-radius: var(--radius); font: 13px var(--mono); color: var(--fg-muted); cursor: pointer; }
+.v2-combo-item[data-focused] { background: var(--bg-hover); color: var(--fg); }
+.v2-combo-item[aria-selected="true"] { color: var(--fg); font-weight: 600; }
 .v2-save-row { display: flex; gap: var(--s3); align-items: center; flex-wrap: wrap; }
 /* A placeholder is an example, not a value. Left at the browser's default
    weight, the Task routes example reads as a saved route. */

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -155,9 +155,9 @@ describe('Rail', () => {
     expect(globalThis.getComputedStyle(label).position).not.toBe('absolute');
   });
 
-  test('an empty list with no draft says so rather than heading nothing', () => {
+  test('an empty list stays quiet — Home carries the one empty-state copy (cou-82)', () => {
     mount({ threads: [], draft: false, selected: null });
-    expect(screen.getByText('No threads yet.')).toBeTruthy();
+    expect(screen.queryByText('No threads yet.')).toBeNull();
     expect(document.querySelector('.v2-rail-list')?.children.length).toBe(0);
   });
 

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -119,7 +119,11 @@ export function Rail({
               </li>
             ))}
           </ul>
-          {threads.length === 0 && !draft ? <p className="muted v2-rail-empty">No threads yet.</p> : null}
+          {/* No "No threads yet." note: a fresh Home already carries the one
+              getting-started copy, and a second empty-state line in the rail
+              beside it read as the app saying the same thing twice
+              (cou-82). An empty list under the Conversations heading reads
+              empty on its own. */}
         </>
       )}
       <button

--- a/runtime/ui/src/v2/chat/ProposalCard.tsx
+++ b/runtime/ui/src/v2/chat/ProposalCard.tsx
@@ -3,6 +3,7 @@ import { ApiError, fetchJson } from '../../api/client';
 import type { ApproveResult, ConflictBody, ProposalStatus, VaultFile } from '../../api/types';
 import type { ProposalView } from '../../chat/turns';
 import { unifiedHunks, type Hunk } from '../diff';
+import { Chevron } from '../icons';
 import { redlineBlocks, wordDiff, type RedlineBlock } from '../redline';
 
 export interface ProposalCardProps {
@@ -57,7 +58,7 @@ export function statusText(status: ProposalStatus, decidedAt?: string): { classN
  * sink, and no part of a redline goes near it.
  *
  * Approved/rejected slips collapse to their set-text status with the change
- * one `view change ⌄` away. The current file is fetched ONCE, on mount —
+ * one `view change` fold away. The current file is fetched ONCE, on mount —
  * not again after a decision — so a settled slip keeps showing what
  * changed. The 409 handling is unchanged from the step-5 card.
  */
@@ -213,7 +214,7 @@ export function ProposalCard({ threadId, proposal, onReload, onDecided, onOpenFi
       {settled ? (
         <div className="v2-slip-acts">
           <button type="button" className="v2-link" aria-expanded={showChange} onClick={() => setShowChange(s => !s)}>
-            view change ⌄
+            view change <Chevron />
           </button>
         </div>
       ) : null}

--- a/runtime/ui/src/v2/chat/Strip.test.tsx
+++ b/runtime/ui/src/v2/chat/Strip.test.tsx
@@ -74,7 +74,9 @@ describe('Strip', () => {
     render(<Strip turn={turn} run={run} ms={{}} />);
     expect(document.querySelector('summary .v2-pill')?.textContent).toBe('DONE');
     expect(screen.getByText('2 sources · 1 proposal pending')).toBeTruthy();
-    expect(document.querySelector('summary .v2-chevron')?.textContent).toBe('details ⌄');
+    // An SVG chevron from icons.tsx, not a `⌄` glyph (cou-82).
+    expect(document.querySelector('summary .v2-chevron')?.textContent?.trim()).toBe('details');
+    expect(document.querySelector('summary .v2-chevron svg.v2-chev-svg')).toBeTruthy();
     // The model, the duration and the tokens are NOT on the line any more —
     // they belong to the record, one click down.
     expect(document.querySelector('summary')?.textContent).not.toContain('fake/fake');

--- a/runtime/ui/src/v2/chat/Strip.tsx
+++ b/runtime/ui/src/v2/chat/Strip.tsx
@@ -1,5 +1,6 @@
 import type { RunRecord, RunStatus } from '../../api/types';
 import type { AssistantTurn } from '../../chat/turns';
+import { Chevron } from '../icons';
 import { stateOf } from '../verbs';
 import { readPathsOf } from './cite';
 import { Steps } from './Steps';
@@ -72,7 +73,7 @@ export function stripLine(turn: AssistantTurn): string {
 
 /**
  * A finished turn's work, folded into ONE HAIRLINE LINE (spec §3.3):
- * `DONE · 3 sources · 1 proposal pending · details ⌄`. Not a box and not a
+ * `DONE · 3 sources · 1 proposal pending · details`. Not a box and not a
  * ledger — the model, the duration and the tokens moved INTO the record, so
  * the collapsed line says only what a reader glancing past it needs.
  * Open, it is the full record — the steps with show/hide, primitives read,
@@ -99,7 +100,7 @@ export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
         {failed === 0 ? null : <span className="v2-strip-failed">{failed === 1 ? '1 failed' : `${failed} failed`}</span>}
         {empty === 0 ? null : <span className="v2-strip-empty">{empty === 1 ? '1 empty' : `${empty} empty`}</span>}
         <span className="v2-chevron" aria-hidden="true">
-          details ⌄
+          details <Chevron />
         </span>
       </summary>
 

--- a/runtime/ui/src/v2/chat/WorkLine.tsx
+++ b/runtime/ui/src/v2/chat/WorkLine.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import type { ToolCallView } from '../../chat/turns';
+import { Chevron } from '../icons';
 import { workLineOf } from '../verbs';
 import { Steps } from './Steps';
 
@@ -11,7 +12,7 @@ export interface WorkLineProps {
 
 /**
  * The turn's one quiet work line (spec §3.3): "Searched the vault · read
- * `nda.md` `acme-nda.md` ⌄" — filename chips, expandable to the full step
+ * `nda.md` `acme-nda.md`" plus a chevron — filename chips, expandable to the full step
  * detail (the existing Steps timeline, show/hide and all).
  */
 export function WorkLine({ tools, ms, onOpenFile }: WorkLineProps): JSX.Element | null {
@@ -34,7 +35,7 @@ export function WorkLine({ tools, ms, onOpenFile }: WorkLineProps): JSX.Element 
         ))}
         {parts.other > 0 ? ` · ran ${parts.other} tool${parts.other === 1 ? '' : 's'}` : ''}
         <span className="v2-chev" aria-hidden="true">
-          {' '}⌄
+          <Chevron />
         </span>
       </button>
       {open ? <Steps tools={tools} ms={ms} onOpenFile={onOpenFile} /> : null}

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -156,8 +156,19 @@ describe('HomePage', () => {
   test('a conversation row opens that thread', async () => {
     const opened: string[] = [];
     mount({ onOpenThread: id => opened.push(id) });
-    await userEvent.click(screen.getByRole('button', { name: /NDA residuals fallback/ }));
+    // The grid waits for the vault read (cou-82) — find, not get.
+    await userEvent.click(await screen.findByRole('button', { name: /NDA residuals fallback/ }));
     expect(opened).toEqual(['t-1']);
+  });
+
+  test('nothing below the starters claims emptiness before the vault read answers', () => {
+    // A fetch that never settles: the page is in its first paint.
+    globalThis.fetch = (async () => new Promise<Response>(() => {})) as unknown as typeof fetch;
+    mount({ threads: [] });
+    // Neither the grid's placeholders nor the getting-started block — a
+    // fresh vault must land on ONE empty-state copy, not a flash of three.
+    expect(document.querySelector('.v2-home-cols')).toBeNull();
+    expect(document.querySelector('.v2-getting-started')).toBeNull();
   });
 
   test('an empty vault with no conversations gets the quiet getting-started block', async () => {

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -94,6 +94,11 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
    * that gets the getting-started block instead of the grid. A reader who
    * has conversations keeps them, whatever the vault holds. */
   const fresh = overview !== null && vaultError === null && matters.length === 0 && threads.length === 0;
+  /** The vault read has answered, one way or the other. Until then the
+   * lower region stays empty: painting the grid first would flash its
+   * "No matters yet." / "No conversations yet." placeholders over a fresh
+   * vault that is about to get the single getting-started block. */
+  const settled = overview !== null || vaultError !== null;
 
   const ask = (): void => {
     if (message === '') return;
@@ -209,7 +214,7 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
           ))}
         </div>
 
-        {fresh ? (
+        {!settled ? null : fresh ? (
           <div className="v2-getting-started rule-double">
             <p>Your vault has no matters yet — counsel files what it learns as you work.</p>
             <p>Ask a question above, or attach a contract from the vault to review.</p>

--- a/runtime/ui/src/v2/icons.tsx
+++ b/runtime/ui/src/v2/icons.tsx
@@ -44,3 +44,25 @@ export function SettingsIcon(): JSX.Element {
     </Icon>
   );
 }
+
+/**
+ * The expander chevron — every fold in the app draws THIS, not a `⌄`/`▸`
+ * glyph (whose baseline drifts font by font). Points down; `open={false}`
+ * rotates it to point right for a closed tree row.
+ */
+export function Chevron({ open = true }: { open?: boolean }): JSX.Element {
+  return (
+    <svg
+      className={open ? 'v2-chev-svg' : 'v2-chev-svg v2-chev-closed'}
+      viewBox="0 0 10 10"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.3}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M2.2 3.6 5 6.4l2.8-2.8" />
+    </svg>
+  );
+}

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -80,6 +80,10 @@ describe('SettingsPage', () => {
     const input = screen.getByLabelText('Default provider') as HTMLInputElement;
     await user.clear(input);
     await user.type(input, 'ollama/gemma4:e4b');
+    // Typing opened the combobox's suggestion list, and react-aria
+    // aria-hides everything outside an open popup — including Save. Close
+    // it the way a keyboard user would before reaching for the button.
+    await user.keyboard('{Escape}');
     await userEvent.click(screen.getByRole('button', { name: 'Save' }));
 
     await waitFor(() => expect(screen.getByText('unknown provider ollama/gemma4:e4b')).toBeTruthy());

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { ApiError, fetchJson } from '../../api/client';
 import type { Health as HealthData, SettingsErrorBody, SettingsView } from '../../api/types';
 import { Health } from '../../settings/Health';
+import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
 import {
   emptyRow,
@@ -157,16 +158,13 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
       <section className="v2-group">
         <h2>Default provider</h2>
         <div className="field">
-          <label htmlFor="v2-default">Default provider</label>
-          {/* A datalist, not a select: the default may legitimately name a
-              provider that is not loaded right now — the one you are about
-              to add — and a select could not express that. */}
-          <input id="v2-default" list="v2-default-options" value={form.default} onChange={e => patch({ default: e.target.value })} />
-          <datalist id="v2-default-options">
-            {effectiveIds.map(id => (
-              <option key={id} value={id} />
-            ))}
-          </datalist>
+          <ProviderCombo
+            id="v2-default"
+            label="Default provider"
+            value={form.default}
+            options={effectiveIds}
+            onChange={value => patch({ default: value })}
+          />
           <FieldError message={errors['default']} />
           {defaultIsKnown ? null : (
             <p className="v2-notice v2-notice-warn" role="status">

--- a/runtime/ui/src/v2/vault/Reader.test.tsx
+++ b/runtime/ui/src/v2/vault/Reader.test.tsx
@@ -92,6 +92,36 @@ describe('Reader', () => {
     expect(asked).toEqual(['matters/x.md']);
   });
 
+  test('no ask bar before the file loads, or on a file that is not there', async () => {
+    install(() => json({ error: 'not found' }, 404));
+    render(<Reader path="practice/standards/nda.md" onAsk={() => {}} />);
+    await waitFor(() => expect(screen.getByText(MISSING_FILE_NOTE)).toBeTruthy());
+    // Nothing to ask about: the bar would anchor to the pane bottom under
+    // a note that says the file does not exist.
+    expect(document.querySelector('.v2-askbar')).toBeNull();
+  });
+
+  test('a deadline row reads like Home — due <date>, amber, raw date in the title', async () => {
+    const soon = new Date(Date.now() + 5 * 86_400_000).toISOString().slice(0, 10);
+    install(() => json({ path: 'matters/x.md', content: `---\ndeadline: ${soon}\n---\n# X\nBody.\n`, version: null, mtimeMs: null }));
+    render(<Reader path="matters/x.md" />);
+    await waitFor(() => expect(document.querySelector('.v2-fm-row dd')).toBeTruthy());
+    const dd = document.querySelector('.v2-fm-row dd') as HTMLElement;
+    expect(dd.textContent).toMatch(/^due /);
+    expect(dd.classList.contains('v2-due-hot')).toBe(true);
+    expect(dd.getAttribute('title')).toBe(soon);
+  });
+
+  test('a deadline that does not parse stays verbatim', async () => {
+    install(() => json({ path: 'matters/x.md', content: '---\ndeadline: end of Q3\n---\n# X\nBody.\n', version: null, mtimeMs: null }));
+    render(<Reader path="matters/x.md" />);
+    await waitFor(() => expect(document.querySelector('.v2-fm-row dd')).toBeTruthy());
+    const dd = document.querySelector('.v2-fm-row dd') as HTMLElement;
+    expect(dd.textContent).toBe('end of Q3');
+    expect(dd.classList.contains('v2-due-hot')).toBe(false);
+    expect(dd.getAttribute('title')).toBeNull();
+  });
+
   test('a non-markdown file renders raw', async () => {
     install(() => json({ path: 'matters/notes.txt', content: '<b>not bold</b>\n', version: null, mtimeMs: null }));
     render(<Reader path="matters/notes.txt" />);

--- a/runtime/ui/src/v2/vault/Reader.tsx
+++ b/runtime/ui/src/v2/vault/Reader.tsx
@@ -2,8 +2,9 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../../api/client';
 import type { VaultFile } from '../../api/types';
 import { isMarkdown, renderMarkdown } from '../../vault/markdown';
+import { dueLabel, parseDeadline, type Due } from '../home/home';
 import { relTime } from '../time';
-import { readerModel } from './frontmatter';
+import { readerModel, type FmRow } from './frontmatter';
 import { outlineOf } from './outline';
 
 /** Moved from FileView (which this component supersedes): a missing file is
@@ -31,6 +32,19 @@ export function withoutHostPaths(message: string): string {
       .slice(-2)
       .join('/'),
   );
+}
+
+/**
+ * Home's `dueLabel`, for the frontmatter's own deadline rows: the reader
+ * says `due Sep 12` (amber inside 14 days, `overdue` past it) in the same
+ * words the matters column uses, instead of a raw ISO date. A value
+ * `Date.parse` cannot read passes through untouched — never rewritten to
+ * "no deadline" over a date that is merely oddly spelled.
+ */
+export function dueOf(row: FmRow): Due | null {
+  if (row.key !== 'deadline' && row.key !== 'due') return null;
+  if (parseDeadline({ deadline: row.value }) === null) return null;
+  return dueLabel({ deadline: row.value });
 }
 
 export interface ReaderProps {
@@ -106,8 +120,15 @@ export function Reader({ path, outline = false, onAsk }: ReaderProps): JSX.Eleme
 
   const crumbs = path.split('/').filter(s => s !== '');
 
+  const loaded = error === null && !missing && file !== null && model !== null;
+
   return (
     <article className="v2-doc" ref={article}>
+      {/* Everything except the ask bar. The article is a flex column at
+          min-height 100% and this block takes the slack, so on a document
+          shorter than the pane the bar still sits at the bottom instead of
+          floating mid-pane under the last paragraph. */}
+      <div className="v2-doc-flow">
       <nav className="v2-doc-crumbs" aria-label="Breadcrumb">
         {crumbs.map((part, i) => (
           <span key={`${i}-${part}`}>
@@ -143,13 +164,19 @@ export function Reader({ path, outline = false, onAsk }: ReaderProps): JSX.Eleme
 
           {model.rows.length === 0 ? null : (
             <dl className="v2-fm">
-              {model.rows.map((row, i) => (
-                <div className="v2-fm-row" key={`${i}-${row.key}`}>
-                  <dt>{row.key}</dt>
-                  <span className="leader" aria-hidden="true" />
-                  <dd>{row.value}</dd>
-                </div>
-              ))}
+              {model.rows.map((row, i) => {
+                const due = dueOf(row);
+                return (
+                  <div className="v2-fm-row" key={`${i}-${row.key}`}>
+                    <dt>{row.key}</dt>
+                    <span className="leader" aria-hidden="true" />
+                    {/* The raw date stays one hover away in the title. */}
+                    <dd className={due?.hot === true ? 'v2-due-hot' : undefined} title={due === null ? undefined : row.value}>
+                      {due === null ? row.value : due.text}
+                    </dd>
+                  </div>
+                );
+              })}
             </dl>
           )}
 
@@ -171,15 +198,16 @@ export function Reader({ path, outline = false, onAsk }: ReaderProps): JSX.Eleme
           ) : (
             <pre className="vault-raw">{file.content}</pre>
           )}
-
-          {onAsk === undefined ? null : (
-            <div className="v2-askbar">
-              <button type="button" onClick={() => onAsk(path)}>
-                Ask counsel about this file <b>↵</b>
-              </button>
-            </div>
-          )}
         </>
+      )}
+      </div>
+
+      {onAsk === undefined || !loaded ? null : (
+        <div className="v2-askbar">
+          <button type="button" onClick={() => onAsk(path)}>
+            Ask counsel about this file <b>↵</b>
+          </button>
+        </div>
       )}
     </article>
   );

--- a/runtime/ui/src/v2/vault/VaultTree.test.tsx
+++ b/runtime/ui/src/v2/vault/VaultTree.test.tsx
@@ -16,7 +16,7 @@ const root: VaultEntry[] = [
   { path: 'matters', kind: 'dir' },
   { path: 'practice', kind: 'dir' },
   { path: 'memory', kind: 'dir' },
-  { path: 'config.md', kind: 'file' },
+  { path: 'scratch.md', kind: 'file' },
 ];
 
 function json(body: unknown): Response {
@@ -59,6 +59,20 @@ describe('VaultTree', () => {
     expect(screen.getByText('memory')).toBeTruthy();
     // Other is a collapsed count; its entries are not in the DOM yet.
     expect(screen.getByText('Other files (1)')).toBeTruthy();
+    expect(screen.queryByText('scratch.md')).toBeNull();
+  });
+
+  test('the vault-root config.md never reaches Other (cou-82)', () => {
+    render(
+      <VaultTree
+        overview={overview}
+        root={[...root, { path: 'config.md', kind: 'file' }]}
+        selected={null}
+        onOpen={() => {}}
+      />,
+    );
+    // Still (1): the setup-written config file is plumbing, not a listing.
+    expect(screen.getByText('Other files (1)')).toBeTruthy();
     expect(screen.queryByText('config.md')).toBeNull();
   });
 
@@ -95,7 +109,7 @@ describe('VaultTree', () => {
     expect(opened).toEqual(['practice/standards/nda.md']);
 
     await userEvent.click(screen.getByText('Other files (1)'));
-    expect(screen.getByText('config.md')).toBeTruthy();
+    expect(screen.getByText('scratch.md')).toBeTruthy();
 
     await userEvent.click(screen.getByText('Vendora × Worldpay'));
     expect(opened).toEqual(['practice/standards/nda.md', 'matters/2026-06-vendora.md']);

--- a/runtime/ui/src/v2/vault/VaultTree.tsx
+++ b/runtime/ui/src/v2/vault/VaultTree.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../../api/client';
 import type { VaultEntry, VaultOverview } from '../../api/types';
 import { ancestorsOf, baseName, orderEntries, ROOT } from '../../vault/Tree';
+import { Chevron } from '../icons';
 import { groupRoot, monthLabel } from './tree';
 
 export interface VaultTreeProps {
@@ -102,7 +103,7 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
         onClick={() => toggle(entry.path)}
       >
         <span className="v2-tri" aria-hidden="true">
-          {open.has(entry.path) ? '▾' : '▸'}
+          <Chevron open={open.has(entry.path)} />
         </span>
         <span className="v2-vname">{baseName(entry.path)}</span>
       </button>
@@ -156,7 +157,7 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
         <>
           <button type="button" className="v2-vrow v2-vdir v2-vother" aria-expanded={otherOpen} onClick={() => setOtherOpen(o => !o)}>
             <span className="v2-tri" aria-hidden="true">
-              {otherOpen ? '▾' : '▸'}
+              <Chevron open={otherOpen} />
             </span>
             <span className="v2-vname">Other files ({groups.other.length})</span>
           </button>

--- a/runtime/ui/src/v2/verbs.ts
+++ b/runtime/ui/src/v2/verbs.ts
@@ -100,7 +100,7 @@ function labelPaths(paths: string[]): string[] {
 }
 
 /** The one quiet work line (spec §3.3): "Searched the vault · read nda.md
- * acme-nda.md ⌄". Proposals are not "work" here — they get slips of their
+ * acme-nda.md ⌄" (the ⌄ now an SVG chevron). Proposals are not "work" here — they get slips of their
  * own below the prose. */
 export function workLineOf(tools: ToolCallView[]): WorkLineParts {
   const parts: WorkLineParts = { searched: false, listed: false, read: [], proposed: 0, other: 0 };

--- a/runtime/ui/src/vault/Tree.test.tsx
+++ b/runtime/ui/src/vault/Tree.test.tsx
@@ -43,6 +43,19 @@ describe('orderEntries', () => {
     ]);
     expect(ordered.map(e => e.path)).toEqual(['law', 'matters', 'alpha.md', 'zeta.md']);
   });
+
+  test('drops the vault-root config.md — and only that one', () => {
+    const ordered = orderEntries([
+      { path: 'config.md', kind: 'file' },
+      { path: 'Config.MD', kind: 'file' },
+      { path: 'matters/config.md', kind: 'file' },
+      { path: 'config.md', kind: 'dir' },
+      { path: 'notes.md', kind: 'file' },
+    ]);
+    // A matter's own config.md stays; so does a directory that happens to
+    // share the name. Case falls with the root file (macOS is one file).
+    expect(ordered.map(e => e.path)).toEqual(['config.md', 'matters/config.md', 'notes.md']);
+  });
 });
 
 describe('isReserved', () => {

--- a/runtime/ui/src/vault/Tree.tsx
+++ b/runtime/ui/src/vault/Tree.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import type { VaultEntry } from '../api/types';
+import { Chevron } from '../v2/icons';
 
 /** The key the root level is cached under. `GET /vault/list` with no `dir`
  * lists the vault root, and `''` is what the server normalizes `.` to. */
@@ -23,11 +24,19 @@ export function isReserved(path: string): boolean {
   return path.split('/').some(segment => segment.toLowerCase() === RESERVED);
 }
 
+/** The vault-root `config.md` (`{legal_root}/config.md`, CONFIGURATION.md):
+ * plumbing setup wrote, not practice content, so listings skip it. Only at
+ * the ROOT — a matter may keep a config.md of its own — and only from
+ * listings: search and a `?path=` deep link still reach it. */
+export function isRootConfig(entry: VaultEntry): boolean {
+  return entry.kind === 'file' && entry.path.toLowerCase() === 'config.md';
+}
+
 /** Directories first, then by name. A vault is folders of matters with a few
  * files beside them, and a flat alphabetical list buries the folders. */
 export function orderEntries(entries: VaultEntry[]): VaultEntry[] {
   return entries
-    .filter(e => !isReserved(e.path))
+    .filter(e => !isReserved(e.path) && !isRootConfig(e))
     .sort((a, b) =>
       a.kind === b.kind ? baseName(a.path).localeCompare(baseName(b.path)) : a.kind === 'dir' ? -1 : 1,
     );
@@ -181,7 +190,7 @@ function Level({ dir, levels, open, selected, onToggle, onSelect }: LevelProps):
               aria-expanded={open.has(entry.path)}
               onClick={() => onToggle(entry.path)}
             >
-              <span aria-hidden="true">{open.has(entry.path) ? '▾' : '▸'}</span> {baseName(entry.path)}
+              <Chevron open={open.has(entry.path)} /> {baseName(entry.path)}
             </button>
             {open.has(entry.path) ? (
               <Level


### PR DESCRIPTION
## What

Six founder-scoped polish items from the 2026-08-31 redesign feedback (cou-82):

1. **Hide `config.md` from vault listings** — the vault-root `config.md` (setup plumbing) is filtered in `orderEntries`, which both trees route through. Root file only, case-insensitive; a matter's own `config.md` still lists, and search / `?path=` deep links still open it.
2. **Anchor the askbar on short docs** — `.v2-doc` is now a flex column at `min-height: 100%` with the document in a growing `.v2-doc-flow` block, so the sticky "Ask counsel about this file" bar sits at the pane bottom even when the document is shorter than the pane. The outline's right float keeps working (the flow block is its own formatting context). The bar also no longer renders during loading or on a missing file.
3. **Single empty-state copy on a fresh Home** — the below-starters region waits for the vault read to settle (no flash of "No matters yet." / "No conversations yet." before the getting-started block), and the rail's redundant "No threads yet." line is removed. A fresh install now shows exactly one copy: the getting-started block.
4. **Humanize deadline in the reader** — frontmatter `deadline:`/`due:` rows render through Home's `dueLabel` (`due Sep 12`, amber inside 14 days, `overdue` past). The raw date stays one hover away in the `title`; unparseable values pass through verbatim.
5. **SVG chevrons everywhere** — `icons.tsx` grows a baseline-aligned `Chevron` (down / rotated right when closed); the `⌄`/`▸`/`▾` glyphs in the strip (`details`), work line, proposal `view change`, and both vault trees now draw it.
6. **Headless combobox for Settings default-provider** — the native `datalist` is replaced by `ProviderCombo`: react-aria **hooks** (`useComboBox`/`useComboBoxState`/`useListBox`/`useOption`) under our own markup, styled entirely with the app tokens — headless only, no styled component library, no portal. `allowsCustomValue` preserves the datalist contract (the default may name a provider you are about to add; the not-loaded warning still shows).

## What to verify (AC)

- [ ] Vault tree + home attach picker: no `config.md` at the root; `Other files (n)` count excludes it; a matter-level config.md still lists.
- [ ] Open a one-paragraph doc in the vault: the ask bar sits at the bottom of the pane, not mid-screen; long docs unchanged (sticky while scrolling).
- [ ] Fresh vault + no threads: exactly one empty-state copy (the getting-started block); no rail "No threads yet."; no flash of grid placeholders on load.
- [ ] A matter with `deadline: <ISO date>` reads `due <Mon D>` in the reader's frontmatter block, amber when ≤14 days or overdue; hover shows the raw date.
- [ ] Every expander (strip `details`, work line, `view change`, tree folds) shows the SVG chevron sitting on the text baseline — no stray `⌄`/`▸` anywhere.
- [ ] Settings → Default provider: click the field or its chevron → styled list of loaded ids; picking fills the field; typing an unknown id keeps it and shows the existing "not loaded" warning; Save round-trips.

## Verification run

- `runtime/ui`: `bun test` 305 pass / 0 fail; `tsc --noEmit` clean; `vite build` clean.
- Root: `bun run test` 609 pass / 0 fail / 2 skip; `typecheck` + `typecheck:runtime` clean.
- `bun run e2e` (Playwright, fake provider): 1 passed.

## Notes

- New deps in `runtime/ui`: `react-aria`, `react-stately` (+ `@react-types/shared` dev, for the `Node` type). Bundle: 404 kB / 125.7 kB gz (was ~271 kB / ~86 kB) — a local-only app, judged acceptable; flagging for awareness.
- react-aria aria-hides content outside an open combobox popup; the settings save test closes the list with Escape before clicking Save, which is what a real user's click does implicitly via blur.