### PR TITLE
Settings rethink: task-oriented groups, structured routes, guided add-provider (cou-84)

### DIFF
--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -215,13 +215,25 @@ export interface RegistryEntry {
   capabilities?: Partial<Capabilities>;
 }
 
+/** One task route, as `TaskRoute` in `runtime/src/providers/registry.ts`
+ * parses it. COPIED from there; a change there is a change here. */
+export interface TaskRouteData {
+  prefer: string;
+  require?: {
+    tools?: boolean;
+    caching?: boolean;
+    thinking?: boolean;
+    contextTokens?: number;
+  };
+  allow_remote?: boolean;
+}
+
 /** `providers.yaml` as data: what `GET /settings` hands out and `PUT
- * /settings` takes back. `tasks` is left opaque — the form edits it as JSON
- * and the server owns its schema. */
+ * /settings` takes back. */
 export interface RegistryFileData {
   default?: string;
   providers?: RegistryEntry[];
-  tasks?: Record<string, unknown>;
+  tasks?: Record<string, TaskRouteData>;
   stepTimeoutMs?: number;
 }
 

--- a/runtime/ui/src/settings/Health.tsx
+++ b/runtime/ui/src/settings/Health.tsx
@@ -24,6 +24,7 @@ export function Health({ health, effective, file }: HealthProps): JSX.Element {
   return (
     <section className="settings-health">
       <h2>Runtime</h2>
+      <p className="muted">What is actually running right now — the file above plus the built-ins. Read-only; when a setting does not seem to take, compare it against this.</p>
       <dl className="facts">
         <div className="fact">
           <dt>

--- a/runtime/ui/src/settings/ProviderCombo.tsx
+++ b/runtime/ui/src/settings/ProviderCombo.tsx
@@ -12,11 +12,14 @@ export interface ProviderComboProps {
    * may legitimately name a provider that is not loaded right now, the one
    * you are about to add. */
   options: string[];
+  /** Shown when the field is empty — the value the runtime falls back to. */
+  placeholder?: string;
   onChange(value: string): void;
 }
 
 /**
- * The default-provider field: a combobox over the loaded provider ids that
+ * A provider picker (the default-provider field and each task route's
+ * Provider field): a combobox over the loaded provider ids that
  * still takes any typed value (cou-82 — the native `datalist` it replaces
  * could not be styled at all, and its dropdown drew in the platform's own
  * chrome). Headless react-aria hooks under our own markup and tokens — no
@@ -24,7 +27,7 @@ export interface ProviderComboProps {
  * positioned sibling of the input, which keeps it inside the form's DOM for
  * tests and screen readers alike.
  */
-export function ProviderCombo({ id, label, value, options, onChange }: ProviderComboProps): JSX.Element {
+export function ProviderCombo({ id, label, value, options, placeholder, onChange }: ProviderComboProps): JSX.Element {
   const { contains } = useFilter({ sensitivity: 'base' });
   const items = options.map(option => ({ id: option }));
   const children = (item: { id: string }): JSX.Element => <Item textValue={item.id}>{item.id}</Item>;
@@ -55,7 +58,7 @@ export function ProviderCombo({ id, label, value, options, onChange }: ProviderC
     <>
       <label {...labelProps}>{label}</label>
       <div className="v2-combo">
-        <input {...inputProps} ref={inputRef} />
+        <input {...inputProps} ref={inputRef} placeholder={placeholder} />
         {/* Its own name only: react-aria labels the toggle by the field
             label too, which would make it a second `Default provider` for
             anything (or anyone) looking the field up by its label. */}

--- a/runtime/ui/src/settings/registry-form.test.ts
+++ b/runtime/ui/src/settings/registry-form.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from 'bun:test';
+import type { RegistryFileData } from '../api/types';
+import {
+  formFromRegistry,
+  humanDuration,
+  mapIssues,
+  registryFromForm,
+  unplacedTaskMessages,
+} from './registry-form';
+
+describe('task routes as rows', () => {
+  const registry: RegistryFileData = {
+    default: 'fake/fake',
+    tasks: {
+      review: { prefer: 'claude-sub/claude-opus-5', require: { contextTokens: 200000, thinking: true } },
+      privacy: { prefer: 'ollama/gemma4:e4b', allow_remote: false },
+    },
+  };
+
+  test('round-trips exactly: file → rows → file', () => {
+    const built = registryFromForm(formFromRegistry(registry));
+    if (!built.ok) throw new Error(JSON.stringify(built.errors));
+    expect(built.registry).toEqual(registry);
+  });
+
+  test('an untouched empty form writes no tasks key', () => {
+    const built = registryFromForm(formFromRegistry({}));
+    if (!built.ok) throw new Error(JSON.stringify(built.errors));
+    expect('tasks' in built.registry).toBe(false);
+  });
+
+  test('a nameless route is an error on ITS row, keyed by row key', () => {
+    const form = formFromRegistry({ tasks: { review: { prefer: 'fake/fake' } } });
+    form.routes.push({ ...form.routes[0]!, key: 'row-test', task: '  ', prefer: 'fake/fake' });
+    const built = registryFromForm(form);
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.errors['route.row-test.task']).toBe('name the kind of work this route matches');
+  });
+
+  test('two routes with one name: the second row carries the error', () => {
+    const form = formFromRegistry({ tasks: { review: { prefer: 'fake/fake' } } });
+    form.routes.push({ ...form.routes[0]!, key: 'row-dup' });
+    const built = registryFromForm(form);
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.errors['route.row-dup.task']).toBe('there is already a route for "review"');
+    expect(built.errors[`route.${form.routes[0]!.key}.task`]).toBeUndefined();
+  });
+
+  test('a route with no provider is an error, not a half-route', () => {
+    const form = formFromRegistry({ tasks: { review: { prefer: 'fake/fake' } } });
+    form.routes[0]!.prefer = ' ';
+    const built = registryFromForm(form);
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.errors[`route.${form.routes[0]!.key}.prefer`]).toBe('pick the provider this work should go to');
+  });
+
+  test('min context must be a positive whole number', () => {
+    const form = formFromRegistry({ tasks: { review: { prefer: 'fake/fake' } } });
+    form.routes[0]!.contextTokens = '-3';
+    const built = registryFromForm(form);
+    expect(built.ok).toBe(false);
+    if (built.ok) return;
+    expect(built.errors[`route.${form.routes[0]!.key}.contextTokens`]).toBe('must be a whole number above zero');
+  });
+});
+
+describe('humanDuration', () => {
+  test('speaks minutes, seconds, and their mix', () => {
+    expect(humanDuration(120000)).toBe('2 minutes');
+    expect(humanDuration(60000)).toBe('1 minute');
+    expect(humanDuration(90000)).toBe('1 minute 30 seconds');
+    expect(humanDuration(1000)).toBe('1 second');
+    expect(humanDuration(1500)).toBe('1.5 seconds');
+    expect(humanDuration(500)).toBe('500 ms');
+  });
+
+  test('says nothing for a value it cannot speak', () => {
+    expect(humanDuration(0)).toBe('');
+    expect(humanDuration(-5)).toBe('');
+    expect(humanDuration(Number.NaN)).toBe('');
+    expect(humanDuration(Number.POSITIVE_INFINITY)).toBe('');
+  });
+});
+
+describe('server issues on routes', () => {
+  test('a tasks issue keeps its full path as the field key', () => {
+    const mapped = mapIssues([{ path: ['tasks', 'review', 'prefer'], message: 'expected string' }]);
+    expect(mapped.fields['tasks.review.prefer']).toBe('expected string');
+    expect(mapped.general).toEqual([]);
+  });
+
+  test('unplacedTaskMessages surfaces what no rendered row will claim', () => {
+    const form = formFromRegistry({ tasks: { review: { prefer: 'fake/fake' } } });
+    const fields = {
+      'tasks.review.prefer': 'shown on the row',
+      'tasks.renamed.prefer': 'orphaned by a rename',
+      tasks: 'a tasks-level issue',
+      default: 'not a tasks issue',
+    };
+    expect(unplacedTaskMessages(fields, form.routes)).toEqual([
+      'tasks.renamed.prefer: orphaned by a rename',
+      'tasks: a tasks-level issue',
+    ]);
+  });
+});

--- a/runtime/ui/src/settings/registry-form.ts
+++ b/runtime/ui/src/settings/registry-form.ts
@@ -9,7 +9,7 @@
  * left empty is OMITTED from the registry rather than written as a default
  * the operator never chose.
  */
-import type { Capabilities, RegistryEntry, RegistryFileData, SettingsIssue } from '../api/types';
+import type { Capabilities, RegistryEntry, RegistryFileData, SettingsIssue, TaskRouteData } from '../api/types';
 
 /** An optional boolean as a control can hold it: unset, on, or off. */
 export type Tri = '' | 'yes' | 'no';
@@ -28,24 +28,44 @@ export interface ProviderRow {
   auth: '' | Capabilities['auth'];
 }
 
+/**
+ * One task route as a row of controls. `TaskRoute` on the server is a small
+ * closed shape — `prefer`, four `require` fields, `allow_remote` — so a row
+ * of controls renders ALL of it and a round trip loses nothing. (This
+ * replaced the raw-JSON textarea the first Settings page shipped with.)
+ */
+export interface RouteRow {
+  /** Stable across edits, like `ProviderRow.key`. Never sent. */
+  key: string;
+  /** The task name — the record's key in the file. */
+  task: string;
+  prefer: string;
+  tools: Tri;
+  caching: Tri;
+  thinking: Tri;
+  contextTokens: string;
+  /** `allow_remote`, whose absence means "allowed". */
+  remote: Tri;
+}
+
 export interface FormState {
   default: string;
   stepTimeoutMs: string;
   providers: ProviderRow[];
-  /** `tasks` as JSON text. The router's task table is a nested map that no
-   * flat form renders honestly, and it is edited rarely; a textarea that
-   * round-trips it exactly beats a form that flattens it wrongly. */
-  tasks: string;
+  routes: RouteRow[];
 }
 
 /**
- * Keyed by field: `default`, `stepTimeoutMs`, `tasks`, or a path into the
- * registry such as `providers.1.baseURL` or
- * `providers.1.capabilities.contextTokens`.
+ * Keyed by field: `default`, `stepTimeoutMs`, or a path into the registry
+ * such as `providers.1.baseURL`, `providers.1.capabilities.contextTokens`,
+ * or `tasks.review.prefer`.
  *
  * The key is deliberately `issue.path.join('.')` — the shape a zod issue
  * from a 400 already has — so a server-side error and a client-side one land
- * on the same input with no translation table between them.
+ * on the same input with no translation table between them. The one
+ * exception is a route row's OWN validation, keyed `route.<row key>.<field>`
+ * instead: a client-side route error can belong to a row whose task name is
+ * empty or duplicated, which no server path could address.
  */
 export type FieldErrors = Record<string, string>;
 
@@ -61,6 +81,59 @@ function tri(value: boolean | undefined): Tri {
 
 export function emptyRow(): ProviderRow {
   return { key: nextKey(), id: '', baseURL: '', apiKeyEnv: '', tools: '', caching: '', thinking: '', contextTokens: '', auth: '' };
+}
+
+/**
+ * The guided starts (cou-84). Each returns a PREFILLED row, not a saved one:
+ * the operator still reads it, finishes it, and presses the one Save — so a
+ * misclick costs nothing and the save semantics stay whole-form.
+ */
+
+/** "I have an OpenAI API key." The id is the vendor's current flagship; the
+ * key is named by environment variable, never typed into the form. */
+export function openaiKeyRow(): ProviderRow {
+  return { ...emptyRow(), id: 'openai/gpt-5.6', apiKeyEnv: 'OPENAI_API_KEY' };
+}
+
+/** "I run a model with Ollama." The id is left for the operator to finish —
+ * only they know which model `ollama list` shows. */
+export function ollamaRow(): ProviderRow {
+  return { ...emptyRow(), id: 'ollama/' };
+}
+
+export function emptyRoute(): RouteRow {
+  return { key: nextKey(), task: '', prefer: '', tools: '', caching: '', thinking: '', contextTokens: '', remote: '' };
+}
+
+export function routeRowFrom(task: string, route: TaskRouteData): RouteRow {
+  const req = route.require ?? {};
+  return {
+    key: nextKey(),
+    task,
+    prefer: route.prefer,
+    tools: tri(req.tools),
+    caching: tri(req.caching),
+    thinking: tri(req.thinking),
+    contextTokens: req.contextTokens === undefined ? '' : String(req.contextTokens),
+    remote: tri(route.allow_remote),
+  };
+}
+
+/**
+ * A millisecond count as a person would say it — "2 minutes", "1 minute 30
+ * seconds" — for the step-timeout field, whose unit the server fixed in
+ * milliseconds long before anyone had to read it. Empty string when there is
+ * nothing sayable (not a positive finite number).
+ */
+export function humanDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return '';
+  if (ms < 1000) return `${ms} ms`;
+  const minutes = Math.floor(ms / 60000);
+  const seconds = (ms % 60000) / 1000;
+  const parts: string[] = [];
+  if (minutes > 0) parts.push(`${minutes} minute${minutes === 1 ? '' : 's'}`);
+  if (seconds > 0) parts.push(`${seconds} second${seconds === 1 ? '' : 's'}`);
+  return parts.join(' ');
 }
 
 export function rowFromEntry(entry: RegistryEntry): ProviderRow {
@@ -83,10 +156,7 @@ export function formFromRegistry(reg: RegistryFileData): FormState {
     default: reg.default ?? '',
     stepTimeoutMs: reg.stepTimeoutMs === undefined ? '' : String(reg.stepTimeoutMs),
     providers: (reg.providers ?? []).map(rowFromEntry),
-    // Pretty-printed: the operator reads this before they edit it. An empty
-    // string, not `{}`, when there are no tasks — so saving an untouched
-    // form does not write a key that was not there.
-    tasks: reg.tasks === undefined ? '' : JSON.stringify(reg.tasks, null, 2),
+    routes: Object.entries(reg.tasks ?? {}).map(([task, route]) => routeRowFrom(task, route)),
   };
 }
 
@@ -151,23 +221,48 @@ export function registryFromForm(form: FormState): BuildResult {
   });
   if (providers.length > 0) registry.providers = providers;
 
-  const tasks = form.tasks.trim();
-  if (tasks !== '') {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(tasks);
-    } catch (err) {
-      errors.tasks = `not valid JSON: ${err instanceof Error ? err.message : String(err)}`;
-      parsed = undefined;
+  // Route rows are error-keyed by `route.<row key>.<field>`, NOT by task
+  // name: two rows can hold the same (or an empty) name while being edited,
+  // and each still deserves its own message on its own row.
+  const tasks: Record<string, TaskRouteData> = {};
+  const seen = new Set<string>();
+  for (const row of form.routes) {
+    const name = row.task.trim();
+    if (name === '') {
+      errors[`route.${row.key}.task`] = 'name the kind of work this route matches';
+      continue;
     }
-    if (parsed !== undefined) {
-      if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-        errors.tasks = 'must be a JSON object of task name → route';
-      } else {
-        registry.tasks = parsed as Record<string, unknown>;
-      }
+    if (seen.has(name)) {
+      errors[`route.${row.key}.task`] = `there is already a route for "${name}"`;
+      continue;
     }
+    seen.add(name);
+    if (row.prefer.trim() === '') {
+      errors[`route.${row.key}.prefer`] = 'pick the provider this work should go to';
+      continue;
+    }
+
+    const require: NonNullable<TaskRouteData['require']> = {};
+    const tools = boolOf(row.tools);
+    if (tools !== undefined) require.tools = tools;
+    const caching = boolOf(row.caching);
+    if (caching !== undefined) require.caching = caching;
+    const thinking = boolOf(row.thinking);
+    if (thinking !== undefined) require.thinking = thinking;
+    const context = row.contextTokens.trim();
+    if (context !== '') {
+      const tokens = Number(context);
+      if (!Number.isInteger(tokens) || tokens <= 0) errors[`route.${row.key}.contextTokens`] = 'must be a whole number above zero';
+      else require.contextTokens = tokens;
+    }
+
+    tasks[name] = {
+      prefer: row.prefer.trim(),
+      ...(Object.keys(require).length === 0 ? {} : { require }),
+      ...(row.remote === '' ? {} : { allow_remote: row.remote === 'yes' }),
+    };
   }
+  if (Object.keys(tasks).length > 0) registry.tasks = tasks;
 
   return Object.keys(errors).length === 0 ? { ok: true, registry } : { ok: false, errors };
 }
@@ -188,15 +283,35 @@ export function mapIssues(issues: SettingsIssue[]): { fields: FieldErrors; gener
       general.push(issue.message);
       continue;
     }
-    // Everything under `tasks` is one textarea on screen, so the sub-path
-    // goes into the message instead of into the key — otherwise an issue at
-    // `tasks.review.prefer` would have no field to attach to.
-    if (key === 'tasks' || key.startsWith('tasks.')) {
-      const detail = key === 'tasks' ? issue.message : `${key}: ${issue.message}`;
-      fields.tasks = fields.tasks === undefined ? detail : `${fields.tasks}; ${detail}`;
-      continue;
-    }
     fields[key] = issue.message;
   }
   return { fields, general };
+}
+
+/** The server-side error keys one route row's controls look up, given the
+ * row's task name. The form checks these; `unplacedTaskMessages` uses the
+ * same list to find the ones nothing will show. */
+export function routeErrorKeys(name: string): string[] {
+  return [
+    `tasks.${name}`,
+    `tasks.${name}.prefer`,
+    `tasks.${name}.require.tools`,
+    `tasks.${name}.require.caching`,
+    `tasks.${name}.require.thinking`,
+    `tasks.${name}.require.contextTokens`,
+    `tasks.${name}.allow_remote`,
+  ];
+}
+
+/**
+ * The `tasks.*` messages from a 400 that no rendered row will claim — a row
+ * was renamed after the failed save, or the issue names a shape no control
+ * draws. They still have to be READ (the save failed for them), so the form
+ * prints them with the general notices instead of dropping them.
+ */
+export function unplacedTaskMessages(fields: FieldErrors, rows: RouteRow[]): string[] {
+  const placed = new Set(rows.flatMap(row => routeErrorKeys(row.task.trim())));
+  return Object.entries(fields)
+    .filter(([key]) => (key === 'tasks' || key.startsWith('tasks.')) && !placed.has(key))
+    .map(([key, message]) => `${key}: ${message}`);
 }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -514,9 +514,16 @@ a { color: var(--accent); }
 .v2-combo-item[data-focused] { background: var(--bg-hover); color: var(--fg); }
 .v2-combo-item[aria-selected="true"] { color: var(--fg); font-weight: 600; }
 .v2-save-row { display: flex; gap: var(--s3); align-items: center; flex-wrap: wrap; }
-/* A placeholder is an example, not a value. Left at the browser's default
-   weight, the Task routes example reads as a saved route. */
+/* A placeholder is an example, not a value. Italic and faint so a route's
+   example provider never reads as a saved one. */
 .v2-settings input::placeholder, .v2-settings textarea::placeholder { color: var(--fg-muted); opacity: 0.65; font-style: italic; }
+/* The guided add-provider starts: one line of what you are trying to do,
+   one button that prefills it. Not `.v2-starters` — the home page owns that
+   name for its ask chips, and its pill rules would restyle these buttons. */
+.v2-guided-starts { border-top: 1px dashed var(--border); margin-top: var(--s3); padding-top: var(--s3); display: flex; flex-direction: column; gap: var(--s3); }
+.v2-guided-start { display: flex; gap: var(--s3); align-items: baseline; justify-content: space-between; flex-wrap: wrap; }
+.v2-guided-start p { margin: 0; flex: 1 1 24rem; }
+.v2-guided-start button { flex: none; }
 .v2-provider { border-top: 1px dashed var(--border); padding-top: var(--s3); margin-top: var(--s3); }
 .v2-provider:first-of-type { border-top: none; padding-top: 0; margin-top: 0; }
 .v2-provider-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr)); gap: var(--s2) var(--s3); }

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -2,18 +2,31 @@ import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { clearToken, TOKEN_KEY } from '../../api/token';
-import type { Health as HealthData, SettingsView } from '../../api/types';
+import type { Health as HealthData, ProviderInfo, SettingsView } from '../../api/types';
 import { SettingsPage } from './SettingsPage';
 
 const health: HealthData = { vault: '/Users/jack/legal', tenant: 'default', providers: [], default: 'fake/fake', stepTimeoutMs: 120000 };
 
+const fakeProvider: ProviderInfo = {
+  id: 'fake/fake',
+  kind: 'direct',
+  auth: 'local',
+  capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1000, auth: 'local' },
+};
+
 const view: SettingsView = {
   file: '/Users/jack/.counsel-os/providers.yaml',
-  registry: { default: 'fake/fake', providers: [{ id: 'openai-compatible/local', baseURL: 'http://127.0.0.1:11434/v1' }] },
+  registry: {
+    default: 'fake/fake',
+    providers: [{ id: 'openai-compatible/local', baseURL: 'http://127.0.0.1:11434/v1' }],
+    // One of everything a route can hold, so rendering and saving cover the
+    // whole shape.
+    tasks: { review: { prefer: 'fake/fake', require: { contextTokens: 1000 }, allow_remote: false } },
+  },
   effective: {
     default: 'fake/fake',
     stepTimeoutMs: 120000,
-    providers: [{ id: 'fake/fake', kind: 'direct', auth: 'local', capabilities: { tools: true, caching: false, thinking: false, contextTokens: 1000, auth: 'local' } }],
+    providers: [fakeProvider],
   },
 };
 
@@ -24,10 +37,10 @@ function json(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
 }
 
-function install(onPut: (body: unknown) => Response): void {
+function install(onPut: (body: unknown) => Response, getView: SettingsView = view): void {
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
-    if (url === '/settings' && (init?.method ?? 'GET') === 'GET') return json(view);
+    if (url === '/settings' && (init?.method ?? 'GET') === 'GET') return json(getView);
     if (url === '/settings' && init?.method === 'PUT') {
       const body: unknown = JSON.parse(String(init.body));
       puts.push(body);
@@ -50,15 +63,20 @@ afterEach(() => {
 });
 
 describe('SettingsPage', () => {
-  test('is grouped in the spec order', async () => {
+  test('is grouped by what the operator came to do, each group with a purpose line', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    // By its LABEL: the group's own heading says "Default provider" too.
     await waitFor(() => expect(screen.getByLabelText('Default provider')).toBeTruthy());
     // Descendant, not child: `Health` draws its own heading inside its own
     // section, one level under the group card.
     const headings = Array.from(document.querySelectorAll('.v2-group h2'), el => el.textContent);
-    expect(headings).toEqual(['Default provider', 'Step timeout', 'Providers', 'Task routes', 'Test', 'Runtime']);
+    expect(headings).toEqual(['Providers', 'Default provider', 'Task routes', 'Step timeout', 'Test', 'Runtime']);
+    // The plain-language purpose lines (cou-84), one under each heading.
+    expect(screen.getByText(/The models this runtime can call/)).toBeTruthy();
+    expect(screen.getByText(/The model that answers when nothing more specific applies/)).toBeTruthy();
+    expect(screen.getByText(/Send one kind of work to a particular model/)).toBeTruthy();
+    expect(screen.getByText(/before the runtime cancels it and reports a timeout/)).toBeTruthy();
+    expect(screen.getByText(/What is actually running right now/)).toBeTruthy();
     // The Test group keeps the step-4 confirm, word for word.
     await userEvent.click(screen.getByRole('button', { name: 'Test' }));
     expect(screen.getByText('This uses one call on fake/fake.')).toBeTruthy();
@@ -101,20 +119,105 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByText('must be positive')).toBeTruthy());
   });
 
-  test('one Save, below every card it writes — not inside Task routes', async () => {
+  test('one Save, below every card it writes', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByLabelText('Task routes (JSON)')).toBeTruthy());
+    await waitFor(() => expect(screen.getByLabelText('Task')).toBeTruthy());
 
     const save = screen.getByRole('button', { name: 'Save' });
     // The button belongs to the form's footer, not to any one group.
     expect(save.closest('.v2-group')).toBeNull();
     expect(save.closest('.v2-save')).not.toBeNull();
-    expect(screen.getByText(/Saves Default provider, Step timeout, Providers and Task routes/)).toBeTruthy();
+    expect(screen.getByText(/Saves Providers, Default provider, Task routes and Step timeout/)).toBeTruthy();
 
     await userEvent.click(save);
     await waitFor(() => expect(screen.getByText(/^Saved\./)).toBeTruthy());
     // The confirmation reads beside the button that caused it.
     expect(screen.getByText(/^Saved\./).closest('.v2-save')).not.toBeNull();
+  });
+
+  test('a task route renders as a structured row and round-trips on save', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Task')).toBeTruthy());
+
+    expect((screen.getByLabelText('Task') as HTMLInputElement).value).toBe('review');
+    expect((screen.getByLabelText('Provider') as HTMLInputElement).value).toBe('fake/fake');
+    expect((screen.getByLabelText('min context (tokens)') as HTMLInputElement).value).toBe('1000');
+    expect((screen.getByLabelText('remote models') as HTMLSelectElement).value).toBe('no');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(puts).toHaveLength(1));
+    expect((puts[0] as { tasks: unknown }).tasks).toEqual({
+      review: { prefer: 'fake/fake', require: { contextTokens: 1000 }, allow_remote: false },
+    });
+  });
+
+  test('an unfinished route is stopped in the page, never sent', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add route' })).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add route' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getByText('name the kind of work this route matches')).toBeTruthy());
+    expect(puts).toHaveLength(0);
+  });
+
+  test('a route naming an unloaded provider warns about the fallback', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Provider')).toBeTruthy());
+
+    const user = userEvent.setup({ document });
+    const prefer = screen.getByLabelText('Provider') as HTMLInputElement;
+    await user.clear(prefer);
+    await user.type(prefer, 'nobody/loaded');
+    expect(screen.getByText(/This route will fall back to the default/)).toBeTruthy();
+  });
+
+  test('the guided starts prefill a provider row without saving anything', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Add OpenAI provider' })).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add OpenAI provider' }));
+    const ids = screen.getAllByLabelText('Id') as HTMLInputElement[];
+    expect(ids.map(el => el.value)).toContain('openai/gpt-5.6');
+    const keys = screen.getAllByLabelText('apiKeyEnv') as HTMLInputElement[];
+    expect(keys.map(el => el.value)).toContain('OPENAI_API_KEY');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Add Ollama model' }));
+    const afterOllama = screen.getAllByLabelText('Id') as HTMLInputElement[];
+    expect(afterOllama.map(el => el.value)).toContain('ollama/');
+    // Prefilled only: nothing was PUT.
+    expect(puts).toHaveLength(0);
+  });
+
+  test('the Claude start appears when the built-in is loaded, and sets the default', async () => {
+    const claude: ProviderInfo = { ...fakeProvider, id: 'claude-sub/claude-opus-5', kind: 'harness', auth: 'subscription' };
+    install(
+      () => json(view),
+      { ...view, effective: { ...view.effective, providers: [fakeProvider, claude] } },
+    );
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByText(/already loaded as/)).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Make it the default' }));
+    expect((screen.getByLabelText('Default provider') as HTMLInputElement).value).toBe('claude-sub/claude-opus-5');
+    // The button disappears once it IS the default — nothing left to do.
+    expect(screen.queryByRole('button', { name: 'Make it the default' })).toBeNull();
+  });
+
+  test('the timeout is echoed in words', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Step timeout (ms)')).toBeTruthy());
+
+    // Empty: the effective fallback, in ms and in words.
+    expect(screen.getByText(/Not set — the runtime uses .* ms \(2 minutes\)/)).toBeTruthy();
+
+    await userEvent.type(screen.getByLabelText('Step timeout (ms)'), '90000');
+    expect(screen.getByText('That is 1 minute 30 seconds.')).toBeTruthy();
   });
 });

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -5,13 +5,19 @@ import { Health } from '../../settings/Health';
 import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
 import {
+  emptyRoute,
   emptyRow,
   formFromRegistry,
+  humanDuration,
   mapIssues,
+  ollamaRow,
+  openaiKeyRow,
   registryFromForm,
+  unplacedTaskMessages,
   type FieldErrors,
   type FormState,
   type ProviderRow,
+  type RouteRow,
   type Tri,
 } from '../../settings/registry-form';
 
@@ -19,12 +25,16 @@ export interface SettingsPageProps {
   health: HealthData | null;
 }
 
+/** The subscription provider every install already has. Named here so the
+ * guided start can point at it instead of adding a duplicate row. */
+const CLAUDE_BUILTIN = 'claude-sub/claude-opus-5';
+
 /**
- * Settings, grouped (spec §2, "Settings page"): Default provider · Step
- * timeout · Providers · Task routes · Test — then Runtime, read-only.
- *
- * The Design group went with the classic design on 2026-08-30: there is one
- * design now, so there is nothing to switch between.
+ * Settings, ordered by what the operator came to do (cou-84): the models you
+ * have (Providers) → the one that answers (Default provider) → the
+ * exceptions (Task routes) → how long an answer may take (Step timeout) —
+ * then Test, then Runtime, read-only. Each group opens with a plain line
+ * saying what it is for.
  */
 export function SettingsPage({ health }: SettingsPageProps): JSX.Element {
   const [view, setView] = useState<SettingsView | null>(null);
@@ -56,7 +66,7 @@ export function SettingsPage({ health }: SettingsPageProps): JSX.Element {
           <RegistryForm key={view.file} view={view} onSaved={setView} />
           <section className="v2-group">
             <h2>Test</h2>
-            <p className="muted">Runs one real step on a scratch thread. Each test costs one model call.</p>
+            <p className="muted">Checks that a provider actually answers, by running one real step on a scratch thread. Each test costs one model call.</p>
             {view.effective.providers.length === 0 ? (
               <p className="muted">Nothing to test — no provider is loaded.</p>
             ) : (
@@ -112,6 +122,10 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     setForm(prev => ({ ...prev, providers: prev.providers.map((row, i) => (i === index ? { ...row, ...change } : row)) }));
     setSaved(false);
   };
+  const patchRoute = (index: number, change: Partial<RouteRow>): void => {
+    setForm(prev => ({ ...prev, routes: prev.routes.map((row, i) => (i === index ? { ...row, ...change } : row)) }));
+    setSaved(false);
+  };
 
   const save = async (): Promise<void> => {
     setSaved(false);
@@ -145,6 +159,10 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     }
   };
 
+  // A `tasks.*` message with no row to sit on still has to be shown; it
+  // joins the general notices by the Save button.
+  const orphanedTaskMessages = unplacedTaskMessages(errors, form.routes);
+
   return (
     // `display: contents` — the groups below are the cards, so the form must
     // not become a box of its own between them and the page's column.
@@ -156,47 +174,11 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
       }}
     >
       <section className="v2-group">
-        <h2>Default provider</h2>
-        <div className="field">
-          <ProviderCombo
-            id="v2-default"
-            label="Default provider"
-            value={form.default}
-            options={effectiveIds}
-            onChange={value => patch({ default: value })}
-          />
-          <FieldError message={errors['default']} />
-          {defaultIsKnown ? null : (
-            <p className="v2-notice v2-notice-warn" role="status">
-              No loaded provider is called <code>{form.default.trim()}</code>. Saving will leave every step falling back to the router.
-            </p>
-          )}
-        </div>
-      </section>
-
-      <section className="v2-group">
-        <h2>Step timeout</h2>
-        <div className="field">
-          <label htmlFor="v2-timeout">Step timeout (ms)</label>
-          <input
-            id="v2-timeout"
-            type="number"
-            min="1"
-            step="1"
-            value={form.stepTimeoutMs}
-            placeholder={String(view.effective.stepTimeoutMs)}
-            onChange={e => patch({ stepTimeoutMs: e.target.value })}
-          />
-          <FieldError message={errors['stepTimeoutMs']} />
-        </div>
-      </section>
-
-      <section className="v2-group">
         <h2>Providers</h2>
         <p className="muted">
-          Edits <code>{view.file}</code>. The built-ins are always loaded and never written here.
+          The models this runtime can call. Your Claude subscription, your Codex subscription, and a local Ollama model are built in and always loaded. Add one here to use an API key, another local model, or a different endpoint. Edits <code>{view.file}</code>; the built-ins are never written there.
         </p>
-        {form.providers.length === 0 ? <p className="muted">None configured.</p> : null}
+        {form.providers.length === 0 ? <p className="muted">None added — the built-ins are doing all the work.</p> : null}
         {form.providers.map((row, index) => (
           <div className="v2-provider" key={row.key}>
             <div className="v2-provider-grid">
@@ -245,36 +227,173 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
             </button>
           </div>
         ))}
-        <button type="button" onClick={() => patch({ providers: [...form.providers, emptyRow()] })}>
-          Add provider
-        </button>
+        {/* The guided starts (cou-84): each names a thing the operator is
+            trying to do and prefills a row for it — nothing is saved until
+            the one Save at the bottom. */}
+        <div className="v2-guided-starts">
+          {effectiveIds.includes(CLAUDE_BUILTIN) ? (
+            <div className="v2-guided-start">
+              <p>
+                <strong>Claude subscription</strong>
+                <span className="muted">
+                  {' '}
+                  — already loaded as <code>{CLAUDE_BUILTIN}</code>. There is nothing to add.
+                </span>
+              </p>
+              {form.default.trim() === CLAUDE_BUILTIN ? null : (
+                <button type="button" onClick={() => patch({ default: CLAUDE_BUILTIN })}>
+                  Make it the default
+                </button>
+              )}
+            </div>
+          ) : null}
+          <div className="v2-guided-start">
+            <p>
+              <strong>OpenAI API key</strong>
+              <span className="muted"> — starts a row for <code>openai/gpt-5.6</code>. Put the key in the <code>OPENAI_API_KEY</code> environment variable before you start the runtime; the file stores the variable name, never the key.</span>
+            </p>
+            <button type="button" onClick={() => patch({ providers: [...form.providers, openaiKeyRow()] })}>
+              Add OpenAI provider
+            </button>
+          </div>
+          <div className="v2-guided-start">
+            <p>
+              <strong>Local Ollama model</strong>
+              <span className="muted"> — starts a row for a model Ollama serves on this machine. Finish the id with the model name <code>ollama list</code> shows, for example <code>ollama/llama3.3</code>.</span>
+            </p>
+            <button type="button" onClick={() => patch({ providers: [...form.providers, ollamaRow()] })}>
+              Add Ollama model
+            </button>
+          </div>
+          <div className="v2-guided-start">
+            <p>
+              <strong>Something else</strong>
+              <span className="muted"> — a blank row, for an Anthropic API key (<code>anthropic/…</code>) or an OpenAI-compatible endpoint (<code>openai-compatible/…</code> with a <code>baseURL</code>).</span>
+            </p>
+            <button type="button" onClick={() => patch({ providers: [...form.providers, emptyRow()] })}>
+              Add provider
+            </button>
+          </div>
+        </div>
+      </section>
+
+      <section className="v2-group">
+        <h2>Default provider</h2>
+        <p className="muted">The model that answers when nothing more specific applies. Every step runs on it, unless a task route below picks a different one.</p>
+        <div className="field">
+          <ProviderCombo
+            id="v2-default"
+            label="Default provider"
+            value={form.default}
+            options={effectiveIds}
+            onChange={value => patch({ default: value })}
+          />
+          <FieldError message={errors['default']} />
+          {defaultIsKnown ? null : (
+            <p className="v2-notice v2-notice-warn" role="status">
+              No loaded provider is called <code>{form.default.trim()}</code>. Saving will leave every step falling back to the router.
+            </p>
+          )}
+        </div>
       </section>
 
       <section className="v2-group">
         <h2>Task routes</h2>
+        <p className="muted">
+          Optional. Send one kind of work to a particular model — keep privacy-sensitive steps on a local model, say, or long documents on a big-context one. A step that names a matching task uses that row&rsquo;s provider; everything else uses the default.
+        </p>
+        {form.routes.length === 0 ? <p className="muted">No routes — every step uses the default provider.</p> : null}
+        {form.routes.map((row, index) => {
+          const name = row.task.trim();
+          const preferKnown = row.prefer.trim() === '' || effectiveIds.includes(row.prefer.trim());
+          return (
+            <div className="v2-provider" key={row.key}>
+              <div className="v2-provider-grid">
+                <div className="field">
+                  <label htmlFor={`v2-${row.key}-task`}>Task</label>
+                  <input id={`v2-${row.key}-task`} value={row.task} placeholder="review" onChange={e => patchRoute(index, { task: e.target.value })} />
+                  <FieldError message={errors[`route.${row.key}.task`] ?? errors[`tasks.${name}`]} />
+                </div>
+                <div className="field">
+                  <ProviderCombo
+                    id={`v2-${row.key}-prefer`}
+                    label="Provider"
+                    value={row.prefer}
+                    options={effectiveIds}
+                    placeholder={view.effective.default ?? ''}
+                    onChange={value => patchRoute(index, { prefer: value })}
+                  />
+                  <FieldError message={errors[`route.${row.key}.prefer`] ?? errors[`tasks.${name}.prefer`]} />
+                </div>
+                <TriField id={`v2-${row.key}-r-tools`} label="requires tools" value={row.tools} error={errors[`tasks.${name}.require.tools`]} onChange={value => patchRoute(index, { tools: value })} />
+                <TriField id={`v2-${row.key}-r-caching`} label="requires caching" value={row.caching} error={errors[`tasks.${name}.require.caching`]} onChange={value => patchRoute(index, { caching: value })} />
+                <TriField id={`v2-${row.key}-r-thinking`} label="requires thinking" value={row.thinking} error={errors[`tasks.${name}.require.thinking`]} onChange={value => patchRoute(index, { thinking: value })} />
+                <div className="field">
+                  <label htmlFor={`v2-${row.key}-r-context`}>min context (tokens)</label>
+                  <input id={`v2-${row.key}-r-context`} type="number" min="1" step="1" value={row.contextTokens} onChange={e => patchRoute(index, { contextTokens: e.target.value })} />
+                  <FieldError message={errors[`route.${row.key}.contextTokens`] ?? errors[`tasks.${name}.require.contextTokens`]} />
+                </div>
+                <div className="field">
+                  <label htmlFor={`v2-${row.key}-remote`}>remote models</label>
+                  <select id={`v2-${row.key}-remote`} value={row.remote} onChange={e => patchRoute(index, { remote: e.target.value as Tri })}>
+                    <option value="">allowed (default)</option>
+                    <option value="yes">allowed</option>
+                    <option value="no">never — stay on this machine</option>
+                  </select>
+                  <FieldError message={errors[`tasks.${name}.allow_remote`]} />
+                </div>
+              </div>
+              {preferKnown ? null : (
+                <p className="v2-notice v2-notice-warn" role="status">
+                  No loaded provider is called <code>{row.prefer.trim()}</code>. This route will fall back to the default.
+                </p>
+              )}
+              <button
+                type="button"
+                className="v2-link v2-remove"
+                onClick={() => {
+                  patch({ routes: form.routes.filter((_, i) => i !== index) });
+                  setErrors({});
+                }}
+              >
+                Remove route {index + 1}
+              </button>
+            </div>
+          );
+        })}
+        <button type="button" onClick={() => patch({ routes: [...form.routes, emptyRoute()] })}>
+          Add route
+        </button>
+      </section>
+
+      <section className="v2-group">
+        <h2>Step timeout</h2>
+        <p className="muted">How long one step — one model answer, including its tool calls — may run before the runtime cancels it and reports a timeout. Long documents can take a few minutes.</p>
         <div className="field">
-          <label htmlFor="v2-tasks">Task routes (JSON)</label>
-          <textarea
-            id="v2-tasks"
-            rows={8}
-            spellCheck={false}
-            value={form.tasks}
-            placeholder={'{\n  "review": { "prefer": "claude-sub/claude-opus-5" }\n}'}
-            onChange={e => patch({ tasks: e.target.value })}
+          <label htmlFor="v2-timeout">Step timeout (ms)</label>
+          <input
+            id="v2-timeout"
+            type="number"
+            min="1"
+            step="1"
+            value={form.stepTimeoutMs}
+            placeholder={String(view.effective.stepTimeoutMs)}
+            onChange={e => patch({ stepTimeoutMs: e.target.value })}
           />
-          <FieldError message={errors['tasks']} />
+          <FieldError message={errors['stepTimeoutMs']} />
+          <TimeoutInWords value={form.stepTimeoutMs} effectiveMs={view.effective.stepTimeoutMs} />
         </div>
       </section>
 
       {/* One Save for the whole form, below every card it writes. Inside the
           last group it read as "save the routes", which is three quarters of
-          a lie: the PUT carries the default, the timeout, the providers and
-          the routes together. The notices live here too, beside the button
+          a lie: the PUT carries the providers, the default, the routes and
+          the timeout together. The notices live here too, beside the button
           that produced them. */}
       <footer className="v2-save">
-        {general.length === 0 ? null : (
+        {general.length === 0 && orphanedTaskMessages.length === 0 ? null : (
           <div className="v2-notice v2-notice-error" role="alert">
-            {general.map(message => (
+            {[...general, ...orphanedTaskMessages].map(message => (
               <p key={message}>{message}</p>
             ))}
           </div>
@@ -288,10 +407,34 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           <button type="submit" className="v2-primary" disabled={busy}>
             {busy ? 'Saving…' : 'Save'}
           </button>
-          <span className="muted">Saves Default provider, Step timeout, Providers and Task routes together.</span>
+          <span className="muted">Saves Providers, Default provider, Task routes and Step timeout together.</span>
         </div>
       </footer>
     </form>
+  );
+}
+
+/**
+ * The timeout in words, because nobody thinks in milliseconds: the field
+ * echoes "that is 2 minutes" for what was typed, or explains what the
+ * runtime falls back to when the field is empty.
+ */
+function TimeoutInWords({ value, effectiveMs }: { value: string; effectiveMs: number }): JSX.Element | null {
+  const raw = value.trim();
+  if (raw === '') {
+    const fallback = humanDuration(effectiveMs);
+    return (
+      <p className="muted" role="note">
+        Not set — the runtime uses {effectiveMs.toLocaleString()} ms{fallback === '' ? '' : ` (${fallback})`}.
+      </p>
+    );
+  }
+  const words = humanDuration(Number(raw));
+  if (words === '') return null;
+  return (
+    <p className="muted" role="note">
+      That is {words}.
+    </p>
   );
 }
 
@@ -304,7 +447,7 @@ function FieldError({ message }: { message?: string }): JSX.Element | null {
   );
 }
 
-function TriField({ id, label, value, onChange }: { id: string; label: string; value: Tri; onChange(value: Tri): void }): JSX.Element {
+function TriField({ id, label, value, error, onChange }: { id: string; label: string; value: Tri; error?: string; onChange(value: Tri): void }): JSX.Element {
   return (
     <div className="field">
       <label htmlFor={id}>{label}</label>
@@ -315,6 +458,7 @@ function TriField({ id, label, value, onChange }: { id: string; label: string; v
           </option>
         ))}
       </select>
+      <FieldError message={error} />
     </div>
   );
 }


### PR DESCRIPTION
## What

Reworks the Settings page (`runtime/ui`) around what the operator is trying to do (cou-84).

- **Reordered, purposeful groups** — Providers → Default provider → Task routes → Step timeout → Test → Runtime. Each group opens with a plain-language purpose line ("The models this runtime can call…", "The model that answers when nothing more specific applies…").
- **Task routes as structured rows** — the raw-JSON textarea is gone. Each route is a row: task name, a provider picker (datalist shared with the Default provider field, so a route can name a provider you are about to add), the `require` fields, and `allow_remote` as a plain "remote models" select ("never — stay on this machine"). `TaskRoute` is a closed server shape, so the rows round-trip `providers.yaml` exactly — a unit test asserts file → rows → file equality. A route naming an unloaded provider warns it will fall back to the default.
- **Guided add-provider starts** — Claude subscription (already built in; one click makes it the default, no duplicate row), OpenAI API key (prefills `openai/gpt-5.6` + `OPENAI_API_KEY`, with the key-goes-in-the-environment explanation), local Ollama model (prefills `ollama/`), and a blank row for everything else. Starts only prefill rows — nothing saves until the one Save.
- **Step timeout in human terms** — purpose line explains what a step is; the field echoes the value in words ("That is 1 minute 30 seconds.") and the empty state names the effective fallback.
- **Save semantics unchanged** — one Save for the whole form, whole-registry PUT, 400 issues land on the fields their zod paths name. `tasks.*` issues no rendered row claims (e.g. after a rename) surface with the general notices instead of being dropped.

## What to verify (AC)

- [ ] Group order + purpose lines: Providers · Default provider · Task routes · Step timeout · Test · Runtime, each with a plain line under the heading.
- [ ] Routes: edit/add/remove rows; save writes structured `tasks:` into `providers.yaml`; a registry with `require`/`allow_remote` round-trips unchanged.
- [ ] Starters prefill only (no PUT until Save); Claude start appears only when `claude-sub/claude-opus-5` is loaded and hides once it is the default.
- [ ] Timeout words: type 90000 → "That is 1 minute 30 seconds."; empty field explains the effective default.
- [ ] Suites: `bun run typecheck:ui`, `bun run ui:test` (313 pass), root `bun run test` (609 pass), `bun run ui:build` — all verified locally.
- [ ] Real-browser round trip verified locally with the fake-serve recipe: added a route + OpenAI starter + timeout, saved, and `providers.yaml` contained exactly `{providers:[{id: openai/gpt-5.6, apiKeyEnv: OPENAI_API_KEY}], tasks: {review: {prefer: fake/fake}}, stepTimeoutMs: 90000}`.

Task: cou-84