### PR TITLE
Rail-footer provider plate + model switcher (cou-90)

### DIFF
--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -320,9 +320,35 @@ a { color: var(--accent); }
 .v2-draft { font-style: italic; }
 .v2-thread-open { flex: 1; min-width: 0; text-align: left; background: none; border: none; padding: 6px 10px; color: inherit; }
 .v2-thread-title { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.v2-foot { margin-top: auto; padding: 10px; display: flex; align-items: center; gap: 8px; min-width: 0; font-size: 12px; color: var(--fg-faint); background: none; border: none; text-align: left; }
+/* The provider plate (cou-90): a designed two-line lockup, not a string.
+ * `.v2-switch` owns the footer slot and anchors the popover; the button is
+ * the plate. The dot pins to line 1 (flex-start + a line-height offset),
+ * because line 2 may be long and the dot marks the vendor, not the block. */
+.v2-switch { margin-top: auto; position: relative; }
+.v2-foot { width: 100%; padding: 10px; display: flex; align-items: flex-start; gap: 8px; min-width: 0; color: var(--fg-faint); background: none; border: none; text-align: left; border-radius: 8px; }
+.v2-foot:hover { background: var(--bg-raised); }
+.v2-foot .v2-dot { margin-top: 5px; }
 .v2-rail-empty { margin: 2px 10px; font-size: 12.5px; font-style: italic; }
 .v2-dot { width: 7px; height: 7px; border-radius: 50%; background: var(--ok); flex-shrink: 0; }
+.v2-dot-amber { background: var(--warn); }
+/* The popover rows keep the dot's column so the vendors align; only the
+ * provider in use gets the ink. */
+.v2-dot-off { background: transparent; }
+.v2-plate { display: flex; flex-direction: column; min-width: 0; }
+/* Line 1 never truncates: set text at 13px, the vendor a lawyer knows. */
+.v2-plate-vendor { font: 13px/1.35 var(--sans); color: var(--fg); white-space: nowrap; display: flex; align-items: center; gap: 8px; }
+.v2-plate-detail { font: 11.5px/1.4 var(--sans); color: var(--fg-faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* The switcher popover: above the footer, inside the rail — no portal. */
+.v2-switch-pop { position: absolute; bottom: calc(100% + 4px); left: 6px; right: 6px; z-index: 30; background: var(--bg-raised); border: 1px solid var(--border-strong); border-radius: var(--radius); box-shadow: var(--shadow); max-height: 18rem; overflow-y: auto; }
+.v2-switch-list { list-style: none; margin: 0; padding: 4px; }
+.v2-switch-item { padding: 6px 10px; border-radius: var(--radius); cursor: pointer; }
+/* The rows carry the dot INSIDE line 1, so line 2 needs the same 15px
+ * (7px dot + 8px gap) to sit in the vendor's column. */
+.v2-switch-item .v2-plate-detail { padding-left: 15px; }
+.v2-switch-item[data-focused] { background: var(--bg-hover); }
+.v2-switch-item:hover { background: var(--bg-hover); }
+/* The last row: a plain act, indented into the vendor column. */
+.v2-switch-settings { display: block; padding: 2px 0 2px 15px; font-size: 12px; color: var(--fg-muted); }
 
 /* Icon rail on the vault route (mock-vault.html .rail): 56px, no labels. */
 .v2-rail.v2-rail-icons { width: var(--rail-w-icons); padding: 14px 8px; align-items: center; }
@@ -625,9 +651,6 @@ a { color: var(--accent); }
 .v2-file-chip { font: 11.5px var(--mono); background: var(--bg-raised); border: 1px solid var(--border); border-radius: 5px; padding: 1px 6px; color: var(--fg-muted); }
 .v2-work-line-wrap .v2-steps { margin-top: 6px; }
 
-/* The rail footer's swap note: quiet, never a banner. */
-.v2-foot-note { font-size: 11px; }
-
 /* Source chips: the derived citations inside the prose. The class is added
    AFTER the sanitizer, by path match — a document cannot mint it. */
 .v2-prose code.v2-cite {
@@ -685,5 +708,6 @@ a { color: var(--accent); }
 /* The transcript column narrows to the mock's 720px measure. */
 .v2-turn { max-width: 720px; }
 
-/* One line, ellipsized: the dot stays on the label line however long the model id. Full text in the title. */
-.v2-foot .v2-lbl { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* The plate clips on its detail line only; the full raw id + auth live in
+ * the title. (The old one-line `.v2-foot .v2-lbl` ellipsis moved onto
+ * `.v2-plate-detail` with the cou-90 plate.) */

--- a/runtime/ui/src/v2/ModelSwitcher.tsx
+++ b/runtime/ui/src/v2/ModelSwitcher.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useRef } from 'react';
+import { useButton, useMenu, useMenuItem, useMenuTrigger, type AriaMenuProps } from 'react-aria';
+import { Item, useMenuTriggerState, useTreeState, type TreeState } from 'react-stately';
+import type { Node } from '@react-types/shared';
+import type { Health } from '../api/types';
+import { plateFor, footerLabel, swapNote } from './plate';
+import { defaultProviderId } from './threads';
+
+/** The final row's key. `/` never appears in it, so no provider id collides. */
+const SETTINGS_KEY = 'open-settings';
+
+export interface ModelSwitcherProps {
+  health: Health | null;
+  /** Make this loaded provider the saved default (the settings round-trip
+   * lives in the Shell — the rail stays presentational). */
+  onSetDefault(id: string): void;
+}
+
+interface Row {
+  id: string;
+}
+
+/**
+ * The rail footer as a provider plate + model switcher (cou-90): the button
+ * is the two-line lockup for the provider a send will actually use, and
+ * clicking it opens a popover of the LOADED providers — pick one and it
+ * becomes the saved default in place, no Settings trip. `Open Settings`
+ * stays, as the popover's last row.
+ *
+ * Headless react-aria menu hooks under our own markup (the ProviderCombo
+ * pattern): no portal — the popover is an absolutely positioned sibling of
+ * the button, above it, inside the rail's DOM.
+ *
+ * The dot is green for "this is the saved default, loaded and answering";
+ * AMBER when the saved default did not load and the runtime fell back —
+ * the title carries the explanation, the plate itself stays calm.
+ */
+export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX.Element {
+  const state = useMenuTriggerState({});
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const { menuTriggerProps, menuProps } = useMenuTrigger<Row>({}, state, triggerRef);
+  const { buttonProps } = useButton(menuTriggerProps, triggerRef);
+
+  // Outside click closes. No portal and no overlay layer, so the listener is
+  // the whole dismiss story; scoped to the open state so it costs nothing
+  // while the menu is shut.
+  const closeRef = useRef(state.close);
+  closeRef.current = state.close;
+  useEffect(() => {
+    if (!state.isOpen) return;
+    const onDown = (event: Event): void => {
+      const target = event.target;
+      if (wrapRef.current !== null && target instanceof globalThis.Node && !wrapRef.current.contains(target)) {
+        closeRef.current();
+      }
+    };
+    document.addEventListener('pointerdown', onDown);
+    return () => document.removeEventListener('pointerdown', onDown);
+  }, [state.isOpen]);
+
+  const effective = health === null ? '' : defaultProviderId(health);
+  const swap = swapNote(health);
+  const plate =
+    health === null ? null : plateFor(effective, health.providers.find(p => p.id === effective)?.auth);
+
+  const rows: Row[] = [...(health?.providers ?? []).map(p => ({ id: p.id })), { id: SETTINGS_KEY }];
+  const children = (row: Row): JSX.Element => {
+    if (row.id === SETTINGS_KEY) {
+      return (
+        <Item textValue="Open Settings">
+          <span className="v2-switch-settings">Open Settings</span>
+        </Item>
+      );
+    }
+    const rowPlate = plateFor(row.id, health?.providers.find(p => p.id === row.id)?.auth);
+    return (
+      <Item textValue={`${rowPlate.vendor} ${rowPlate.detail}`}>
+        {/* The same lockup as the footer. The dot slot is always there so the
+            vendor column lines up; only the provider in use gets the ink. */}
+        <span className="v2-plate">
+          <span className="v2-plate-vendor">
+            <span className={row.id === effective ? 'v2-dot' : 'v2-dot v2-dot-off'} aria-hidden="true" />
+            {rowPlate.vendor}
+          </span>
+          <span className="v2-plate-detail">{rowPlate.detail}</span>
+        </span>
+      </Item>
+    );
+  };
+
+  const act = (key: React.Key): void => {
+    state.close();
+    if (key === SETTINGS_KEY) {
+      globalThis.location.hash = '#/settings';
+      return;
+    }
+    // Re-picking the provider already in use is a no-op, not a save.
+    if (String(key) !== effective) onSetDefault(String(key));
+  };
+
+  return (
+    <div className="v2-switch" ref={wrapRef}>
+      {state.isOpen ? (
+        <div
+          className="v2-switch-pop"
+          onKeyDown={event => {
+            if (event.key === 'Escape') {
+              state.close();
+              triggerRef.current?.focus();
+            }
+          }}
+        >
+          <SwitchMenu {...menuProps} items={rows} autoFocus={state.focusStrategy || true} onAction={act} onClose={state.close}>
+            {children}
+          </SwitchMenu>
+        </div>
+      ) : null}
+      <button
+        {...buttonProps}
+        ref={triggerRef}
+        type="button"
+        className="v2-foot"
+        title={
+          health === null
+            ? undefined
+            : `${footerLabel(health)}${swap === null ? '' : ` — ${swap}`} — switch model`
+        }
+      >
+        <span className={swap === null ? 'v2-dot' : 'v2-dot v2-dot-amber'} aria-hidden="true" />
+        <span className="v2-lbl v2-plate">
+          {plate === null ? (
+            <span className="v2-plate-vendor">…</span>
+          ) : (
+            <>
+              <span className="v2-plate-vendor">{plate.vendor}</span>
+              <span className="v2-plate-detail">{plate.detail}</span>
+            </>
+          )}
+        </span>
+      </button>
+    </div>
+  );
+}
+
+function SwitchMenu(props: AriaMenuProps<Row> & { onClose(): void }): JSX.Element {
+  const state = useTreeState(props);
+  const ref = useRef<HTMLUListElement | null>(null);
+  // Its own name, not the trigger's: `aria-labelledby` (from the trigger's
+  // menu props) outranks `aria-label`, and would name the menu after the
+  // plate's whole text. `onAction`/`onClose` register HERE and reach every
+  // item through the menu's own plumbing — passing them to `useMenuItem`
+  // again would fire each pick twice.
+  const { menuProps } = useMenu({ ...props, 'aria-label': 'Switch model', 'aria-labelledby': undefined }, state, ref);
+  return (
+    <ul {...menuProps} ref={ref} className="v2-switch-list">
+      {[...state.collection].map(item => (
+        <SwitchRow key={item.key} item={item} state={state} />
+      ))}
+    </ul>
+  );
+}
+
+function SwitchRow({ item, state }: { item: Node<Row>; state: TreeState<Row> }): JSX.Element {
+  const ref = useRef<HTMLLIElement | null>(null);
+  const { menuItemProps, isFocused } = useMenuItem({ key: item.key }, state, ref);
+  return (
+    <li {...menuItemProps} ref={ref} className="v2-switch-item" data-focused={isFocused ? true : undefined}>
+      {item.rendered}
+    </li>
+  );
+}

--- a/runtime/ui/src/v2/ModelSwitcher.tsx
+++ b/runtime/ui/src/v2/ModelSwitcher.tsx
@@ -11,6 +11,11 @@ const SETTINGS_KEY = 'open-settings';
 
 export interface ModelSwitcherProps {
   health: Health | null;
+  /** True in the 56px icon rail (vault route). The icon rail centers its
+   * children, so the footer wrapper shrinks to the dot and a rail-anchored
+   * popover would inherit a ~2px box — there the plate stays a plain button
+   * and keeps the icon rail's escape hatch: navigate to Settings. */
+  collapsed: boolean;
   /** Make this loaded provider the saved default (the settings round-trip
    * lives in the Shell — the rail stays presentational). */
   onSetDefault(id: string): void;
@@ -35,7 +40,7 @@ interface Row {
  * AMBER when the saved default did not load and the runtime fell back —
  * the title carries the explanation, the plate itself stays calm.
  */
-export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX.Element {
+export function ModelSwitcher({ health, collapsed, onSetDefault }: ModelSwitcherProps): JSX.Element {
   const state = useMenuTriggerState({});
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -58,6 +63,12 @@ export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX
     document.addEventListener('pointerdown', onDown);
     return () => document.removeEventListener('pointerdown', onDown);
   }, [state.isOpen]);
+
+  // A menu left open when the route collapses the rail would reappear the
+  // moment the rail expands again.
+  useEffect(() => {
+    if (collapsed) closeRef.current();
+  }, [collapsed]);
 
   const effective = health === null ? '' : defaultProviderId(health);
   const swap = swapNote(health);
@@ -89,10 +100,14 @@ export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX
     );
   };
 
+  const openSettings = (): void => {
+    globalThis.location.hash = '#/settings';
+  };
+
   const act = (key: React.Key): void => {
     state.close();
     if (key === SETTINGS_KEY) {
-      globalThis.location.hash = '#/settings';
+      openSettings();
       return;
     }
     // Re-picking the provider already in use is a no-op, not a save.
@@ -101,7 +116,7 @@ export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX
 
   return (
     <div className="v2-switch" ref={wrapRef}>
-      {state.isOpen ? (
+      {!collapsed && state.isOpen ? (
         <div
           className="v2-switch-pop"
           onKeyDown={event => {
@@ -117,14 +132,17 @@ export function ModelSwitcher({ health, onSetDefault }: ModelSwitcherProps): JSX
         </div>
       ) : null}
       <button
-        {...buttonProps}
+        // Collapsed = plain navigation, so none of the trigger's menu
+        // props (aria-haspopup/expanded would promise a popup that never
+        // comes).
+        {...(collapsed ? { onClick: openSettings } : buttonProps)}
         ref={triggerRef}
         type="button"
         className="v2-foot"
         title={
           health === null
             ? undefined
-            : `${footerLabel(health)}${swap === null ? '' : ` — ${swap}`} — switch model`
+            : `${footerLabel(health)}${swap === null ? '' : ` — ${swap}`} — ${collapsed ? 'open Settings' : 'switch model'}`
         }
       >
         <span className={swap === null ? 'v2-dot' : 'v2-dot v2-dot-amber'} aria-hidden="true" />

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -1,22 +1,29 @@
-import { cleanup, render, screen, userEvent } from '../test/dom';
+import { cleanup, render, screen, userEvent, within } from '../test/dom';
 
 import { readFileSync } from 'node:fs';
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import type { Health, ThreadHeader } from '../api/types';
-import { footerLabel, Rail, railLabel, swapNote } from './Rail';
+import type { Health, ProviderInfo } from '../api/types';
+import type { ThreadHeader } from '../api/types';
+import { Rail, railLabel } from './Rail';
+
+const fake: ProviderInfo = {
+  id: 'fake/fake',
+  kind: 'direct',
+  auth: 'local',
+  capabilities: { tools: true, caching: false, thinking: false, contextTokens: 8192, auth: 'local' },
+};
+const claude: ProviderInfo = {
+  id: 'claude-sub/claude-opus-5',
+  kind: 'harness',
+  auth: 'subscription',
+  capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' },
+};
 
 const health: Health = {
   vault: '/tmp/vault',
   tenant: 'default',
-  providers: [
-    {
-      id: 'fake/fake',
-      kind: 'direct',
-      auth: 'local',
-      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 8192, auth: 'local' },
-    },
-  ],
+  providers: [fake],
   default: 'fake/fake',
   stepTimeoutMs: 600_000,
 };
@@ -43,6 +50,7 @@ function mount(over: Partial<Parameters<typeof Rail>[0]> = {}) {
       onNew={() => {}}
       onOpenDraft={() => {}}
       onDelete={() => {}}
+      onSetDefault={() => {}}
       {...over}
     />,
   );
@@ -88,34 +96,80 @@ describe('Rail', () => {
     expect(railLabel(untitled)).toBe('Untitled');
   });
 
-  test('the footer is the default model + auth, and opens Settings', async () => {
+  test('the footer is the provider plate: vendor on line 1, model · connection on line 2', () => {
     mount();
-    expect(footerLabel(health)).toBe('fake/fake · local');
-    expect(footerLabel(null)).toBe('…');
-    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
-    expect(location.hash).toBe('#/settings');
+    const foot = document.querySelector('.v2-foot') as HTMLElement;
+    expect(foot.querySelector('.v2-plate-vendor')?.textContent).toBe('fake');
+    expect(foot.querySelector('.v2-plate-detail')?.textContent).toBe('fake/fake · local');
+    expect(foot.getAttribute('title')).toBe('fake/fake · local — switch model');
+    // The green dot: the saved default is the one answering.
+    expect(foot.querySelector('.v2-dot')?.classList.contains('v2-dot-amber')).toBe(false);
   });
 
-  test('the footer names the model a send will ACTUALLY use, and says when that is not the saved one', () => {
-    // The saved default names a provider this runtime did not load. The
-    // composer's picker used to say so; the footer is the only place left.
-    const swapped: Health = { ...health, default: 'openai/nope' };
-    expect(footerLabel(swapped)).toBe('fake/fake · local');
-    expect(swapNote(swapped)).toBe('saved default openai/nope not loaded');
+  test('a known provider gets its designed lockup', () => {
+    mount({ health: { ...health, providers: [claude], default: claude.id } });
+    const foot = document.querySelector('.v2-foot') as HTMLElement;
+    expect(foot.querySelector('.v2-plate-vendor')?.textContent).toBe('Claude');
+    expect(foot.querySelector('.v2-plate-detail')?.textContent).toBe('Opus 5 · subscription');
+  });
 
+  test('saved-default-not-loaded: AMBER dot, explanation in the title, no label note', () => {
+    // The saved default names a provider this runtime did not load. The
+    // parenthetical swap note the label used to carry moved into the dot +
+    // title (cou-90) — the plate itself stays calm.
+    const swapped: Health = { ...health, default: 'openai/nope' };
     mount({ health: swapped });
     const foot = document.querySelector('.v2-foot') as HTMLElement;
-    expect(foot.querySelector('.v2-lbl')?.textContent).toBe('fake/fake · local');
-    expect(foot.querySelector('.v2-foot-note')?.textContent).toBe('(saved default openai/nope not loaded)');
-    expect(foot.getAttribute('title')).toBe('fake/fake · local — saved default openai/nope not loaded — open Settings');
+    expect(foot.querySelector('.v2-dot')?.classList.contains('v2-dot-amber')).toBe(true);
+    expect(foot.querySelector('.v2-foot-note')).toBeNull();
+    expect(foot.querySelector('.v2-plate-vendor')?.textContent).toBe('fake');
+    expect(foot.getAttribute('title')).toBe('fake/fake · local — saved default openai/nope not loaded — switch model');
   });
 
-  test('a saved default that IS loaded says nothing extra', () => {
-    expect(swapNote(health)).toBeNull();
-    expect(swapNote(null)).toBeNull();
+  test('clicking the footer opens the switcher: one lockup per loaded provider + Open Settings', async () => {
+    mount({ health: { ...health, providers: [fake, claude] } });
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    const menu = screen.getByRole('menu', { name: 'Switch model' });
+    const vendors = Array.from(menu.querySelectorAll('.v2-plate-vendor'), (el: Element) => el.textContent);
+    expect(vendors).toEqual(['fake', 'Claude']);
+    const details = Array.from(menu.querySelectorAll('.v2-plate-detail'), (el: Element) => el.textContent);
+    expect(details).toEqual(['fake/fake · local', 'Opus 5 · subscription']);
+    // The row in use carries the dot's ink; the other keeps the column.
+    const dots = Array.from(menu.querySelectorAll('.v2-dot'), (el: Element) => el.classList.contains('v2-dot-off'));
+    expect(dots).toEqual([false, true]);
+    expect(screen.getByText('Open Settings')).toBeTruthy();
+  });
+
+  test('picking a provider saves it as the default and closes the popover', async () => {
+    const picked: string[] = [];
+    mount({ health: { ...health, providers: [fake, claude] }, onSetDefault: id => picked.push(id) });
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    await userEvent.click(screen.getByText('Claude'));
+    expect(picked).toEqual(['claude-sub/claude-opus-5']);
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+    expect(location.hash).not.toBe('#/settings');
+  });
+
+  test('re-picking the provider already in use is a no-op, not a save', async () => {
+    const picked: string[] = [];
+    mount({ health: { ...health, providers: [fake, claude] }, onSetDefault: id => picked.push(id) });
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    // Scoped to the menu: the footer plate says `fake/fake · local` too.
+    await userEvent.click(within(screen.getByRole('menu', { name: 'Switch model' })).getByText('fake/fake · local'));
+    expect(picked).toEqual([]);
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+  });
+
+  test('Open Settings stays, as the final row', async () => {
     mount();
-    expect(document.querySelector('.v2-foot-note')).toBeNull();
-    expect(document.querySelector('.v2-foot')?.getAttribute('title')).toBe('fake/fake · local — open Settings');
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    const items = Array.from(document.querySelectorAll('.v2-switch-item'), el => el.textContent);
+    expect(items[items.length - 1]).toBe('Open Settings');
+    await userEvent.click(screen.getByText('Open Settings'));
+    expect(location.hash).toBe('#/settings');
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
   });
 
   test('collapsed: labels and conversations disappear, the icons stay', () => {
@@ -136,7 +190,7 @@ describe('Rail', () => {
       const link = screen.getByRole('link', { name });
       expect(link.querySelector('.v2-lbl')?.textContent).toBe(name);
     }
-    expect(document.querySelector('.v2-foot .v2-lbl')?.textContent).toBe('fake/fake · local');
+    expect(document.querySelector('.v2-foot .v2-lbl .v2-plate-detail')?.textContent).toBe('fake/fake · local');
 
     // Style contract: clipped to 1px, NOT `display: none`. `display: none`
     // takes the element out of the accessibility tree, which would leave a

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -37,8 +37,8 @@ const acme: ThreadHeader = {
 };
 const untitled: ThreadHeader = { id: 't-2', createdAt: '2026-08-27T10:00:00.000Z', updatedAt: '2026-08-27T10:00:00.000Z', sessions: {} };
 
-function mount(over: Partial<Parameters<typeof Rail>[0]> = {}) {
-  return render(
+function railElement(over: Partial<Parameters<typeof Rail>[0]> = {}) {
+  return (
     <Rail
       route="home"
       threads={[acme, untitled]}
@@ -52,8 +52,12 @@ function mount(over: Partial<Parameters<typeof Rail>[0]> = {}) {
       onDelete={() => {}}
       onSetDefault={() => {}}
       {...over}
-    />,
+    />
   );
+}
+
+function mount(over: Partial<Parameters<typeof Rail>[0]> = {}) {
+  return render(railElement(over));
 }
 
 /**
@@ -169,6 +173,32 @@ describe('Rail', () => {
     expect(items[items.length - 1]).toBe('Open Settings');
     await userEvent.click(screen.getByText('Open Settings'));
     expect(location.hash).toBe('#/settings');
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+  });
+
+  test('collapsed: the footer is a Settings shortcut, not a popover trigger (cou-92)', async () => {
+    // The 56px icon rail centers its children, so the footer wrapper shrinks
+    // to the dot and a rail-anchored popover would render ~2px wide. There
+    // the plate keeps the icon rail's escape hatch: navigate to Settings.
+    mount({ collapsed: true, route: 'vault' });
+    const foot = screen.getByRole('button', { name: /fake\/fake/ });
+    // No popup promise on the button — a popup never comes in the icon rail.
+    expect(foot.getAttribute('aria-haspopup')).toBeNull();
+    expect(foot.getAttribute('title')).toBe('fake/fake · local — open Settings');
+    await userEvent.click(foot);
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+    expect(screen.queryByRole('menu')).toBeNull();
+    expect(location.hash).toBe('#/settings');
+  });
+
+  test('an open switcher closes when the route collapses the rail (cou-92)', async () => {
+    const view = mount({ collapsed: false });
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    expect(document.querySelector('.v2-switch-pop')).toBeTruthy();
+    view.rerender(railElement({ collapsed: true, route: 'vault' }));
+    expect(document.querySelector('.v2-switch-pop')).toBeNull();
+    // Back on an expanded route the menu stays shut — no popover springs back.
+    view.rerender(railElement({ collapsed: false }));
     expect(document.querySelector('.v2-switch-pop')).toBeNull();
   });
 

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -1,7 +1,7 @@
 import type { Health, ThreadHeader } from '../api/types';
 import type { Route } from '../app';
 import { ChatIcon, HomeIcon, SettingsIcon, VaultIcon } from './icons';
-import { defaultProviderId } from './threads';
+import { ModelSwitcher } from './ModelSwitcher';
 
 export interface RailProps {
   route: Route;
@@ -12,7 +12,7 @@ export interface RailProps {
    * BUTTON so they can get back to it from any other surface (cou-88). */
   draft: boolean;
   busy?: boolean;
-  /** `/health` — the footer's `● <default model> · <auth>` (spec §3.1). */
+  /** `/health` — the footer's provider plate (spec §3.1, cou-90). */
   health: Health | null;
   /** True on the vault route: the rail collapses to a 56px icon rail
    * (spec §3.1). */
@@ -23,38 +23,15 @@ export interface RailProps {
    * pane — never a reset. `onNew` starts a draft; this one returns to it. */
   onOpenDraft: () => void;
   onDelete: (id: string) => void;
+  /** The footer switcher picked a loaded provider: save it as the default
+   * (the settings round-trip lives in the Shell). */
+  onSetDefault: (id: string) => void;
 }
 
 /** The title the first send gave the thread, or `Untitled`. */
 export function railLabel(thread: ThreadHeader): string {
   const title = thread.title?.trim() ?? '';
   return title !== '' ? title : 'Untitled';
-}
-
-/**
- * The rail footer (spec §3.3: the model picker moved out of the composer
- * and into the rail; clicking it opens Settings).
- *
- * It names the provider a send will ACTUALLY use — `defaultProviderId`, the
- * same rule the composer's send follows — not the saved default. The two
- * differ when the saved default names a provider this runtime did not load,
- * and the footer is now the only place that could say so.
- */
-export function footerLabel(health: Health | null): string {
-  if (health === null) return '…';
-  const effective = defaultProviderId(health);
-  const model = effective === '' ? (health.default ?? 'no default model') : effective;
-  const auth = health.providers.find(p => p.id === effective)?.auth;
-  return auth === undefined ? model : `${model} · ${auth}`;
-}
-
-/** The swap, said quietly: the saved default is not loaded, so the footer's
- * model is not the one Settings has on file. `null` when they agree. */
-export function swapNote(health: Health | null): string | null {
-  if (health === null) return null;
-  const saved = health.default;
-  if (saved === null || saved === '' || health.providers.some(p => p.id === saved)) return null;
-  return `saved default ${saved} not loaded`;
 }
 
 export function Rail({
@@ -69,6 +46,7 @@ export function Rail({
   onNew,
   onOpenDraft,
   onDelete,
+  onSetDefault,
 }: RailProps): JSX.Element {
   return (
     <aside className={collapsed ? 'v2-rail v2-rail-icons' : 'v2-rail'} aria-label="Rail">
@@ -137,22 +115,7 @@ export function Rail({
               empty on its own. */}
         </>
       )}
-      <button
-        type="button"
-        className="v2-foot"
-        title={
-          health === null
-            ? undefined
-            : `${footerLabel(health)}${swapNote(health) === null ? '' : ` — ${swapNote(health)}`} — open Settings`
-        }
-        onClick={() => {
-          globalThis.location.hash = '#/settings';
-        }}
-      >
-        <span className="v2-dot" aria-hidden="true" />
-        <span className="v2-lbl">{footerLabel(health)}</span>
-        {swapNote(health) === null ? null : <span className="v2-foot-note muted">({swapNote(health)})</span>}
-      </button>
+      <ModelSwitcher health={health} onSetDefault={onSetDefault} />
     </aside>
   );
 }

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -115,7 +115,7 @@ export function Rail({
               empty on its own. */}
         </>
       )}
-      <ModelSwitcher health={health} onSetDefault={onSetDefault} />
+      <ModelSwitcher health={health} collapsed={collapsed} onSetDefault={onSetDefault} />
     </aside>
   );
 }

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -606,4 +606,46 @@ describe('Shell', () => {
     await waitFor(() => expect(workNode()?.hasAttribute('hidden')).toBe(false));
     expect(document.querySelector('aside[aria-label="Vault drawer"]')).toBeTruthy();
   });
+
+  test('the footer switcher saves the picked default through PUT /settings and the plate updates in place (cou-90)', async () => {
+    const claude = {
+      id: 'claude-sub/claude-opus-5',
+      kind: 'harness',
+      auth: 'subscription',
+      capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' },
+    };
+    const two: Health = { ...health, providers: [...health.providers, claude] as Health['providers'] };
+    const puts: unknown[] = [];
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.startsWith('/health')) return json(two);
+      if (url.startsWith('/settings') && method === 'PUT') {
+        const body = JSON.parse(String(init?.body)) as { default?: string };
+        puts.push(body);
+        return json({
+          ...settings,
+          registry: { ...settings.registry, default: body.default },
+          effective: { default: body.default ?? null, stepTimeoutMs: 600_000, providers: two.providers },
+        } satisfies SettingsView);
+      }
+      return await (base as unknown as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(document.querySelector('.v2-foot .v2-plate-detail')?.textContent).toBe('fake/fake · local'));
+
+    await userEvent.click(document.querySelector('.v2-foot') as HTMLElement);
+    await userEvent.click(screen.getByText('Claude'));
+
+    // The PUT is a read-modify-write of the FILE: only `default` changed;
+    // the registry's own providers list (empty — the built-ins live in no
+    // file) went back untouched.
+    await waitFor(() => expect(puts).toEqual([{ default: 'claude-sub/claude-opus-5', providers: [] }]));
+    // And the plate re-rendered from the PUT's own `effective` — no reload.
+    await waitFor(() => expect(document.querySelector('.v2-foot .v2-plate-vendor')?.textContent).toBe('Claude'));
+    expect(document.querySelector('.v2-foot .v2-plate-detail')?.textContent).toBe('Opus 5 · subscription');
+    expect(document.querySelector('.v2-foot .v2-dot')?.classList.contains('v2-dot-amber')).toBe(false);
+  });
 });

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import { readToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
-import type { Health, ThreadHeader } from '../api/types';
+import type { Health, SettingsView, ThreadHeader } from '../api/types';
 import { parseHash, threadFromHash, TOKEN_MESSAGE, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
 import type { ComposerSeed } from './chat/Composer';
@@ -250,6 +250,40 @@ export function Shell(): JSX.Element {
     })();
   }, [unauthorized, loadThreads]);
 
+  /**
+   * The rail footer's switcher picked a loaded provider (cou-90): make it
+   * the saved default via the settings API, then fold the PUT's own
+   * `effective` back into `health` so the plate updates in place.
+   *
+   * Read-modify-write on `registry` — the FILE — never on `effective`:
+   * round-tripping `effective` through the PUT would write the built-ins
+   * (and `--fake`) into the operator's `providers.yaml` as if they had
+   * asked for them. Only `default` changes; providers, routes and the
+   * timeout ride along untouched.
+   */
+  const setDefaultProvider = async (id: string): Promise<void> => {
+    setError(null);
+    try {
+      const view = await fetchJson<SettingsView>('/settings');
+      const next = await fetchJson<SettingsView>('/settings', {
+        method: 'PUT',
+        body: JSON.stringify({ ...view.registry, default: id }),
+      });
+      setHealth(current =>
+        current === null
+          ? current
+          : {
+              ...current,
+              default: next.effective.default,
+              providers: next.effective.providers,
+              stepTimeoutMs: next.effective.stepTimeoutMs,
+            },
+      );
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setError(detail(err));
+    }
+  };
+
   const deleteThread = async (id: string): Promise<void> => {
     if (!globalThis.confirm('Delete this thread? Its transcript cannot be recovered from here.')) return;
     setBusy(true);
@@ -300,6 +334,7 @@ export function Shell(): JSX.Element {
         onNew={openDraft}
         onOpenDraft={returnToDraft}
         onDelete={id => void deleteThread(id)}
+        onSetDefault={id => void setDefaultProvider(id)}
       />
       <div className="v2-main-col">
         {error === null ? null : (

--- a/runtime/ui/src/v2/plate.test.ts
+++ b/runtime/ui/src/v2/plate.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from 'bun:test';
+import type { Health } from '../api/types';
+import { footerLabel, modelName, plateFor, swapNote } from './plate';
+
+describe('plateFor', () => {
+  // The founder's table (cou-90), row by row.
+  test('claude-sub → Claude on a subscription', () => {
+    expect(plateFor('claude-sub/claude-opus-5', 'subscription')).toEqual({
+      vendor: 'Claude',
+      detail: 'Opus 5 · subscription',
+      known: true,
+    });
+  });
+
+  test('anthropic → Claude over an API key', () => {
+    expect(plateFor('anthropic/claude-opus-5', 'apikey')).toEqual({
+      vendor: 'Claude',
+      detail: 'Opus 5 · API key',
+      known: true,
+    });
+  });
+
+  test('openai → OpenAI over an API key', () => {
+    expect(plateFor('openai/gpt-5', 'apikey')).toEqual({ vendor: 'OpenAI', detail: 'GPT-5 · API key', known: true });
+  });
+
+  test('codex → ChatGPT on a subscription', () => {
+    expect(plateFor('codex-sub/gpt-5.6-terra', 'subscription')).toEqual({
+      vendor: 'ChatGPT',
+      detail: 'GPT-5.6 Terra · subscription',
+      known: true,
+    });
+    expect(plateFor('codex/gpt-5', 'subscription').vendor).toBe('ChatGPT');
+  });
+
+  test('ollama/* → Ollama, local, the model tag verbatim', () => {
+    expect(plateFor('ollama/llama3', 'local')).toEqual({ vendor: 'Ollama', detail: 'llama3 · local', known: true });
+    expect(plateFor('ollama/gemma4:e4b', 'local').detail).toBe('gemma4:e4b · local');
+  });
+
+  test('no auth from /health: the table supplies the connection', () => {
+    expect(plateFor('ollama/llama3').detail).toBe('llama3 · local');
+    expect(plateFor('claude-sub/claude-opus-5').detail).toBe('Opus 5 · subscription');
+  });
+
+  test('/health wins over the table when they disagree', () => {
+    // An operator can wire a `claude-sub/…` id to anything; say what IS.
+    expect(plateFor('claude-sub/claude-opus-5', 'apikey').detail).toBe('Opus 5 · API key');
+  });
+
+  test('unknown id: the raw id on the detail line — never an invented name', () => {
+    expect(plateFor('mistral/large-latest', 'apikey')).toEqual({
+      vendor: 'mistral',
+      detail: 'mistral/large-latest · API key',
+      known: false,
+    });
+    expect(plateFor('fake/fake')).toEqual({ vendor: 'fake', detail: 'fake/fake', known: false });
+  });
+
+  test('an id with no slash falls back whole', () => {
+    expect(plateFor('custom', 'local')).toEqual({ vendor: 'custom', detail: 'custom · local', known: false });
+  });
+});
+
+describe('modelName', () => {
+  test('claude ids restyle to the marketing casing', () => {
+    expect(modelName('claude-opus-5')).toBe('Opus 5');
+    expect(modelName('claude-sonnet-5')).toBe('Sonnet 5');
+    expect(modelName('claude-haiku-4-5')).toBe('Haiku 4.5');
+  });
+
+  test('gpt ids keep the GPT- prefix and cap the codename', () => {
+    expect(modelName('gpt-5')).toBe('GPT-5');
+    expect(modelName('gpt-5.6-terra')).toBe('GPT-5.6 Terra');
+  });
+
+  test('anything else stays verbatim', () => {
+    expect(modelName('llama3')).toBe('llama3');
+    expect(modelName('gemma4:e4b')).toBe('gemma4:e4b');
+    expect(modelName('claude-opus')).toBe('claude-opus');
+  });
+});
+
+const health: Health = {
+  vault: '/tmp/vault',
+  tenant: 'default',
+  providers: [
+    {
+      id: 'fake/fake',
+      kind: 'direct',
+      auth: 'local',
+      capabilities: { tools: true, caching: false, thinking: false, contextTokens: 8192, auth: 'local' },
+    },
+  ],
+  default: 'fake/fake',
+  stepTimeoutMs: 600_000,
+};
+
+describe('footerLabel / swapNote', () => {
+  test('the title line is the raw effective id + auth', () => {
+    expect(footerLabel(health)).toBe('fake/fake · local');
+    expect(footerLabel(null)).toBe('…');
+  });
+
+  test('the swap is named when the saved default did not load', () => {
+    const swapped: Health = { ...health, default: 'openai/nope' };
+    expect(footerLabel(swapped)).toBe('fake/fake · local');
+    expect(swapNote(swapped)).toBe('saved default openai/nope not loaded');
+    expect(swapNote(health)).toBeNull();
+    expect(swapNote(null)).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/plate.ts
+++ b/runtime/ui/src/v2/plate.ts
@@ -1,0 +1,102 @@
+import type { Capabilities, Health } from '../api/types';
+import { defaultProviderId } from './threads';
+
+export type Auth = Capabilities['auth'];
+
+/**
+ * The provider plate (cou-90): the two-line lockup the rail footer and the
+ * model switcher's rows share — line 1 the vendor a lawyer knows, line 2
+ * `<Model> · <connection>`. Set text only, brief/ledger motif — no pills.
+ */
+export interface Plate {
+  /** Line 1 — the vendor's name, or the id's own prefix when the vendor is
+   * unknown. Never an invented name. */
+  vendor: string;
+  /** Line 2 — `<Model> · <connection>`; the RAW id for an unknown vendor,
+   * so what the reader sees is exactly what `providers.yaml` says. */
+  detail: string;
+  /** False when the id matched no vendor row and the plate fell back. */
+  known: boolean;
+}
+
+/** `auth`, said the way the plate says it. */
+const CONNECTION: Record<Auth, string> = {
+  subscription: 'subscription',
+  apikey: 'API key',
+  local: 'local',
+};
+
+/** The id prefixes the runtime actually ships, by hand. Anything else falls
+ * back to the raw id — the table never guesses. */
+const VENDORS: Record<string, { vendor: string; connection: string }> = {
+  'claude-sub': { vendor: 'Claude', connection: 'subscription' },
+  anthropic: { vendor: 'Claude', connection: 'API key' },
+  openai: { vendor: 'OpenAI', connection: 'API key' },
+  codex: { vendor: 'ChatGPT', connection: 'subscription' },
+  'codex-sub': { vendor: 'ChatGPT', connection: 'subscription' },
+  ollama: { vendor: 'Ollama', connection: 'local' },
+};
+
+/**
+ * The model's marketing casing, derived from the id — a restyle, never a
+ * rename: `claude-opus-5` → `Opus 5`, `gpt-5.6-terra` → `GPT-5.6 Terra`.
+ * Anything the two patterns do not cover stays verbatim (`llama3`,
+ * `gemma4:e4b`) — a raw tag is honest; a guessed name is wrong somewhere.
+ */
+export function modelName(model: string): string {
+  const claude = /^claude-([a-z]+)-(\d[\d.-]*)$/.exec(model);
+  if (claude !== null) {
+    const family = claude[1]!.charAt(0).toUpperCase() + claude[1]!.slice(1);
+    return `${family} ${claude[2]!.replaceAll('-', '.')}`;
+  }
+  const gpt = /^gpt-(.+)$/.exec(model);
+  if (gpt !== null) {
+    const [version, ...rest] = gpt[1]!.split('-');
+    const words = rest.map(word => (/^[a-z]/.test(word) ? word.charAt(0).toUpperCase() + word.slice(1) : word));
+    return [`GPT-${version}`, ...words].join(' ');
+  }
+  return model;
+}
+
+/**
+ * The plate for one provider id. `auth` is `/health`'s word on how the
+ * provider connects and wins over the table's assumption when both exist;
+ * without either, the detail line is the model alone.
+ */
+export function plateFor(id: string, auth?: Auth): Plate {
+  const slash = id.indexOf('/');
+  const prefix = slash === -1 ? id : id.slice(0, slash);
+  const row = VENDORS[prefix];
+  const connection = auth === undefined ? row?.connection : CONNECTION[auth];
+  if (row === undefined || slash === -1) {
+    return { vendor: prefix, detail: connection === undefined ? id : `${id} · ${connection}`, known: false };
+  }
+  const model = modelName(id.slice(slash + 1));
+  return { vendor: row.vendor, detail: connection === undefined ? model : `${model} · ${connection}`, known: true };
+}
+
+/**
+ * The footer's one-line summary — raw id + auth, for the title/tooltip where
+ * precision beats polish.
+ *
+ * It names the provider a send will ACTUALLY use — `defaultProviderId`, the
+ * same rule the composer's send follows — not the saved default. The two
+ * differ when the saved default names a provider this runtime did not load,
+ * and the footer is now the only place that could say so.
+ */
+export function footerLabel(health: Health | null): string {
+  if (health === null) return '…';
+  const effective = defaultProviderId(health);
+  const model = effective === '' ? (health.default ?? 'no default model') : effective;
+  const auth = health.providers.find(p => p.id === effective)?.auth;
+  return auth === undefined ? model : `${model} · ${auth}`;
+}
+
+/** The swap, said quietly: the saved default is not loaded, so the footer's
+ * model is not the one Settings has on file. `null` when they agree. */
+export function swapNote(health: Health | null): string | null {
+  if (health === null) return null;
+  const saved = health.default;
+  if (saved === null || saved === '' || health.providers.some(p => p.id === saved)) return null;
+  return `saved default ${saved} not loaded`;
+}


### PR DESCRIPTION
## What

The rail footer becomes a designed **provider plate**, not a string — the audience is lawyers:

- **Line 1:** `● <Vendor>` — 13px set text, `--fg`, dot pinned to this line, never truncates.
- **Line 2:** `<Model> · <connection>` — 11.5px `--fg-faint`, e.g. `Opus 5 · subscription`, `GPT-5.6 Terra · subscription`, `gemma4:e4b · local`.
- **Humanizer** (`plate.ts`): `claude-sub` → Claude/subscription, `anthropic` → Claude/API key, `openai` → OpenAI/API key, `codex`/`codex-sub` → ChatGPT/subscription, `ollama/*` → Ollama/local. `/health`'s `auth` wins over the table. An unknown id falls back to the raw id on line 2 — a name is never invented.
- **Amber dot** when the saved default is not loaded; the explanation stays in the `title` (replaces the old parenthetical label note). Set text only — no pills (brief/ledger motif).
- **Clicking the plate opens a popover** of the loaded providers (headless react-aria menu hooks, the ProviderCombo pattern — own markup, no portal, no native select). Each row reuses the same two-line lockup; the row in use carries the dot's ink. **Open Settings** stays as the final row.
- **Picking a row saves the default via the existing settings API**: GET `/settings` → PUT with only `registry.default` changed (read-modify-write of the FILE, never `effective`, so built-ins are never written into `providers.yaml`). The plate updates in place from the PUT's `effective`.

## What to verify (AC)

- [ ] Footer shows the two-line plate for the effective provider; vendor line never truncates; detail line ellipsizes.
- [ ] Amber dot + title explanation when `health.default` names an unloaded provider; green otherwise; no `(saved default … not loaded)` span in the label anymore.
- [ ] Click footer → popover lists loaded providers with humanized lockups + Open Settings last; Escape / outside click / pick all close it.
- [ ] Pick saves the default (PUT carries the registry untouched except `default`) and the plate flips in place, no reload.
- [ ] Re-picking the current provider is a no-op (no PUT).
- [ ] Collapsed (vault-route) icon rail still shows just the dot, labels clipped not removed.

## Verification done

- `bun run typecheck` + `bun run typecheck:ui` clean; `bun run test` 612 pass / 2 skip; `bun run ui:test` 344 pass (20 new: humanizer table incl. fallback, amber-dot state, popover pick → save + plate update at both Rail and Shell level); `bun run ui:build` clean.
- Real-browser (Playwright/Chromium) against `bun runtime/src/cli.ts serve`: plate renders, popover opens with all rows humanized, picking Ollama flipped the plate in place and wrote `default: ollama/gemma4:e4b` to `providers.yaml` with NO providers key added (built-ins stayed out of the file); the saved default survived a reload; Open Settings row navigates.
- Note for QA: under `serve --fake` the runtime pins the *effective* default to `fake/fake`, so a pick saves to file but the plate keeps showing fake — that is the fake-mode design, not a switcher bug. Verify the flip on a non-fake serve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)