### PR TITLE
UI polish round 2: rail +/× alignment, reachable draft, derived thread titles, two-tier type scale (cou-88)

### DIFF
--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, beforeEach } from 'bun:test';
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ThreadStore } from './store';
@@ -161,6 +161,40 @@ describe('ThreadStore', () => {
   test('a real uuid passes id validation', async () => {
     const header = await store.create('default', {});
     await expect(store.get('default', header.id)).resolves.toBeDefined();
+  });
+
+  // cou-88: threads from before titling existed (or created bare by another
+  // client) must not sit in the rail as `Untitled` rows — list/get derive a
+  // title from the first user message.
+  test('an untitled thread with messages lists and gets under its first line', async () => {
+    const header = await store.create('default', {});
+    await store.append('default', header.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: '\nReview the Acme NDA\nplease' });
+
+    const listed = await store.list('default');
+    expect(listed[0]?.title).toBe('Review the Acme NDA');
+    expect((await store.get('default', header.id)).header.title).toBe('Review the Acme NDA');
+  });
+
+  test('a derived title is cut to 60 characters on a word boundary, and never written back', async () => {
+    const header = await store.create('default', {});
+    const long = 'What is our position on liability caps in vendor agreements today?';
+    await store.append('default', header.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: long });
+
+    const listed = await store.list('default');
+    expect(listed[0]?.title).toBe('What is our position on liability caps in vendor agreements');
+
+    const onDisk = JSON.parse(readFileSync(join(root, '.counsel', 'threads', 'default', `${header.id}.json`), 'utf8')) as { title?: string };
+    expect(onDisk.title).toBeUndefined();
+  });
+
+  test('a real title always wins over derivation; no messages leaves the thread untitled', async () => {
+    const titled = await store.create('default', { title: 'Named by hand' });
+    await store.append('default', titled.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'something else' });
+    const empty = await store.create('default', {});
+
+    const byId = new Map((await store.list('default')).map(h => [h.id, h]));
+    expect(byId.get(titled.id)?.title).toBe('Named by hand');
+    expect(byId.get(empty.id)?.title).toBeUndefined();
   });
 
   test('append on an unknown thread throws and creates no orphan .jsonl', async () => {

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -53,6 +53,25 @@ export interface ThreadStoreOptions {
   codexHomeRoot?: string;
 }
 
+/**
+ * The title rule, server side: the first non-empty line, cut to 60
+ * characters on a word boundary — the same rule the UI applies at creation
+ * (`titleFor`, runtime/ui/src/v2/threads.ts; keep the two in step). It runs
+ * at READ time for threads that never got a title: threads from before
+ * titling existed (pre-v0.11) and threads other clients created bare, which
+ * otherwise sit in the rail as `Untitled` rows forever (cou-88).
+ */
+const TITLE_MAX = 60;
+
+function titleFrom(message: string): string {
+  const first = message.split('\n').find(line => line.trim() !== '') ?? '';
+  const line = first.trim();
+  if (line.length <= TITLE_MAX) return line;
+  const cut = line.slice(0, TITLE_MAX);
+  const space = cut.lastIndexOf(' ');
+  return (space > TITLE_MAX / 2 ? cut.slice(0, space) : cut).trimEnd();
+}
+
 export class ThreadStore {
   private readonly root: string;
   private readonly codexHomeRoot: string;
@@ -95,6 +114,35 @@ export class ThreadStore {
     writeFileSync(this.headerPath(tenant, header.id), JSON.stringify(header, null, 2), 'utf8');
   }
 
+  /**
+   * The header as a reader should see it: an untitled thread borrows the
+   * first line of its first user message as its title. Derived, never
+   * written back — `append`/`setSession` do synchronous read-modify-writes
+   * of the header, and a write from a `list` in flight could clobber one.
+   * A thread with no user message at all stays untitled.
+   */
+  private presentHeader(tenant: Tenant, header: ThreadHeader): ThreadHeader {
+    if ((header.title ?? '').trim() !== '') return header;
+    let title = '';
+    try {
+      // Line-by-line, stopping at the first user event, so presenting a long
+      // legacy transcript does not parse the whole log.
+      for (const line of readFileSync(this.logPath(tenant, header.id), 'utf8').split('\n')) {
+        if (line === '') continue;
+        const ev = JSON.parse(line) as ThreadEvent;
+        if ('t' in ev && ev.t === 'user') {
+          title = titleFrom(ev.content);
+          break;
+        }
+      }
+    } catch {
+      // A missing or corrupt log must not take the whole list down; the row
+      // shows as Untitled and opening the thread reports the real error.
+      return header;
+    }
+    return title === '' ? header : { ...header, title };
+  }
+
   private readEvents(tenant: Tenant, id: string): ThreadEvent[] {
     const text = readFileSync(this.logPath(tenant, id), 'utf8');
     return text
@@ -124,7 +172,7 @@ export class ThreadStore {
   async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {
     this.validateTenant(tenant);
     this.validateId(id);
-    return { header: this.readHeader(tenant, id), events: this.readEvents(tenant, id) };
+    return { header: this.presentHeader(tenant, this.readHeader(tenant, id)), events: this.readEvents(tenant, id) };
   }
 
   async list(tenant: Tenant): Promise<ThreadHeader[]> {
@@ -133,7 +181,7 @@ export class ThreadStore {
     if (!existsSync(dir)) return [];
     const headers = readdirSync(dir)
       .filter(name => name.endsWith('.json'))
-      .map(name => this.readHeader(tenant, name.slice(0, -'.json'.length)));
+      .map(name => this.presentHeader(tenant, this.readHeader(tenant, name.slice(0, -'.json'.length))));
     headers.sort((a, b) => a.createdAt.localeCompare(b.createdAt));
     return headers;
   }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -77,6 +77,11 @@
 
 * { box-sizing: border-box; }
 
+/* Two-tier type scale (cou-88): READING surfaces — chat prose (`.v2-prose`)
+   and the vault reading pane (`.v2-doc-md`) — stay at reading size, ~16–17px
+   serif. Everything that FRAMES them (the rail, home's matter/docket/convo
+   rows, ask placeholders, the thread header, settings copy) sits a notch
+   below for density. When sizing a new surface, pick its tier first. */
 body {
   margin: 0;
   font: 14px/1.55 var(--sans);
@@ -282,7 +287,7 @@ a { color: var(--accent); }
 .v2-brand { font: 600 15px/1 var(--serif); letter-spacing: 0.01em; padding: 6px 10px 16px; display: flex; align-items: center; gap: 8px; }
 .v2-mark { width: 20px; height: 20px; border-radius: 6px; background: linear-gradient(135deg, var(--accent), #b3762f); display: inline-block; flex-shrink: 0; }
 .v2-nav { display: flex; flex-direction: column; gap: 1px; }
-.v2-nav a { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 8px; color: var(--fg-muted); text-decoration: none; font-weight: 500; }
+.v2-nav a { display: flex; align-items: center; gap: 10px; padding: 7px 10px; border-radius: 8px; color: var(--fg-muted); text-decoration: none; font-weight: 500; font-size: 13px; }
 .v2-nav a[aria-current="page"] { background: var(--bg-hover); color: var(--fg); }
 .v2-nav a:hover { background: var(--bg-raised); }
 .v2-nav-icon { width: 16px; height: 16px; opacity: 0.75; flex-shrink: 0; }
@@ -294,7 +299,8 @@ a { color: var(--accent); }
 .v2-chev-closed { transform: rotate(-90deg); }
 .v2-rail-section {
   margin-top: 20px;
-  padding: 0 10px 6px;
+  /* No right padding: the + below shares the row ×'s column (cou-88). */
+  padding: 0 0 6px 10px;
   font: 600 10.5px/1 var(--sans);
   letter-spacing: 0.09em;
   text-transform: uppercase;
@@ -303,15 +309,17 @@ a { color: var(--accent); }
   justify-content: space-between;
   align-items: center;
 }
-.v2-rail-new { background: none; border: none; color: var(--fg-faint); padding: 0 2px; font-size: 13px; }
+/* The section's + and each row's ×: one fixed-width hit target, one right
+   edge — both are the last flex child of a full-width row (cou-88). */
+.v2-rail-new, .v2-thread-delete { background: none; border: none; color: var(--fg-faint); width: 26px; padding: 0; text-align: center; flex: none; }
+.v2-rail-new { font-size: 13px; }
 .v2-rail-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1px; }
-.v2-thread, .v2-draft { display: flex; align-items: center; border-radius: 8px; color: var(--fg-muted); font-size: 13px; }
+.v2-thread, .v2-draft { display: flex; align-items: center; border-radius: 8px; color: var(--fg-muted); font-size: 12.5px; }
 .v2-thread[aria-current="true"], .v2-draft[aria-current="true"] { background: var(--bg-hover); color: var(--fg); }
-.v2-thread:hover { background: var(--bg-raised); }
-.v2-draft { padding: 6px 10px; font-style: italic; }
+.v2-thread:hover, .v2-draft:hover { background: var(--bg-raised); }
+.v2-draft { font-style: italic; }
 .v2-thread-open { flex: 1; min-width: 0; text-align: left; background: none; border: none; padding: 6px 10px; color: inherit; }
 .v2-thread-title { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v2-thread-delete { background: none; border: none; color: var(--fg-faint); padding: 0 8px; }
 .v2-foot { margin-top: auto; padding: 10px; display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--fg-faint); background: none; border: none; text-align: left; }
 .v2-rail-empty { margin: 2px 10px; font-size: 12.5px; font-style: italic; }
 .v2-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); flex-shrink: 0; }
@@ -490,7 +498,9 @@ a { color: var(--accent); }
 
 /* ── v2 settings ──────────────────────────────────────────────────────── */
 
-.v2-settings { max-width: 60rem; display: flex; flex-direction: column; gap: var(--s4); }
+/* 13.5px: settings copy is chrome, not reading matter. rem-sized fields and
+   labels inside keep their own scale. */
+.v2-settings { max-width: 60rem; display: flex; flex-direction: column; gap: var(--s4); font-size: 13.5px; }
 /* Groups are ruled entries now, not cards: a double rule opens each, a
  * small-caps run-in names it. */
 .v2-group { border: none; border-top: 3px double var(--border-strong); border-radius: 0; background: none; box-shadow: none; padding: 12px 2px 16px; }
@@ -541,7 +551,7 @@ a { color: var(--accent); }
 .v2-sub { color: var(--fg-muted); margin-bottom: 26px; font: italic 15px/1.5 var(--serif); }
 
 .v2-ask { background: var(--bg-raised); border: 1px solid var(--border-strong); border-radius: var(--radius-lg); padding: 16px 18px 12px; box-shadow: var(--shadow); }
-.v2-ask textarea { width: 100%; background: none; border: none; color: var(--fg); font: 16px/1.5 var(--sans); resize: none; outline: none; padding: 0; }
+.v2-ask textarea { width: 100%; background: none; border: none; color: var(--fg); font: 15px/1.5 var(--sans); resize: none; outline: none; padding: 0; }
 .v2-ask textarea::placeholder { color: var(--fg-faint); }
 .v2-ask-row { display: flex; align-items: center; gap: 10px; margin-top: 10px; flex-wrap: wrap; }
 .v2-ask-chip { font-size: 12px; color: var(--fg-muted); border: 1px solid var(--border-strong); border-radius: 999px; padding: 3px 10px; background: var(--bg); cursor: pointer; }
@@ -559,7 +569,7 @@ a { color: var(--accent); }
 .v2-docket { border-top: 3px double var(--border-strong); border-bottom: 1px solid var(--border); margin-top: 22px; margin-bottom: 26px; padding: 12px 2px 14px; }
 .v2-docket-head { margin-bottom: 8px; }
 .v2-docket-row { display: flex; align-items: baseline; gap: 12px; padding: 4px 0; }
-.v2-docket-what { font: 17px/1.4 var(--serif); color: var(--fg); }
+.v2-docket-what { font: 15px/1.45 var(--serif); color: var(--fg); }
 .v2-docket-path { font: 12px var(--mono); color: var(--fg-faint); margin-top: 3px; }
 .v2-docket-go { margin-left: auto; background: none; border: none; color: var(--accent); font: 600 13px var(--sans); flex-shrink: 0; cursor: pointer; }
 .v2-docket-go::after { content: " →"; }
@@ -581,13 +591,13 @@ a { color: var(--accent); }
 .v2-matter { padding: 10px 0; border-top: 1px solid var(--border); }
 .v2-matter:first-of-type { border-top: none; }
 .v2-matter-top { display: flex; align-items: baseline; gap: 12px; }
-.v2-matter-name { font: 500 15px/1.35 var(--serif); color: var(--fg); text-decoration: none; min-width: 0; }
+.v2-matter-name { font: 500 14px/1.35 var(--serif); color: var(--fg); text-decoration: none; min-width: 0; }
 .v2-due { font-size: 12px; color: var(--fg-faint); flex-shrink: 0; }
 .v2-due-hot { color: var(--amber); font-weight: 600; }
 .v2-na { font-size: 12px; color: var(--fg-muted); margin-top: 2px; }
 .v2-na b { font-weight: 600; }
 
-.v2-convo { display: flex; width: 100%; align-items: baseline; gap: 10px; padding: 8px 0; border: none; border-top: 1px solid var(--border); background: none; font-size: 13.5px; text-align: left; cursor: pointer; }
+.v2-convo { display: flex; width: 100%; align-items: baseline; gap: 10px; padding: 8px 0; border: none; border-top: 1px solid var(--border); background: none; font-size: 13px; text-align: left; cursor: pointer; }
 .v2-convo:first-of-type { border-top: none; }
 .v2-convo-title { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .v2-convo-when { color: var(--fg-faint); font-size: 12px; flex-shrink: 0; }
@@ -604,7 +614,7 @@ a { color: var(--accent); }
 /* ── Chat (mock-chat.html) ───────────────────────────────────────────── */
 
 .v2-thread-head { display: flex; align-items: baseline; gap: 12px; padding: 14px 40px 12px; border-bottom: 1px solid var(--border); }
-.v2-thread-head h1 { font: 600 20px/1.3 var(--serif); margin: 0; }
+.v2-thread-head h1 { font: 600 18px/1.3 var(--serif); margin: 0; }
 .v2-matter-chip { font-size: 12px; color: var(--fg-muted); border: 1px solid var(--border); border-radius: 999px; padding: 2px 9px; }
 .v2-thread-date { margin-left: auto; font-size: 12px; color: var(--fg-faint); }
 

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -41,6 +41,7 @@ function mount(over: Partial<Parameters<typeof Rail>[0]> = {}) {
       collapsed={false}
       onSelect={() => {}}
       onNew={() => {}}
+      onOpenDraft={() => {}}
       onDelete={() => {}}
       {...over}
     />,
@@ -165,6 +166,13 @@ describe('Rail', () => {
     mount({ draft: true, selected: null });
     expect(document.querySelector('li.v2-draft[aria-current="true"]')).toBeTruthy();
     expect((screen.getByRole('button', { name: 'New conversation' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('the draft row is a button that reaches onOpenDraft (cou-88)', async () => {
+    let opened = 0;
+    mount({ draft: true, selected: null, onOpenDraft: () => (opened += 1) });
+    await userEvent.click(screen.getByRole('button', { name: 'Open the new conversation' }));
+    expect(opened).toBe(1);
   });
 
   test('select and delete reach their handlers', async () => {

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -8,7 +8,8 @@ export interface RailProps {
   threads: ThreadHeader[];
   selected: string | null;
   /** True while the main pane holds a draft — a conversation with no thread
-   * yet. The draft is a row so the reader can see where they are. */
+   * yet. The draft is a row so the reader can see where they are, and a
+   * BUTTON so they can get back to it from any other surface (cou-88). */
   draft: boolean;
   busy?: boolean;
   /** `/health` — the footer's `● <default model> · <auth>` (spec §3.1). */
@@ -18,6 +19,9 @@ export interface RailProps {
   collapsed: boolean;
   onSelect: (id: string) => void;
   onNew: () => void;
+  /** The draft row: navigate back to the draft already live in the chat
+   * pane — never a reset. `onNew` starts a draft; this one returns to it. */
+  onOpenDraft: () => void;
   onDelete: (id: string) => void;
 }
 
@@ -63,6 +67,7 @@ export function Rail({
   collapsed,
   onSelect,
   onNew,
+  onOpenDraft,
   onDelete,
 }: RailProps): JSX.Element {
   return (
@@ -99,8 +104,14 @@ export function Rail({
           </div>
           <ul className="v2-rail-list" aria-label="Threads">
             {draft ? (
+              /* A button, not dead text (cou-88 nav bug: a draft left for
+                 Home or Settings was unreachable). The aria-label is distinct
+                 from the + button's "New conversation" — the two sit side by
+                 side and name different acts: start vs return. */
               <li className="v2-draft" aria-current="true">
-                <span className="v2-thread-title">New conversation</span>
+                <button type="button" className="v2-thread-open" aria-label="Open the new conversation" onClick={onOpenDraft}>
+                  <span className="v2-thread-title">New conversation</span>
+                </button>
               </li>
             ) : null}
             {threads.map(thread => (

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -227,6 +227,43 @@ describe('Shell', () => {
     expect(document.querySelector('.v2-transcript .v2-empty')?.textContent).toContain('the thread is created when you send');
   });
 
+  // cou-88 regression: a draft left for another surface must be reachable
+  // again — the Chat nav and the rail's draft row both return to the SAME
+  // draft, never to a thread and never to a fresh (wiped) one.
+  test('the Chat nav returns to the live draft, not to a thread', async () => {
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'New conversation' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'Message' }), 'half-typed');
+
+    goTo('#/');
+    expect(workNode()?.hasAttribute('hidden')).toBe(true);
+    goTo('#/chat');
+
+    expect(workNode()?.hasAttribute('hidden')).toBe(false);
+    expect(document.querySelector('li.v2-draft[aria-current="true"]')).toBeTruthy();
+    expect(document.querySelector('li.v2-thread[aria-current="true"]')).toBeNull();
+    expect(document.querySelector('.v2-thread-head')).toBeNull();
+    expect((screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement).value).toBe('half-typed');
+  });
+
+  test("the rail's draft row navigates back to the draft from Home", async () => {
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'New conversation' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'Message' }), 'keep me');
+
+    goTo('#/');
+    const pane = chatNode();
+    await userEvent.click(screen.getByRole('button', { name: 'Open the new conversation' }));
+
+    expect(workNode()?.hasAttribute('hidden')).toBe(false);
+    expect(location.hash).toBe('#/chat');
+    // The same pane: a return, not a re-keyed (wiped) draft.
+    expect(chatNode()).toBe(pane);
+    expect((screen.getByRole('textbox', { name: 'Message' }) as HTMLTextAreaElement).value).toBe('keep me');
+  });
+
   test('on #/vault the rail collapses to icons and the workspace hides, chat intact', async () => {
     render(<Shell />);
     await waitFor(() => expect(chatNode()).toBeTruthy());

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -118,6 +118,17 @@ export function Shell(): JSX.Element {
     globalThis.history.replaceState(null, '', '#/chat');
   };
 
+  /** The rail's draft row: RETURN to the draft already live in the chat
+   * pane. Navigation only — never `newDraft`, which re-keys `Chat` and
+   * would wipe whatever the reader had typed. The pane is mounted-but-hidden
+   * off `#/chat` (the keep-stream invariant), so the draft is simply shown
+   * again (cou-88). */
+  const returnToDraft = (): void => {
+    setRoute('chat');
+    setVaultPath(null);
+    globalThis.history.replaceState(null, '', '#/chat');
+  };
+
   /** Re-stamp `?thread=` onto a bare `#/chat`. The rail's Chat link has no
    * thread in its href, so following it from `#/chat?thread=t-1` used to
    * leave t-1 on screen under a URL that no longer named it — copy the link
@@ -287,6 +298,7 @@ export function Shell(): JSX.Element {
         collapsed={route === 'vault'}
         onSelect={openThread}
         onNew={openDraft}
+        onOpenDraft={returnToDraft}
         onDelete={id => void deleteThread(id)}
       />
       <div className="v2-main-col">


### PR DESCRIPTION
Founder feedback 2026-08-31 (cou-88), three items:

## 1 — Align the CONVERSATIONS + with the row × column
`.v2-rail-new` and `.v2-thread-delete` now share one rule: a fixed 26px-wide, centered hit target. The section header lost its right padding, so both are the last flex child of a full-width row — same right edge.

## 2 — Nav bug: a draft must be reachable after navigating away
The rail's "New conversation" draft row was dead text. A draft left for Home or Settings was unreachable: the + button is disabled while a draft exists, and clicking a thread row kills the draft. The row is now a button (`aria-label="Open the new conversation"`, distinct from the + button's name) wired to a new `returnToDraft` in the Shell — pure navigation (`setRoute('chat')` + `replaceState('#/chat')`), never `newDraft`, so the reader's typed text survives. The Chat nav already returned to the live draft via `stampThread`'s draft guard; a regression test now locks both paths (draft kept, typed text kept, no thread header, never a different thread).

Also: untitled threads no longer linger as **Untitled** rows. Titling arrived with the v0.11 redesign, so every pre-v0.11 thread (and any thread another client creates bare) sat in the rail as `Untitled` forever. `ThreadStore.list()`/`get()` now derive a title from the first line of the thread's first user message — the same 60-char word-boundary rule the UI applies at creation. Derived at read time, never written back (append's sync read-modify-write of the header must not race a write from list). A thread with no user message at all still reads `Untitled` — the UI cannot create one.

## 3 — Two-tier type scale
Documented at the top of `styles.css`: reading surfaces (chat prose `.v2-prose`, vault reading pane `.v2-doc-md`) stay at ~16–17px serif; the chrome drops a notch for density — nav 14→13, rail rows 13→12.5, docket rows 17→15, matter names 15→14, convo rows 13.5→13, home ask textarea (and its placeholder) 16→15, thread header 20→18, settings copy →13.5.

## What to verify (AC)
- [ ] Rail: + under CONVERSATIONS sits flush with the thread rows' × (same width, same right edge).
- [ ] Start a draft, type something, go Home → click the "New conversation" row → same draft, text intact, hash `#/chat`.
- [ ] Same, but return via the Chat nav link → same draft, never a thread.
- [ ] A pre-existing thread with no `title` in its header shows its first message's first line in the rail and the thread header (not "Untitled").
- [ ] Chat prose and vault reading pane unchanged; rail/lists/headers visibly denser.

## Verified locally
- `bun run typecheck` + `typecheck:runtime` + `typecheck:ui` — clean.
- `bun run test` (612 pass) and `runtime/ui` `bun test` (324 pass, incl. 5 new tests).
- `evals:self-test`, `evals:runner-test`, `law:frontmatter`, knowledge lint, browse-reference diff, script syntax — all green.
- Playwright e2e (`bun run e2e`) — 1 passed.
- Real-browser QA against a fake-provider serve with a seeded legacy untitled thread: screenshots confirm the derived title in rail/home/thread header, the +/× column alignment, and the draft round trip preserving typed text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)