### PR TITLE
ui: review fixes — heading glue, tool-trace verbs, settings default, search results, matter order, home due column, thread header, clickable vault paths

### DIFF
--- a/runtime/src/providers/claude-harness.test.ts
+++ b/runtime/src/providers/claude-harness.test.ts
@@ -20,6 +20,16 @@ describe('mapClaudeMessage', () => {
     expect(ev).toEqual([{ type: 'tool_result', id: 't1', name: '', output: '{"x":1}', isError: false }]);
   });
 
+  test('a tool_result takes the name of the tool_use it pairs with, across messages (cou-78)', () => {
+    const names = new Map<string, string>();
+    mapClaudeMessage({ type: 'assistant', message: { content: [{ type: 'tool_use', id: 't1', name: 'mcp__counsel__vault_list', input: { dir: '.' } }] } }, undefined, names);
+    const ev = mapClaudeMessage({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't1', content: [{ type: 'text', text: '[]' }], is_error: false }] } }, undefined, names);
+    expect(ev).toEqual([{ type: 'tool_result', id: 't1', name: 'vault_list', output: '[]', isError: false }]);
+    // An id the map never saw stays nameless rather than guessing.
+    const orphan = mapClaudeMessage({ type: 'user', message: { content: [{ type: 'tool_result', tool_use_id: 't9', content: [], is_error: false }] } }, undefined, names);
+    expect(orphan[0]).toMatchObject({ type: 'tool_result', id: 't9', name: '' });
+  });
+
   test('result with valid structured output → done', () => {
     const ev = mapClaudeMessage({ type: 'result', subtype: 'success', output: { a: 1 }, usage: { input_tokens: 10, output_tokens: 5 }, total_cost_usd: 0.01 }, z.object({ a: z.number() }));
     expect(ev).toEqual([{ type: 'done', output: { a: 1 }, usage: { inputTokens: 10, outputTokens: 5, costUsd: 0.01 } }]);

--- a/runtime/src/providers/claude-harness.ts
+++ b/runtime/src/providers/claude-harness.ts
@@ -13,7 +13,7 @@ const BUILTIN_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'MultiEdit', 'Glob', 'Gr
 
 type AnyMsg = { type: string; [k: string]: unknown };
 
-export function mapClaudeMessage(raw: unknown, outputSchema?: ZodType<unknown>): StepEvent[] {
+export function mapClaudeMessage(raw: unknown, outputSchema?: ZodType<unknown>, toolNames?: Map<string, string>): StepEvent[] {
   const msg = raw as AnyMsg;
   const out: StepEvent[] = [];
   if (msg.type === 'system' && msg.subtype === 'init' && typeof msg.session_id === 'string') {
@@ -25,11 +25,18 @@ export function mapClaudeMessage(raw: unknown, outputSchema?: ZodType<unknown>):
       if (block.type === 'text' && typeof block.text === 'string') out.push({ type: 'text', text: block.text });
       else if (block.type === 'tool_use') {
         const name = String(block.name);
-        out.push({ type: 'tool_call', id: String(block.id), name: name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name, input: block.input });
+        const mapped = name.startsWith(MCP_PREFIX) ? name.slice(MCP_PREFIX.length) : name;
+        toolNames?.set(String(block.id), mapped);
+        out.push({ type: 'tool_call', id: String(block.id), name: mapped, input: block.input });
       } else if (block.type === 'tool_result') {
         const parts = Array.isArray(block.content) ? block.content as Array<{ type: string; text?: string }> : [];
         const text = parts.filter(p => p.type === 'text').map(p => p.text ?? '').join('');
-        out.push({ type: 'tool_result', id: String(block.tool_use_id), name: '', output: text || block.content, isError: Boolean(block.is_error) });
+        // The SDK's tool_result block carries no tool name — only the
+        // `tool_use_id`. The paired call's name (recorded above, in an
+        // earlier message of the same run) fills it, so consumers never see
+        // a nameless result (cou-78 / cou-93 item 2).
+        const id = String(block.tool_use_id);
+        out.push({ type: 'tool_result', id, name: toolNames?.get(id) ?? '', output: text || block.content, isError: Boolean(block.is_error) });
       }
     }
     return out;
@@ -203,8 +210,11 @@ export class ClaudeHarnessProvider implements ModelProvider {
       const stream = query({ prompt, options: buildQueryOptions(req, this.opts.model, server, cwd) });
 
       let sessionId: string | undefined;
+      // tool_use → tool_result pairing across messages: results name their
+      // call only by id, so the names live for the run and fill each result.
+      const toolNames = new Map<string, string>();
       for await (const msg of stream) {
-        for (const ev of mapClaudeMessage(msg, req.outputSchema)) {
+        for (const ev of mapClaudeMessage(msg, req.outputSchema, toolNames)) {
           if (ev.type === 'session') { sessionId = ev.id; yield ev; continue; }
           yield ev.type === 'done' && sessionId ? { ...ev, sessionId } : ev;
         }

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1056,3 +1056,21 @@ describe('redesign reads (spec §4)', () => {
     expect(typeof body.mtimeMs).toBe('number');
   });
 });
+
+describe('vault index (cou-93 item 8)', () => {
+  test('lists every file path, flat, through the same listing the tree uses', async () => {
+    const app = appWithFake();
+    await vault.write('default', 'matters/acme/notes.md', 'NOTES\n');
+    await vault.write('default', 'practice/standards/nda.md', '# NDA\n');
+    const res = await call(app, 'GET', '/vault/index');
+    expect(res.status).toBe(200);
+    const paths = (await res.json()) as string[];
+    expect(paths).toContain('matters/acme/notes.md');
+    expect(paths).toContain('practice/standards/nda.md');
+    // Files only — a directory is not a thing an answer cites.
+    expect(paths).not.toContain('matters');
+    expect(paths).not.toContain('matters/acme');
+    // The store's own bookkeeping never appears.
+    expect(paths.some(p => p.toLowerCase().startsWith('.counsel'))).toBe(false);
+  });
+});

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -487,6 +487,38 @@ export function createApp(deps: ServerDeps): App {
     return json(await deps.vault.search(deps.tenant, q));
   };
 
+  /** How many file paths `GET /vault/index` returns at most. A vault past
+   * this is an archive; the index is a citation gate, not a mirror. */
+  const INDEX_MAX_FILES = 5000;
+
+  /**
+   * Every file path in the vault, flat (cou-93 item 8): the client's
+   * known-path set for turning a path the model wrote in prose into a chip
+   * that opens the reader. Built by walking `vault.list` — the SAME listing
+   * the tree uses, so `.counsel`, dotfiles and symlinks are already gone and
+   * the index can never name a path the tree would not show. Breadth-first
+   * and capped, so a pathological vault bounds the walk instead of the walk
+   * unbounding the response.
+   */
+  const vaultIndexRoute = async (): Promise<Response> => {
+    const files: string[] = [];
+    const queue: string[] = ['.'];
+    while (queue.length > 0 && files.length < INDEX_MAX_FILES) {
+      const dir = queue.shift()!;
+      let entries: Awaited<ReturnType<typeof deps.vault.list>>;
+      try {
+        entries = await deps.vault.list(deps.tenant, dir);
+      } catch {
+        continue; // One unreadable directory never fails the whole index.
+      }
+      for (const entry of entries) {
+        if (entry.kind === 'dir') queue.push(entry.path);
+        else if (files.length < INDEX_MAX_FILES) files.push(entry.path);
+      }
+    }
+    return json(files);
+  };
+
   /** The docket's feed (spec §4). Only the pending listing exists; an
    * explicit other status is a 400 so a future caller cannot read
    * "everything" as "pending".
@@ -560,6 +592,7 @@ export function createApp(deps: ServerDeps): App {
         if (second === 'list') return await vaultList(url);
         if (second === 'overview') return await vaultOverviewRoute();
         if (second === 'search') return await vaultSearchRoute(url);
+        if (second === 'index') return await vaultIndexRoute();
       }
 
       if (segments.length === 1 && first === 'proposals' && method === 'GET') {

--- a/runtime/ui/src/chat/turns.test.ts
+++ b/runtime/ui/src/chat/turns.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from 'bun:test';
+import type { StepEvent } from '../api/types';
+import { applyStepEvent, emptyAssistantTurn } from './turns';
+
+function run(events: StepEvent[]): ReturnType<typeof emptyAssistantTurn> {
+  return events.reduce((turn, ev) => applyStepEvent(turn, ev), emptyAssistantTurn({ status: 'streaming' }));
+}
+
+describe('applyStepEvent text segments (cou-93 item 1)', () => {
+  test('text split around tool work gets a paragraph break, so a heading after a tool still renders', () => {
+    const turn = run([
+      { type: 'text', text: "I'll look at what's in the vault and check for recent activity." },
+      { type: 'tool_call', id: 'c1', name: 'vault_list', input: { dir: 'matters' } },
+      { type: 'tool_result', id: 'c1', name: 'vault_list', output: [] },
+      { type: 'text', text: '## What changed — week of Aug 24–31' },
+    ]);
+    expect(turn.text).toBe("I'll look at what's in the vault and check for recent activity.\n\n## What changed — week of Aug 24–31");
+  });
+
+  test('deltas streamed within one segment still join seamlessly', () => {
+    const turn = run([
+      { type: 'text', text: 'The cap ' },
+      { type: 'text', text: 'is 2x fees.' },
+    ]);
+    expect(turn.text).toBe('The cap is 2x fees.');
+  });
+
+  test('a tool before any text adds no leading break', () => {
+    const turn = run([
+      { type: 'tool_call', id: 'c1', name: 'vault_read', input: { path: 'a.md' } },
+      { type: 'tool_result', id: 'c1', name: 'vault_read', output: 'x' },
+      { type: 'text', text: 'Done.' },
+    ]);
+    expect(turn.text).toBe('Done.');
+  });
+
+  test('a segment that already ends in a blank line is not padded twice', () => {
+    const turn = run([
+      { type: 'text', text: 'First.\n\n' },
+      { type: 'tool_call', id: 'c1', name: 'vault_read', input: { path: 'a.md' } },
+      { type: 'text', text: 'Second.' },
+    ]);
+    expect(turn.text).toBe('First.\n\nSecond.');
+  });
+});
+
+describe('applyStepEvent tool names (cou-93 item 2)', () => {
+  test('a nameless result keeps the name of the call it pairs with', () => {
+    const turn = run([
+      { type: 'tool_call', id: 'c1', name: 'vault_list', input: { dir: '.' } },
+      { type: 'tool_result', id: 'c1', name: '', output: ['matters'] },
+    ]);
+    expect(turn.tools).toHaveLength(1);
+    expect(turn.tools[0]!.name).toBe('vault_list');
+    expect(turn.tools[0]!.hasResult).toBe(true);
+  });
+
+  test('a named result still wins over the call', () => {
+    const turn = run([
+      { type: 'tool_call', id: 'c1', name: 'vault_list', input: { dir: '.' } },
+      { type: 'tool_result', id: 'c1', name: 'vault_list', output: [] },
+    ]);
+    expect(turn.tools[0]!.name).toBe('vault_list');
+  });
+});

--- a/runtime/ui/src/chat/turns.ts
+++ b/runtime/ui/src/chat/turns.ts
@@ -48,6 +48,13 @@ export interface AssistantTurn {
   runId?: string;
   provider?: string;
   text: string;
+  /** A tool ran since the last text arrived. The next text event is a NEW
+   * segment, not a continuation: the Claude harness emits whole text blocks
+   * split around tool calls, and joining them bare glues `…activity.` onto
+   * `## What changed` so the heading never renders (cou-93 item 1). Streamed
+   * deltas within one segment have no tool between them, so they still join
+   * seamlessly. */
+  toolBreak?: boolean;
   tools: ToolCallView[];
   proposals: ProposalView[];
   warnings: string[];
@@ -77,7 +84,10 @@ function withToolResult(turn: AssistantTurn, ev: Extract<StepEvent, { type: 'too
   const at = tools.findIndex(t => t.id === ev.id && !t.hasResult);
   const filled: ToolCallView = {
     id: ev.id,
-    name: ev.name,
+    // Threads persisted before the harness learned to name its results
+    // (cou-78) carry `name: ''` — the paired call knows the name, so a
+    // nameless result must never overwrite it (cou-93 item 2).
+    name: ev.name !== '' || at === -1 ? ev.name : tools[at]!.name,
     input: at === -1 ? undefined : tools[at]!.input,
     output: ev.output,
     isError: ev.isError ?? false,
@@ -94,12 +104,21 @@ function withToolResult(turn: AssistantTurn, ev: Extract<StepEvent, { type: 'too
  */
 export function applyStepEvent(turn: AssistantTurn, ev: StepEvent): AssistantTurn {
   switch (ev.type) {
-    case 'text':
-      return { ...turn, text: turn.text + ev.text };
+    case 'text': {
+      // A paragraph break between segments split around tool work, and only
+      // there — see `toolBreak`. Never inside a segment a provider streams
+      // as deltas.
+      const sep = turn.toolBreak === true && turn.text !== '' && !turn.text.endsWith('\n\n') ? '\n\n' : '';
+      return { ...turn, text: turn.text + sep + ev.text, toolBreak: false };
+    }
     case 'tool_call':
-      return { ...turn, tools: [...turn.tools, { id: ev.id, name: ev.name, input: ev.input, hasResult: false }] };
+      return {
+        ...turn,
+        toolBreak: turn.toolBreak === true || turn.text !== '',
+        tools: [...turn.tools, { id: ev.id, name: ev.name, input: ev.input, hasResult: false }],
+      };
     case 'tool_result':
-      return withToolResult(turn, ev);
+      return withToolResult({ ...turn, toolBreak: turn.toolBreak === true || turn.text !== '' }, ev);
     case 'proposal':
       return turn.proposals.some(p => p.id === ev.id)
         ? turn

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -491,6 +491,16 @@ a { color: var(--accent); }
 .v2-vmonth { margin-left: auto; font-size: 10.5px; color: var(--fg-faint); flex-shrink: 0; }
 .v2-vother { color: var(--fg-faint); margin-top: 8px; }
 .v2-vempty { margin: 12px; }
+/* Typing alone searches nothing — one quiet line under the box says so. */
+.v2-vhint { margin: -4px 20px 6px; font-size: 11.5px; }
+/* Search hits (cou-93 item 4): a document, not a path. The title on the first
+   line; the folder as a small-caps run-in and the matched line beneath, both
+   quiet. The full path is the row's tooltip. */
+.v2-vcount { font-weight: 500; letter-spacing: 0; text-transform: none; }
+.v2-vhit { flex-direction: column; align-items: stretch; gap: 1px; padding: 6px 8px; white-space: normal; }
+.v2-vhit-title { color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-vhit-line { font-size: 11.5px; color: var(--fg-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-vhit-dir { font: 600 9.5px/1 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; margin-right: 6px; }
 
 /* Reading pane (mock-vault.html .doc): ~68ch serif measure. */
 .v2-vault-main { flex: 1; min-width: 0; overflow-y: auto; position: relative; }
@@ -642,7 +652,13 @@ a { color: var(--accent); }
 
 .v2-thread-head { display: flex; align-items: baseline; gap: 12px; padding: 14px 40px 12px; border-bottom: 1px solid var(--border); }
 .v2-thread-head h1 { font: 600 18px/1.3 var(--serif); margin: 0; }
-.v2-matter-chip { font-size: 12px; color: var(--fg-muted); border: 1px solid var(--border); border-radius: 999px; padding: 2px 9px; }
+/* The thread's matter: a small-caps run-in and the matter's real title, set
+   as text and linked to the file (cou-93 item 7) — the ledger language has
+   no pills. */
+.v2-thread-matter { display: inline-flex; align-items: baseline; gap: 7px; min-width: 0; font-size: 12.5px; color: var(--fg-muted); text-decoration: none; }
+.v2-thread-matter .v2-tag { font-size: 9.5px; }
+.v2-thread-matter-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-thread-matter:hover .v2-thread-matter-name { text-decoration: underline; }
 .v2-thread-date { margin-left: auto; font-size: 12px; color: var(--fg-faint); }
 
 /* One quiet work line. */

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -81,10 +81,32 @@ export function Shell(): JSX.Element {
   const drawerRef = useRef(drawer);
   drawerRef.current = drawer;
 
-  const fileDecided = useCallback((path: string): void => {
-    const open = drawerRef.current;
-    if (open.open && open.path === path) setDrawerRevision(revision => revision + 1);
+  /**
+   * Every file path the vault holds (`GET /vault/index`), the set behind
+   * clickable paths in answers (cou-93 item 8). Loaded once the token is
+   * good and again after a proposal lands — an approval can create the very
+   * file the answer names. An older runtime without the route answers with
+   * the HTML shell; that parse failure is swallowed and paths stay plain
+   * text, which is exactly what they were before.
+   */
+  const [vaultPaths, setVaultPaths] = useState<ReadonlySet<string>>(() => new Set());
+  const loadIndex = useCallback(async (): Promise<void> => {
+    try {
+      const paths = await fetchJson<unknown>('/vault/index');
+      if (Array.isArray(paths)) setVaultPaths(new Set(paths.filter((p): p is string => typeof p === 'string')));
+    } catch {
+      // Left as it was: a stale or empty index only means fewer chips.
+    }
   }, []);
+
+  const fileDecided = useCallback(
+    (path: string): void => {
+      const open = drawerRef.current;
+      if (open.open && open.path === path) setDrawerRevision(revision => revision + 1);
+      void loadIndex();
+    },
+    [loadIndex],
+  );
 
   const selectThread = (id: string): void => {
     setNotFound(false);
@@ -223,6 +245,7 @@ export function Shell(): JSX.Element {
     void (async () => {
       try {
         setHealth(await fetchJson<Health>('/health'));
+        void loadIndex();
         const { threads: list, fresh } = await loadThreads();
         if (!fresh) return;
         // The fragment may already name the thread (a pasted link, the
@@ -248,7 +271,7 @@ export function Shell(): JSX.Element {
         setListed(true);
       }
     })();
-  }, [unauthorized, loadThreads]);
+  }, [unauthorized, loadThreads, loadIndex]);
 
   /**
    * The rail footer's switcher picked a loaded provider (cou-90): make it
@@ -379,6 +402,7 @@ export function Shell(): JSX.Element {
                 onAskUsed={askUsed}
                 onFileDecided={fileDecided}
                 onOpenFile={openDrawer}
+                vaultPaths={vaultPaths}
               />
             )}
           </main>

--- a/runtime/ui/src/v2/chat/Chat.test.tsx
+++ b/runtime/ui/src/v2/chat/Chat.test.tsx
@@ -277,7 +277,7 @@ describe("v2 Chat, given home's ask", () => {
 });
 
 describe('v2 Chat, the thread header', () => {
-  test('serif title, the matter chip from the first matter read, and the date', async () => {
+  test('serif title, the matter line from the first matter read, and the date', async () => {
     const events: ThreadEvent[] = [
       { t: 'user', at, content: 'check it' },
       { t: 'step', at, runId: 'r-1', provider: 'fake/fake' },
@@ -290,11 +290,17 @@ describe('v2 Chat, the thread header', () => {
     );
     render(<Chat threadId="t-1" health={health} />);
     await waitFor(() => expect(document.querySelector('.v2-thread-head h1')?.textContent).toBe('NDA residuals fallback'));
-    // The first MATTER file, not the first file read at all.
-    expect(document.querySelector('.v2-matter-chip')?.textContent).toBe('matter: Acme nda');
+    // The first MATTER file, not the first file read at all — set as a
+    // run-in plus the matter's REAL title (its file's H1 here), linked to
+    // the file; no pill (cou-93 item 7).
+    const line = document.querySelector('a.v2-thread-matter')!;
+    expect(line.getAttribute('href')).toBe('#/vault?path=matters%2Facme-nda.md');
+    expect(line.querySelector('.v2-tag')?.textContent).toBe('Matter');
+    await waitFor(() => expect(line.querySelector('.v2-thread-matter-name')?.textContent).toBe('NDA'));
+    expect(document.querySelector('.v2-matter-chip')).toBeNull();
   });
 
-  test('a thread nobody named reads as Untitled, and a thread on no matter shows no chip', async () => {
+  test('a thread nobody named reads as Untitled, and a thread on no matter shows no matter line', async () => {
     install(async () =>
       json(
         thread('t-1', [
@@ -307,7 +313,7 @@ describe('v2 Chat, the thread header', () => {
     );
     render(<Chat threadId="t-1" health={health} />);
     await waitFor(() => expect(document.querySelector('.v2-thread-head h1')?.textContent).toBe('Untitled'));
-    expect(document.querySelector('.v2-matter-chip')).toBeNull();
+    expect(document.querySelector('.v2-thread-matter')).toBeNull();
   });
 
   test('a draft has no thread, so it has no header', () => {

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, streamStep } from '../../api/client';
-import type { Health, RunRecord, Thread, ThreadEvent, ThreadHeader } from '../../api/types';
+import type { Health, RunRecord, Thread, ThreadEvent, ThreadHeader, VaultFile } from '../../api/types';
 import { proposalFromHash } from '../../app';
 import { applyStepEvent, buildTurns, emptyAssistantTurn, type AssistantTurn, type Turn } from '../../chat/turns';
 import { createThread, defaultProviderId, titleFor } from '../threads';
 import { relTime } from '../time';
-import { prettifyName } from '../vault/frontmatter';
+import { prettifyName, readerModel } from '../vault/frontmatter';
 import { Composer, type ComposerSeed } from './Composer';
 import { TurnView } from './Turn';
 
@@ -36,6 +36,9 @@ export interface ChatProps {
   /** The ask was sent — the shell drops it, so a later remount of this pane
    * cannot send it a second time. */
   onAskUsed?: () => void;
+  /** Every file path the vault holds (`GET /vault/index`): a path the model
+   * writes in an answer becomes a click target only when it is in here. */
+  vaultPaths?: ReadonlySet<string>;
 }
 
 function detail(err: unknown): string {
@@ -50,11 +53,11 @@ function titleOf(header: ThreadHeader): string {
   return title === '' ? 'Untitled' : title;
 }
 
-/** Best-effort, client-side (spec §3.3): the thread's matter chip is the
- * first matter file the thread read, prettified. `matters/` is the
- * conventional dir; a vault with a custom `matters_path` just shows no chip
- * — the chip is a courtesy, not a record. */
-export function matterChipOf(events: ThreadEvent[]): string | null {
+/** Best-effort, client-side (spec §3.3): the thread's matter is the first
+ * matter file the thread read. `matters/` is the conventional dir; a vault
+ * with a custom `matters_path` just shows no matter line — it is a
+ * courtesy, not a record. */
+export function matterPathOf(events: ThreadEvent[]): string | null {
   for (const ev of events) {
     if ('t' in ev) continue;
     if (ev.type !== 'tool_call' || ev.name !== 'vault_read') continue;
@@ -62,9 +65,15 @@ export function matterChipOf(events: ThreadEvent[]): string | null {
     if (typeof input !== 'object' || input === null) continue;
     const path = (input as Record<string, unknown>)['path'];
     if (typeof path !== 'string' || !path.startsWith('matters/')) continue;
-    return prettifyName(path.slice(path.lastIndexOf('/') + 1));
+    return path;
   }
   return null;
+}
+
+/** What the header calls the matter before (or without) reading its file:
+ * the filename prettified, as the reader's own dochead would. */
+function matterFallbackTitle(path: string): string {
+  return prettifyName(path.slice(path.lastIndexOf('/') + 1));
 }
 
 /**
@@ -88,6 +97,7 @@ export function Chat({
   onSeedUsed,
   initialAsk,
   onAskUsed,
+  vaultPaths,
 }: ChatProps): JSX.Element {
   /** The thread this pane is about. A ref, not only state: `load` and
    * `send` read it outside a render, and it changes exactly once — from
@@ -346,14 +356,49 @@ export function Chat({
   const isDraft = threadId === null && pending === null && frozen.length === 0;
   const empty = !loading && threadId !== null && turns.length === 0 && frozen.length === 0 && pending === null;
 
-  const matter = thread === null ? null : matterChipOf(thread.events);
+  const matterPath = thread === null ? null : matterPathOf(thread.events);
+
+  /**
+   * The matter's REAL title for the header (cou-93 item 7): a slug
+   * prettified (`Sinai lerner k12 partnership`) is not what the lawyer calls
+   * the matter. One read of the matter file, through the same frontmatter
+   * model the reader uses; until it lands — or if it cannot — the prettified
+   * filename stands in, so the line never flashes empty.
+   */
+  const [matterTitles, setMatterTitles] = useState<Record<string, string>>({});
+  useEffect(() => {
+    if (matterPath === null || matterTitles[matterPath] !== undefined) return;
+    let cancelled = false;
+    void (async () => {
+      let title = matterFallbackTitle(matterPath);
+      try {
+        const file = await fetchJson<VaultFile>(`/vault/read?path=${encodeURIComponent(matterPath)}`);
+        if (typeof file.content === 'string') title = readerModel(file.content, matterPath).title;
+      } catch {
+        // A matter file that moved or cannot be read keeps the fallback —
+        // the header is a courtesy, not a record.
+      }
+      if (!cancelled) setMatterTitles(current => ({ ...current, [matterPath]: title }));
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [matterPath]);
+  const matterTitle = matterPath === null ? null : (matterTitles[matterPath] ?? matterFallbackTitle(matterPath));
 
   return (
     <section className="v2-chat">
       {thread === null ? null : (
         <header className="v2-thread-head">
           <h1>{titleOf(thread.header)}</h1>
-          {matter === null ? null : <span className="v2-matter-chip">matter: {matter}</span>}
+          {/* Set text with a small-caps run-in, linked to the file — not a
+              pill (the ledger language has none). */}
+          {matterPath === null || matterTitle === null ? null : (
+            <a className="v2-thread-matter" href={`#/vault?path=${encodeURIComponent(matterPath)}`} title={matterPath}>
+              <span className="v2-tag">Matter</span>
+              <span className="v2-thread-matter-name">{matterTitle}</span>
+            </a>
+          )}
           <span className="v2-thread-date">{relTime(thread.header.createdAt)}</span>
         </header>
       )}
@@ -372,14 +417,15 @@ export function Chat({
             onReload={reload}
             onDecided={decided}
             onOpenFile={onOpenFile}
+            vaultPaths={vaultPaths}
           />
         ))}
         {frozen.map((turn, i) => (
-          <TurnView key={`frozen-${i}`} turn={turn} threadId={threadId} onReload={reload} onDecided={decided} onOpenFile={onOpenFile} />
+          <TurnView key={`frozen-${i}`} turn={turn} threadId={threadId} onReload={reload} onDecided={decided} onOpenFile={onOpenFile} vaultPaths={vaultPaths} />
         ))}
         {pending === null ? null : <TurnView turn={{ kind: 'user', content: pending }} threadId={threadId} onReload={reload} />}
         {live === null ? null : (
-          <TurnView turn={live} threadId={threadId} live liveMs={liveMs} onReload={reload} onDecided={decided} onOpenFile={onOpenFile} />
+          <TurnView turn={live} threadId={threadId} live liveMs={liveMs} onReload={reload} onDecided={decided} onOpenFile={onOpenFile} vaultPaths={vaultPaths} />
         )}
       </div>
 

--- a/runtime/ui/src/v2/chat/Turn.test.tsx
+++ b/runtime/ui/src/v2/chat/Turn.test.tsx
@@ -171,3 +171,32 @@ describe('TurnView work line', () => {
     expect(document.querySelector('.v2-work-line')).toBeNull();
   });
 });
+
+describe('TurnView vault-index chips (cou-93 item 8)', () => {
+  const index: ReadonlySet<string> = new Set(['matters/acme.md', 'practice/standards/nda.md']);
+
+  test('a full path the vault holds is a chip even when this step never read it', async () => {
+    const opened: string[] = [];
+    const turn: AssistantTurn = emptyAssistantTurn({ status: 'done', text: 'Three files touched: `matters/acme.md`.' });
+    render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} onOpenFile={path => opened.push(path)} vaultPaths={index} />);
+    const chip = document.querySelector('.v2-prose code.v2-cite')!;
+    expect(chip.textContent).toBe('matters/acme.md');
+    await userEvent.click(chip);
+    expect(opened).toEqual(['matters/acme.md']);
+  });
+
+  test('a bare basename or a path the vault does not hold stays plain code', async () => {
+    const opened: string[] = [];
+    const turn: AssistantTurn = emptyAssistantTurn({ status: 'done', text: 'See `nda.md` and `matters/ghost.md`.' });
+    render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} onOpenFile={path => opened.push(path)} vaultPaths={index} />);
+    expect(document.querySelector('.v2-prose code.v2-cite')).toBeNull();
+    for (const code of Array.from(document.querySelectorAll('.v2-prose code'))) await userEvent.click(code);
+    expect(opened).toEqual([]);
+  });
+
+  test('without an index, behaviour is exactly the derived-only rule', () => {
+    const turn: AssistantTurn = emptyAssistantTurn({ status: 'done', text: 'See `matters/acme.md`.' });
+    render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} onOpenFile={() => {}} />);
+    expect(document.querySelector('.v2-prose code.v2-cite')).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/chat/Turn.tsx
+++ b/runtime/ui/src/v2/chat/Turn.tsx
@@ -20,6 +20,10 @@ export interface TurnProps {
   /** Passed to every proposal card: a decision landed on this path. */
   onDecided?: (path: string) => void;
   onOpenFile?: (path: string) => void;
+  /** Every file path the vault holds. A backticked FULL path the answer
+   * names becomes a click target when it is one of these (cou-93 item 8) —
+   * the second gate beside the derivation set, never a third source. */
+  vaultPaths?: ReadonlySet<string>;
 }
 
 /** The record's per-call timings, keyed onto this turn's tool ids. The
@@ -56,14 +60,33 @@ export function msFromRun(tools: ToolCallView[], run: RunRecord | undefined): Re
  * document without complaining — an unclosed `**` is simply not emphasis
  * yet — and re-parsing per chunk is memoized on the text, so the answer does
  * not change typeface at the moment the stream ends.
+ *
+ * A second, wider gate (cou-93 item 8): a code span whose text is a FULL
+ * path the vault holds (`vaultPaths`, from `GET /vault/index`) is a chip too
+ * — "see `matters/acme.md`" in an answer that listed the directory rather
+ * than reading the file was dead text. Full paths only: a bare basename
+ * still resolves through the derivation map alone, so an ambiguous `nda.md`
+ * can never open the wrong file. Same minting, same click gate — the model
+ * still cannot name a path into existence.
  */
-function Prose({ text, tools, onOpenFile }: { text: string; tools: ToolCallView[]; onOpenFile?: (path: string) => void }): JSX.Element {
+function Prose({
+  text,
+  tools,
+  vaultPaths,
+  onOpenFile,
+}: {
+  text: string;
+  tools: ToolCallView[];
+  vaultPaths?: ReadonlySet<string>;
+  onOpenFile?: (path: string) => void;
+}): JSX.Element {
   // The memos key on the paths as a STRING, not on the array: `buildTurns`
   // rebuilds every turn on every render of the pane, so an array dep would
   // re-parse the whole transcript's markdown on each frame of a stream.
   const cites = readPathsOf(tools).join('\n');
   const derived = useMemo(() => citationMap(cites === '' ? [] : cites.split('\n')), [cites]);
-  const html = useMemo(() => markCitations(renderMarkdown(text), new Set(derived.keys())), [text, derived]);
+  const spellings = useMemo(() => new Set([...derived.keys(), ...(vaultPaths ?? [])]), [derived, vaultPaths]);
+  const html = useMemo(() => markCitations(renderMarkdown(text), spellings), [text, spellings]);
   return (
     <div
       className="markdown v2-prose"
@@ -71,9 +94,11 @@ function Prose({ text, tools, onOpenFile }: { text: string; tools: ToolCallView[
         if (onOpenFile === undefined) return;
         const chip = (event.target as Element).closest?.('code.v2-cite');
         if (chip === null || chip === undefined) return;
-        // The map is the derivation set, so this is the second gate: a chip
-        // whose text is not a file this step read opens nothing.
-        const path = derived.get(chip.textContent ?? '');
+        // The derivation map, then the vault index, are the second gate: a
+        // chip whose text is neither a file this step read nor a path the
+        // vault holds opens nothing.
+        const spelled = chip.textContent ?? '';
+        const path = derived.get(spelled) ?? (vaultPaths?.has(spelled) === true ? spelled : undefined);
         if (path === undefined) return;
         event.preventDefault();
         onOpenFile(path);
@@ -89,7 +114,7 @@ function Prose({ text, tools, onOpenFile }: { text: string; tools: ToolCallView[
  * above the text on both paths, so the reader sees the work as it happens
  * and can still find it after the answer lands.
  */
-export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onReload, onDecided, onOpenFile }: TurnProps): JSX.Element {
+export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onReload, onDecided, onOpenFile, vaultPaths }: TurnProps): JSX.Element {
   if (turn.kind === 'user') {
     return (
       <article className="v2-turn v2-turn-user">
@@ -117,7 +142,7 @@ export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onRel
               working…
             </p>
           ) : (
-            <Prose text={turn.text} tools={turn.tools} onOpenFile={onOpenFile} />
+            <Prose text={turn.text} tools={turn.tools} vaultPaths={vaultPaths} onOpenFile={onOpenFile} />
           )}
         </>
       ) : (
@@ -125,7 +150,7 @@ export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onRel
           {/* The work line reads ABOVE the answer, finished or not: what was
               consulted, then what it concluded. */}
           <WorkLine tools={turn.tools} ms={ms} onOpenFile={onOpenFile} />
-          {turn.text === '' ? null : <Prose text={turn.text} tools={turn.tools} onOpenFile={onOpenFile} />}
+          {turn.text === '' ? null : <Prose text={turn.text} tools={turn.tools} vaultPaths={vaultPaths} onOpenFile={onOpenFile} />}
 
           {/* The turn owns its error text: it reads here, unfolded, and the
               strip's record leaves out the identical copy it holds. */}

--- a/runtime/ui/src/v2/chat/WorkLine.test.tsx
+++ b/runtime/ui/src/v2/chat/WorkLine.test.tsx
@@ -21,7 +21,7 @@ describe('WorkLine', () => {
 
     await userEvent.click(line);
     expect(document.querySelector('.v2-steps')).toBeTruthy();
-    expect(screen.getByText('Searched')).toBeTruthy();
+    expect(screen.getByText('Searched the vault for')).toBeTruthy();
   });
 
   test('no tools, no line', () => {

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -256,3 +256,24 @@ describe('HomePage', () => {
     expect(screen.getByRole('link', { name: '3 more in the vault →' })).toBeTruthy();
   });
 });
+
+describe('HomePage matter rows without a deadline (cou-93 item 6)', () => {
+  test('the due slot shows the stage, and stays empty when there is none — never "no deadline"', async () => {
+    overviewBody = {
+      matters: [
+        { path: 'matters/2026-06-forge.md', title: 'Forge — Duty Refund', frontmatter: { stage: 'working' }, mtimeMs: Date.now() },
+        { path: 'matters/2026-05-twine.md', title: 'Twine — Pilot', frontmatter: {}, mtimeMs: Date.now() - 1000 },
+      ],
+      groups: { practice: 0, knowledge: 0, other: 0 },
+    };
+    render(<HomePage threads={threads} onAsk={() => {}} onOpenThread={() => {}} />);
+    await waitFor(() => expect(screen.getByText('Forge — Duty Refund')).toBeTruthy());
+    expect(screen.getByText('working').className).toContain('v2-due');
+    expect(screen.queryByText('no deadline')).toBeNull();
+    const rows = document.querySelectorAll('.v2-matter');
+    expect(rows).toHaveLength(2);
+    // The row with neither has no slot and no leader pointing at nothing.
+    expect(rows[1]!.querySelector('.v2-due')).toBeNull();
+    expect(rows[1]!.querySelector('.leader')).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -5,7 +5,7 @@ import { Tree } from '../../vault/Tree';
 import { railLabel } from '../Rail';
 import { relTime } from '../time';
 import {
-  dueLabel,
+  dueSlot,
   greetingFor,
   nextActionOf,
   sortMatters,
@@ -237,7 +237,7 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
                 <p className="muted">No matters yet.</p>
               ) : (
                 matters.slice(0, MAX_MATTERS).map(matter => {
-                  const due = dueLabel(matter.frontmatter);
+                  const slot = dueSlot(matter.frontmatter);
                   const next = nextActionOf(matter.frontmatter);
                   return (
                     <div className="v2-matter" key={matter.path}>
@@ -245,8 +245,12 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
                         <a className="v2-matter-name" href={`#/vault?path=${encodeURIComponent(matter.path)}`}>
                           {matter.title}
                         </a>
-                        <span className="leader" aria-hidden="true" />
-                        <span className={due.hot ? 'v2-due v2-due-hot' : 'v2-due'}>{due.text}</span>
+                        {slot === null ? null : (
+                          <>
+                            <span className="leader" aria-hidden="true" />
+                            <span className={slot.hot ? 'v2-due v2-due-hot' : 'v2-due'}>{slot.text}</span>
+                          </>
+                        )}
                       </div>
                       <div className="v2-na">
                         {next === null ? null : (

--- a/runtime/ui/src/v2/home/home.test.ts
+++ b/runtime/ui/src/v2/home/home.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from 'bun:test';
 import type { MatterOverview } from '../../api/types';
 import {
   dueLabel,
+  dueSlot,
   greetingFor,
   nextActionOf,
   parseDeadline,
   sortMatters,
+  stageOf,
   starterFill,
   STARTERS,
   sublineFor,
@@ -102,5 +104,23 @@ describe('the ask box', () => {
     expect(starterFill("What's our position on…")).toBe("What's our position on ");
     expect(starterFill('Draft a response')).toBe('Draft a response to ');
     expect(starterFill('What changed this week?')).toBe('What changed in the vault this week?');
+  });
+});
+
+describe('dueSlot (cou-93 item 6)', () => {
+  test('a deadline wins, hot or not', () => {
+    expect(dueSlot({ deadline: '2026-09-12' }, NOW)).toEqual({ text: 'due Sep 12', hot: true });
+    expect(dueSlot({ deadline: '2026-12-01', stage: 'working' }, NOW)).toEqual({ text: 'due Dec 1', hot: false });
+  });
+
+  test('no deadline shows the stage; no stage shows nothing — never "no deadline"', () => {
+    expect(dueSlot({ stage: 'working' }, NOW)).toEqual({ text: 'working', hot: false });
+    expect(dueSlot({ stage: '  ' }, NOW)).toBeNull();
+    expect(dueSlot({}, NOW)).toBeNull();
+  });
+
+  test('stageOf trims and blanks', () => {
+    expect(stageOf({ stage: ' signed ' })).toBe('signed');
+    expect(stageOf({})).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/home/home.ts
+++ b/runtime/ui/src/v2/home/home.ts
@@ -90,6 +90,24 @@ function daysUntil(deadline: Date, now: Date): number {
   return Math.round((then - today) / 86_400_000);
 }
 
+/** The matter's `stage` (`working`, `signed`, …), or `null`. */
+export function stageOf(fm: Record<string, string>): string | null {
+  const raw = (fm['stage'] ?? '').trim();
+  return raw === '' ? null : raw;
+}
+
+/**
+ * What the Home row's right-hand slot says (cou-93 item 6). A deadline when
+ * there is one — hot when close — else the matter's stage, else nothing:
+ * "no deadline" set on every row of a vault that dates nothing was a column
+ * of noise, and the leader beside it pointed at nothing.
+ */
+export function dueSlot(fm: Record<string, string>, now: Date = new Date()): Due | null {
+  if (parseDeadline(fm) !== null) return dueLabel(fm, now);
+  const stage = stageOf(fm);
+  return stage === null ? null : { text: stage, hot: false };
+}
+
 export function dueLabel(fm: Record<string, string>, now: Date = new Date()): Due {
   const deadline = parseDeadline(fm);
   if (deadline === null) return { text: 'no deadline', hot: false };

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -221,3 +221,18 @@ describe('SettingsPage', () => {
     expect(screen.getByText('That is 1 minute 30 seconds.')).toBeTruthy();
   });
 });
+
+describe('SettingsPage, the default provider field (cou-93 item 3)', () => {
+  test('shows the EFFECTIVE default when the file sets none, says so, and offers no button to make the default the default', async () => {
+    const claude: ProviderInfo = { ...fakeProvider, id: 'claude-sub/claude-opus-5', kind: 'harness', auth: 'subscription' };
+    install(
+      () => json(view),
+      { file: view.file, registry: {}, effective: { default: 'claude-sub/claude-opus-5', stepTimeoutMs: 600000, providers: [claude] } },
+    );
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Default provider')).toBeTruthy());
+    expect((screen.getByLabelText('Default provider') as HTMLInputElement).value).toBe('claude-sub/claude-opus-5');
+    expect(screen.getByText(/Built-in default/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Make it the default' })).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -103,8 +103,18 @@ const TRI_OPTIONS: { value: Tri; label: string }[] = [
  * `effective` back through `PUT` would write the built-ins into the
  * operator's config as if they had asked for them.
  */
+/** The file may set no default; the field then STARTS on the runtime's
+ * effective (built-in) default rather than blank (cou-93 item 3): a blank
+ * field beside a Runtime panel that names one read as a bug. Save writes
+ * it to the file only once the operator changes it — see `save`. */
+function seedDefault(form: FormState, view: SettingsView): FormState {
+  const effective = view.effective.default ?? '';
+  if (form.default.trim() !== '' || effective === '') return form;
+  return { ...form, default: effective };
+}
+
 function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: SettingsView): void }): JSX.Element {
-  const [form, setForm] = useState<FormState>(() => formFromRegistry(view.registry));
+  const [form, setForm] = useState<FormState>(() => seedDefault(formFromRegistry(view.registry), view));
   const [errors, setErrors] = useState<FieldErrors>({});
   const [general, setGeneral] = useState<string[]>([]);
   const [saved, setSaved] = useState(false);
@@ -113,6 +123,12 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
   // The one the runtime is running, which is not always the one in the file.
   const effectiveIds = view.effective.providers.map(p => p.id);
   const defaultIsKnown = form.default.trim() === '' || effectiveIds.includes(form.default.trim());
+  /** The file sets no default and the field still shows the built-in one
+   * it was seeded with. While that holds, Save leaves `default` OUT of the
+   * PUT: the file must not acquire the built-in as if the operator had
+   * asked for it. */
+  const fileHasDefault = (view.registry.default ?? '').trim() !== '';
+  const showingBuiltin = !fileHasDefault && form.default.trim() !== '' && form.default.trim() === (view.effective.default ?? '');
 
   const patch = (change: Partial<FormState>): void => {
     setForm(prev => ({ ...prev, ...change }));
@@ -140,8 +156,10 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     setGeneral([]);
     setBusy(true);
     try {
-      const next = await fetchJson<SettingsView>('/settings', { method: 'PUT', body: JSON.stringify(built.registry) });
-      setForm(formFromRegistry(next.registry));
+      // `undefined` drops out of the JSON — the file keeps having no default.
+      const body = showingBuiltin ? { ...built.registry, default: undefined } : built.registry;
+      const next = await fetchJson<SettingsView>('/settings', { method: 'PUT', body: JSON.stringify(body) });
+      setForm(seedDefault(formFromRegistry(next.registry), next));
       setSaved(true);
       onSaved(next);
     } catch (err) {
@@ -240,6 +258,8 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
                   — already loaded as <code>{CLAUDE_BUILTIN}</code>. There is nothing to add.
                 </span>
               </p>
+              {/* Hidden when it already IS the effective default — offering
+                  to make the default the default reads as "it is not". */}
               {form.default.trim() === CLAUDE_BUILTIN ? null : (
                 <button type="button" onClick={() => patch({ default: CLAUDE_BUILTIN })}>
                   Make it the default
@@ -288,6 +308,11 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
             options={effectiveIds}
             onChange={value => patch({ default: value })}
           />
+          {showingBuiltin ? (
+            <p className="muted" role="note">
+              Built-in default — nothing is set in <code>{view.file}</code>. Pick a provider to write one.
+            </p>
+          ) : null}
           <FieldError message={errors['default']} />
           {defaultIsKnown ? null : (
             <p className="v2-notice v2-notice-warn" role="status">

--- a/runtime/ui/src/v2/vault/VaultPage.test.tsx
+++ b/runtime/ui/src/v2/vault/VaultPage.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '../../te
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { TOKEN_KEY } from '../../api/token';
 import type { VaultHit, VaultOverview } from '../../api/types';
-import { VaultPage } from './VaultPage';
+import { cleanSnippet, VaultPage } from './VaultPage';
 
 const realFetch = globalThis.fetch;
 
@@ -54,18 +54,40 @@ describe('VaultPage', () => {
   });
 
   test('Enter runs the search; results replace the tree; clear restores it', async () => {
-    hits = [{ path: 'matters/acme.md', snippet: 'Term: 2 years', score: 1 }];
+    hits = [
+      { path: 'matters/acme.md', snippet: 'Term: 2 years', score: 1 },
+      { path: 'practice/reference/corporate-partnering.md', snippet: 'practice/reference/corporate-partnering.md', score: 0.5 },
+    ];
     const opened: string[] = [];
     render(<VaultPage path={null} onOpen={path => opened.push(path)} />);
     await waitFor(() => expect(screen.getByText('Acme Corp — NDA')).toBeTruthy());
 
-    await userEvent.type(screen.getByLabelText('Search the vault'), 'acme{Enter}');
+    await userEvent.type(screen.getByLabelText('Search the vault'), 'acme');
+    // Typing alone searches nothing, and the pane says so (cou-93 item 4).
+    expect(screen.getByText('Enter to search')).toBeTruthy();
+    await userEvent.type(screen.getByLabelText('Search the vault'), '{Enter}');
     expect(searched).toEqual(['acme']);
-    await waitFor(() => expect(screen.getByText('matters/acme.md')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('region', { name: 'Search results' })).toBeTruthy());
+    const results = screen.getByRole('region', { name: 'Search results' }) as HTMLElement;
     // The grouped tree is replaced until the search clears (spec §3.4).
-    expect(screen.queryByText('Acme Corp — NDA')).toBeNull();
+    expect(document.querySelector('.v2-vgroup + .v2-vrow-ind')).toBeNull();
+    expect(screen.queryByText('Enter to search')).toBeNull();
 
-    await userEvent.click(screen.getByText('matters/acme.md'));
+    // A hit is a DOCUMENT: the matter's title, its folder as a run-in, the
+    // matched line — never a bare truncated path (cou-93 item 4).
+    const rows = Array.from(results.querySelectorAll<HTMLElement>('.v2-vhit'));
+    expect(rows).toHaveLength(2);
+    expect(results.textContent).toContain('Results · 2');
+    expect(rows[0]!.querySelector('.v2-vhit-title')?.textContent).toBe('Acme Corp — NDA');
+    expect(rows[0]!.querySelector('.v2-vhit-dir')?.textContent).toBe('matters');
+    expect(rows[0]!.querySelector('.v2-vhit-line')?.textContent).toContain('Term: 2 years');
+    expect(rows[0]!.getAttribute('title')).toBe('matters/acme.md');
+    // A filename hit (the server echoes the path as its snippet) prettifies
+    // the filename and does not print the path twice.
+    expect(rows[1]!.querySelector('.v2-vhit-title')?.textContent).toBe('Corporate partnering');
+    expect(rows[1]!.querySelector('.v2-vhit-line')?.textContent).toBe('practice/reference');
+
+    await userEvent.click(rows[0]!);
     expect(opened).toEqual(['matters/acme.md']);
 
     await userEvent.click(screen.getByRole('button', { name: 'clear' }));
@@ -99,5 +121,14 @@ describe('VaultPage', () => {
     render(<VaultPage path="matters/acme.md" onOpen={() => {}} />);
     await waitFor(() => expect(document.querySelector('.v2-doc')).toBeTruthy());
     await waitFor(() => expect(screen.getByText('Acme')).toBeTruthy());
+  });
+});
+
+describe('cleanSnippet', () => {
+  test('strips the markdown a matched line carries', () => {
+    expect(cleanSnippet('## Audit Rights')).toBe('Audit Rights');
+    expect(cleanSnippet('- **Our standard:** Net 30')).toBe('Our standard: Net 30');
+    expect(cleanSnippet('> quoted')).toBe('quoted');
+    expect(cleanSnippet('plain line')).toBe('plain line');
   });
 });

--- a/runtime/ui/src/v2/vault/VaultPage.tsx
+++ b/runtime/ui/src/v2/vault/VaultPage.tsx
@@ -1,8 +1,32 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../../api/client';
 import type { VaultEntry, VaultHit, VaultOverview } from '../../api/types';
+import { prettifyName } from './frontmatter';
 import { Reader } from './Reader';
 import { VaultTree } from './VaultTree';
+
+/** Where a hit lives, for the run-in: `practice/reference`, or `''` at the root. */
+function dirOf(path: string): string {
+  const cut = path.lastIndexOf('/');
+  return cut === -1 ? '' : path.slice(0, cut);
+}
+
+/**
+ * A hit is a DOCUMENT, not a path (cou-93 item 4): thirty truncated
+ * `practice/reference/corporate-partnering…` rows told the reader nothing.
+ * A matter shows its overview title; anything else its filename prettified,
+ * the way the reader's own dochead does. The full path stays one hover away.
+ */
+export function hitTitle(path: string, overview: VaultOverview | null): string {
+  const matter = overview?.matters.find(m => m.path === path);
+  return matter?.title ?? prettifyName(path.slice(path.lastIndexOf('/') + 1));
+}
+
+/** The matched line as prose: heading marks, list bullets, quote bars and
+ * bold stars are markdown for the reader's editor, not for a results row. */
+export function cleanSnippet(snippet: string): string {
+  return snippet.replace(/^[\s#>*-]+/, '').replace(/\*\*/g, '').trim();
+}
 
 export interface VaultPageProps {
   /** The file named by `#/vault?path=…`, or `null` for the tree alone. */
@@ -94,11 +118,20 @@ export function VaultPage({ path, onOpen, onAsk }: VaultPageProps): JSX.Element 
           />
           <kbd aria-hidden="true">⌘K</kbd>
         </div>
+        {/* Typing alone searches nothing — said before the reader wonders
+            why the tree did not move (cou-93 item 4). */}
+        {hits === null && query.trim() !== '' ? (
+          <p className="muted v2-vhint" role="status">
+            Enter to search
+          </p>
+        ) : null}
 
         {hits !== null ? (
           <div className="v2-tlist v2-vresults" role="region" aria-label="Search results">
             <div className="v2-vgroup">
-              Results{' '}
+              <span>
+                Results{hits.length === 0 ? null : <span className="v2-vcount"> · {hits.length}</span>}
+              </span>
               <button type="button" className="v2-link" onClick={clear}>
                 clear
               </button>
@@ -111,19 +144,31 @@ export function VaultPage({ path, onOpen, onAsk }: VaultPageProps): JSX.Element 
                 </button>
               </p>
             ) : (
-              hits.map(hit => (
-                <button
-                  key={hit.path}
-                  type="button"
-                  className="v2-vrow"
-                  aria-current={path === hit.path ? 'page' : undefined}
-                  onClick={() => onOpen(hit.path)}
-                >
-                  <span className="v2-vname" title={hit.snippet}>
-                    {hit.path}
-                  </span>
-                </button>
-              ))
+              hits.map(hit => {
+                const dir = dirOf(hit.path);
+                // The server falls back to the path itself when no line
+                // matched (a filename hit); repeating it under the title
+                // would say nothing twice.
+                const snippet = hit.snippet === hit.path ? '' : cleanSnippet(hit.snippet);
+                return (
+                  <button
+                    key={hit.path}
+                    type="button"
+                    className="v2-vrow v2-vhit"
+                    aria-current={path === hit.path ? 'page' : undefined}
+                    title={hit.path}
+                    onClick={() => onOpen(hit.path)}
+                  >
+                    <span className="v2-vhit-title">{hitTitle(hit.path, overview)}</span>
+                    {dir === '' && snippet === '' ? null : (
+                      <span className="v2-vhit-line">
+                        {dir === '' ? null : <span className="v2-vhit-dir">{dir}</span>}
+                        {snippet}
+                      </span>
+                    )}
+                  </button>
+                );
+              })
             )}
           </div>
         ) : error !== null ? (

--- a/runtime/ui/src/v2/vault/VaultTree.tsx
+++ b/runtime/ui/src/v2/vault/VaultTree.tsx
@@ -88,6 +88,7 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
       type="button"
       className={indent ? 'v2-vrow v2-vrow-ind' : 'v2-vrow'}
       aria-current={selected === path ? 'page' : undefined}
+      title={name}
       onClick={() => onOpen(path)}
     >
       <span className="v2-vname">{name}</span>
@@ -126,6 +127,9 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
               type="button"
               className="v2-vrow v2-vrow-ind"
               aria-current={selected === matter.path ? 'page' : undefined}
+              // The 300px pane clips most matter titles; the whole title
+              // is one hover away (cou-93 item 5).
+              title={matter.title}
               onClick={() => onOpen(matter.path)}
             >
               <span className="v2-vname">{matter.title}</span>

--- a/runtime/ui/src/v2/vault/tree.test.ts
+++ b/runtime/ui/src/v2/vault/tree.test.ts
@@ -24,7 +24,8 @@ describe('groupRoot', () => {
   test('matters from the overview; practice, knowledge and the rest from the root listing', () => {
     const groups = groupRoot(root, overview);
     expect(groups.mattersDir).toBe('matters');
-    expect(groups.matters.map(m => m.title)).toEqual(['Sinai content license', 'Acme Corp — NDA']);
+    // Newest first (cou-93 item 5), whatever order the overview arrived in.
+    expect(groups.matters.map(m => m.title)).toEqual(['Acme Corp — NDA', 'Sinai content license']);
     expect(groups.practice.map(e => e.path)).toEqual(['practice']);
     expect(groups.knowledge.map(e => e.path)).toEqual(['memory', 'law', 'entities']);
     expect(groups.other.map(e => e.path)).toEqual(['config.md', 'scratch']);

--- a/runtime/ui/src/v2/vault/tree.ts
+++ b/runtime/ui/src/v2/vault/tree.ts
@@ -36,7 +36,11 @@ export function groupRoot(rootEntries: VaultEntry[], overview: VaultOverview): T
   // `entities · law · memory` against the mock.
   const spec = [...KNOWLEDGE_DIRS];
   knowledge.sort((a, b) => spec.indexOf(a.path) - spec.indexOf(b.path));
-  return { mattersDir, matters: overview.matters, practice, knowledge, other };
+  // Matters read newest first. The overview arrives in the filesystem's
+  // order — no order a reader can follow (cou-93 item 5); recency is the
+  // key Home breaks its ties on, so the two surfaces agree.
+  const matters = [...overview.matters].sort((a, b) => b.mtimeMs - a.mtimeMs);
+  return { mattersDir, matters, practice, knowledge, other };
 }
 
 const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'] as const;

--- a/runtime/ui/src/v2/verbs.test.ts
+++ b/runtime/ui/src/v2/verbs.test.ts
@@ -10,15 +10,26 @@ describe('verbFor', () => {
   test('the table', () => {
     expect(verbFor(tool('vault_read', { path: 'matters/acme.md' }))).toEqual({ verb: 'Read', object: 'matters/acme.md' });
     expect(verbFor(tool('vault_list', { dir: 'matters' }))).toEqual({ verb: 'Listed', object: 'matters' });
-    expect(verbFor(tool('vault_search', { query: 'cap' }))).toEqual({ verb: 'Searched', object: 'cap' });
+    expect(verbFor(tool('vault_search', { query: 'cap' }))).toEqual({ verb: 'Searched the vault for', object: 'cap' });
     expect(verbFor(tool('read_primitive', { name: 'evaluate' }))).toEqual({ verb: 'Consulted primitive', object: 'evaluate' });
     expect(verbFor(tool('propose_update', { path: 'practice/x.md', content: '' }))).toEqual({ verb: 'Proposed', object: 'practice/x.md' });
     expect(verbFor(tool('vault_write', { path: 'a.md' }))).toEqual({ verb: 'Wrote', object: 'a.md' });
   });
 
-  test('grep-like names are searches; anything else is Ran <name>', () => {
+  test('grep-like names are searches; scripts are Ran; anything else is Called <name> (cou-93 item 2)', () => {
     expect(verbFor(tool('vault_grep', { pattern: 'x' })).verb).toBe('Searched');
-    expect(verbFor(tool('web_fetch', { url: 'https://x' }))).toEqual({ verb: 'Ran web_fetch' });
+    expect(verbFor(tool('web_fetch', { url: 'https://x' }))).toEqual({ verb: 'Called web_fetch' });
+    expect(verbFor(tool('docket_sweep', { root: '.' })).verb).toBe('Ran docket_sweep');
+  });
+
+  test('the root listing reads as the vault, not as a dot', () => {
+    expect(verbFor(tool('vault_list', { dir: '.' }))).toEqual({ verb: 'Listed the vault' });
+    expect(verbFor(tool('vault_list', {}))).toEqual({ verb: 'Listed the vault' });
+  });
+
+  test('a nameless tool never reads as Ran <argument>', () => {
+    // Threads persisted before the harness named its results (cou-78).
+    expect(verbFor(tool('', { dir: '.' })).verb).toBe('Called a tool');
   });
 
   test('a non-object input has no object', () => {

--- a/runtime/ui/src/v2/verbs.ts
+++ b/runtime/ui/src/v2/verbs.ts
@@ -14,11 +14,23 @@ export interface Verb {
 const TABLE: Record<string, string> = {
   vault_read: 'Read',
   vault_list: 'Listed',
-  vault_search: 'Searched',
+  vault_search: 'Searched the vault for',
   read_primitive: 'Consulted primitive',
   propose_update: 'Proposed',
   vault_write: 'Wrote',
 };
+
+/** The platform's script tools (`runtime/src/tools/builtin.ts`) — the one
+ * family where "Ran" is the honest verb, because a script is a thing you
+ * run. Everything else unknown reads "Called". */
+const SCRIPT_TOOLS: ReadonlySet<string> = new Set([
+  'docket_sweep',
+  'extract_redlines',
+  'check_document',
+  'clean_format',
+  'apply_redlines',
+  'word_compare',
+]);
 
 const SEARCH_LIKE = /grep|search|find/i;
 
@@ -35,9 +47,21 @@ function objectOf(input: unknown): string | undefined {
   return undefined;
 }
 
+/** The fallback resolves by NAME, never by argument: an unnamed tool must
+ * not read as "Ran ." with the input standing in for the verb's subject
+ * (cou-93 item 2). */
+function fallbackVerb(name: string): string {
+  if (name === '') return 'Called a tool';
+  if (SCRIPT_TOOLS.has(name)) return `Ran ${name}`;
+  if (SEARCH_LIKE.test(name)) return 'Searched';
+  return `Called ${name}`;
+}
+
 export function verbFor(tool: ToolCallView): Verb {
-  const verb = TABLE[tool.name] ?? (SEARCH_LIKE.test(tool.name) ? 'Searched' : `Ran ${tool.name}`);
+  const verb = TABLE[tool.name] ?? fallbackVerb(tool.name);
   const object = objectOf(tool.input);
+  // The root listing's argument is `.` — "Listed ." reads as a typo.
+  if (tool.name === 'vault_list' && (object === undefined || object === '.' || object === '/')) return { verb: 'Listed the vault' };
   return object === undefined ? { verb } : { verb, object };
 }
 


### PR DESCRIPTION
Eight fixes from the 2026-09-01 founder review of the live 0.11.2 build (pair-built; QA reviews).

1. **Chat** — text segments split around tool calls join with a paragraph break; `…activity.## What changed` now renders its heading.
2. **Tool trace** — the Claude harness fills `tool_result` names from the paired `tool_use` (closes cou-78); old nameless results keep the call's name client-side; verbs resolve by tool name (`Listed the vault`, `Read …`, `Called <name>`), never `Ran <argument>`.
3. **Settings** — the default-provider field seeds from the effective default when the file sets none, says "Built-in default", and Save leaves `default` out of the PUT until the operator changes it. No "Make it the default" on the row that is the default.
4. **Vault search** — hits are documents: title, folder run-in, cleaned snippet, `RESULTS · n`, full path on hover; "Enter to search" hint while typing.
5. **Vault tree** — matters newest first; full titles on hover.
6. **Home** — the due slot shows the matter's stage when it has no deadline, and nothing when it has neither. No more "no deadline" column.
7. **Thread header** — `MATTER` run-in + the matter file's real title, linked to the file. Pill removed.
8. **Answers** — a backticked full path the vault holds (`GET /vault/index`) becomes a chip that opens the reader. Minted post-sanitize, click gated on the index; basenames still resolve only through the derivation set, so an ambiguous `nda.md` never opens the wrong file.

Tests: `bun run test` 614 pass · `bun run ui:test` 363 pass · both typechecks clean. Verified in a real browser against the founder's vault on a spare port (Home, the two-segment thread, vault search, Settings).