### PR TITLE
ui: session-lost screen — say what happened, show the command, accept the pasted address

### DIFF
--- a/runtime/ui/src/api/token.test.ts
+++ b/runtime/ui/src/api/token.test.ts
@@ -1,7 +1,7 @@
 import '../test/dom';
 
 import { afterEach, describe, expect, test } from 'bun:test';
-import { bootstrapToken, clearToken, getToken, readToken, splitTokenFromHash, TOKEN_KEY, TokenMissingError } from './token';
+import { bootstrapToken, clearToken, getToken, readToken, splitTokenFromHash, storeToken, TOKEN_KEY, tokenFromPaste, TokenMissingError } from './token';
 
 afterEach(() => {
   clearToken();
@@ -67,5 +67,47 @@ describe('bootstrapToken', () => {
 describe('getToken', () => {
   test('throws TokenMissingError when this tab never got one', () => {
     expect(() => getToken()).toThrow(TokenMissingError);
+  });
+});
+
+describe('tokenFromPaste', () => {
+  const hex = 'a'.repeat(32) + '0123456789abcdef'.repeat(2);
+
+  test('the whole printed URL', () => {
+    expect(tokenFromPaste(`http://127.0.0.1:7431/#token=${hex}`)).toBe(hex);
+  });
+
+  test('a bare fragment, with or without the hash, and the raw hex', () => {
+    expect(tokenFromPaste(`#token=${hex}`)).toBe(hex);
+    expect(tokenFromPaste(`token=${hex}`)).toBe(hex);
+    expect(tokenFromPaste(hex)).toBe(hex);
+  });
+
+  test('surrounding whitespace and upper-case hex are tolerated', () => {
+    expect(tokenFromPaste(`  ${hex.toUpperCase()}\n`)).toBe(hex);
+  });
+
+  test('anything that is not a 64-hex token is null', () => {
+    expect(tokenFromPaste('')).toBeNull();
+    expect(tokenFromPaste('   ')).toBeNull();
+    expect(tokenFromPaste('http://127.0.0.1:7431/')).toBeNull();
+    expect(tokenFromPaste('#token=abc123')).toBeNull();
+    expect(tokenFromPaste(hex.slice(0, 63))).toBeNull();
+    expect(tokenFromPaste(`${hex}z`)).toBeNull();
+    expect(tokenFromPaste('#/vault?path=matters%2Facme.md')).toBeNull();
+  });
+
+  test('a route sharing the fragment does not hide the token', () => {
+    expect(tokenFromPaste(`http://127.0.0.1:7431/#/vault&token=${hex}`)).toBe(hex);
+  });
+});
+
+describe('storeToken', () => {
+  test('writes the tab store and memory, never the URL', () => {
+    globalThis.history.replaceState(null, '', '/#/chat');
+    storeToken('f'.repeat(64));
+    expect(readToken()).toBe('f'.repeat(64));
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBe('f'.repeat(64));
+    expect(globalThis.location.hash).toBe('#/chat');
   });
 });

--- a/runtime/ui/src/api/token.ts
+++ b/runtime/ui/src/api/token.ts
@@ -142,3 +142,37 @@ export function clearToken(): void {
     /* nothing to clear */
   }
 }
+
+/** The shape `serve` mints: `randomBytes(32).toString('hex')` — 64 hex
+ * characters, nothing else. A paste that is not this is not a token. */
+const TOKEN_SHAPE = /^[0-9a-f]{64}$/i;
+
+/**
+ * The token inside whatever the reader pasted from the terminal: the whole
+ * printed URL (`http://127.0.0.1:7431/#token=…`), a bare `#token=…` or
+ * `token=…` fragment, or the raw hex. `null` for anything else — a guess
+ * would only be refused by the runtime a request later, with less to say.
+ */
+export function tokenFromPaste(text: string): string | null {
+  const trimmed = text.trim();
+  if (trimmed === '') return null;
+  let candidate = trimmed;
+  const hash = trimmed.indexOf('#');
+  if (hash !== -1) candidate = splitTokenFromHash(trimmed.slice(hash)).token ?? '';
+  else if (trimmed.startsWith('token=')) candidate = decode(trimmed.slice('token='.length));
+  return TOKEN_SHAPE.test(candidate) ? candidate.toLowerCase() : null;
+}
+
+/**
+ * Stores a token the reader pasted — the same two places `bootstrapToken`
+ * writes, and nowhere else: `sessionStorage` (this tab, until it closes) and
+ * the in-memory copy. Never the URL.
+ */
+export function storeToken(token: string): void {
+  memoryToken = token;
+  try {
+    session()?.setItem(TOKEN_KEY, token);
+  } catch {
+    /* private mode, quota, blocked site data — the memory copy stands in */
+  }
+}

--- a/runtime/ui/src/app.tsx
+++ b/runtime/ui/src/app.tsx
@@ -3,10 +3,6 @@ import { Shell } from './v2/Shell';
 /** The four surfaces the fragment routes between (redesign spec §3.1). */
 export type Route = 'home' | 'chat' | 'vault' | 'settings';
 
-/** Spec §5, word for word: the page cannot fix this itself — the token is
- * printed by the process that owns it. */
-export const TOKEN_MESSAGE = 'token missing or stale — restart `counsel-os serve` and open the printed URL';
-
 /** The fragment split into the part that picks a surface and the part that
  * parameterizes it — `#/vault?path=matters/acme/notes.md`. The query lives
  * in the FRAGMENT, not the URL's own query string: the token lives there

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -711,3 +711,24 @@ a { color: var(--accent); }
 /* The plate clips on its detail line only; the full raw id + auth live in
  * the title. (The old one-line `.v2-foot .v2-lbl` ellipsis moved onto
  * `.v2-plate-detail` with the cou-90 plate.) */
+
+/* ── Session lost (spec §5) ──────────────────────────────────────────── */
+
+/* The one page with no rail: a short serif column, the two things that
+   could have happened in set text, the command, and a paste field. */
+.v2-lost { flex: 1; }
+.v2-lost-wrap { max-width: 560px; margin: 48px auto 0; }
+.v2-lost-title { font: 400 30px/1.3 var(--serif); margin: 0 0 6px; }
+.v2-lost-lede { font: 15px/1.6 var(--serif); color: var(--fg-muted); margin: 0 0 28px; }
+.v2-lost-group { padding: 14px 0 6px; margin-top: 18px; }
+.v2-lost-group .runin { margin-bottom: 8px; }
+.v2-lost-group .muted { font-size: 13px; margin: 0 0 8px; }
+.v2-lost-cmd { display: flex; align-items: baseline; gap: 12px; padding: 8px 12px; margin: 6px 0 10px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius); }
+.v2-lost-cmd code { flex: 1; min-width: 0; overflow-wrap: anywhere; font-size: 12.5px; }
+.v2-lost-form { display: flex; flex-direction: column; gap: 8px; }
+.v2-lost-form label { font-size: 13px; color: var(--fg-muted); }
+.v2-lost-form input { width: 100%; padding: 8px 10px; font: 13px var(--mono); color: var(--fg); background: var(--bg-raised); border: 1px solid var(--border-strong); border-radius: 8px; }
+.v2-lost-form input[aria-invalid="true"] { border-color: var(--error); }
+.v2-lost-acts { display: flex; align-items: center; gap: 14px; }
+.v2-lost-acts .v2-ask-go { margin-left: 0; }
+.v2-lost-error { font-size: 13px; color: var(--error); margin: 0; }

--- a/runtime/ui/src/v2/SessionLost.test.tsx
+++ b/runtime/ui/src/v2/SessionLost.test.tsx
@@ -1,0 +1,94 @@
+import { cleanup, render, screen, userEvent, waitFor } from '../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, readToken, TOKEN_KEY } from '../api/token';
+import { SERVE_COMMAND, SessionLost } from './SessionLost';
+
+const realFetch = globalThis.fetch;
+const hex = 'abcdef0123456789'.repeat(4);
+
+let probes: RequestInit[] = [];
+let runtimeUp = true;
+
+beforeEach(() => {
+  probes = [];
+  runtimeUp = true;
+  clearToken();
+  sessionStorage.clear();
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url.startsWith('/health')) {
+      probes.push(init ?? {});
+      if (!runtimeUp) throw new TypeError('Failed to fetch');
+      return new Response('{"error":"unauthorized"}', { status: 401, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+describe('SessionLost', () => {
+  test('the runtime answers 401 → "running, this tab has no key"; the probe carries no token', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'stale-token');
+    render(<SessionLost onRestored={() => {}} />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('The runtime is running'));
+    expect(probes).toHaveLength(1);
+    const headers = probes[0]!.headers as Record<string, string> | undefined;
+    expect(headers?.['authorization']).toBeUndefined();
+  });
+
+  test('nothing listening → "not running", with the command to start it', async () => {
+    runtimeUp = false;
+    render(<SessionLost onRestored={() => {}} />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('counsel-os is not running'));
+    expect(screen.getByText(SERVE_COMMAND)).toBeTruthy();
+  });
+
+  test('"check again" probes again', async () => {
+    runtimeUp = false;
+    render(<SessionLost onRestored={() => {}} />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('not running'));
+    runtimeUp = true;
+    await userEvent.click(screen.getByRole('button', { name: 'check again' }));
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('The runtime is running'));
+    expect(probes).toHaveLength(2);
+  });
+
+  test('a pasted printed URL stores the token in the tab and hands control back', async () => {
+    let restored = 0;
+    render(<SessionLost onRestored={() => (restored += 1)} />);
+    await userEvent.type(screen.getByLabelText('Paste the address the runtime printed'), `http://127.0.0.1:7431/#token=${hex}`);
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(restored).toBe(1);
+    expect(readToken()).toBe(hex);
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBe(hex);
+    expect(globalThis.location.hash).not.toContain('token');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('a paste that is not a token says so inline and stores nothing', async () => {
+    let restored = 0;
+    render(<SessionLost onRestored={() => (restored += 1)} />);
+    const field = screen.getByLabelText('Paste the address the runtime printed');
+    await userEvent.type(field, 'http://127.0.0.1:7431/');
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    expect(screen.getByRole('alert').textContent).toContain('not an address the runtime printed');
+    expect(field.getAttribute('aria-invalid')).toBe('true');
+    expect(restored).toBe(0);
+    expect(readToken()).toBeNull();
+    // Typing again clears the error.
+    await userEvent.type(field, 'x');
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('Open is disabled until something is pasted', async () => {
+    render(<SessionLost onRestored={() => {}} />);
+    expect((screen.getByRole('button', { name: 'Open' }) as HTMLButtonElement).disabled).toBe(true);
+  });
+});

--- a/runtime/ui/src/v2/SessionLost.tsx
+++ b/runtime/ui/src/v2/SessionLost.tsx
@@ -1,0 +1,153 @@
+import { useCallback, useEffect, useState } from 'react';
+import { storeToken, tokenFromPaste } from '../api/token';
+
+/**
+ * How the reader starts the runtime today (CHANGELOG 0.10.0, roadmap §9).
+ * There is no installed `counsel-os` binary yet — that is roadmap §9 — so
+ * the page shows the source-checkout command rather than inventing one. One
+ * place to change when the binary ships.
+ */
+export const SERVE_COMMAND = 'bun runtime/src/cli.ts serve --vault <your vault> --open';
+
+/** What the probe found: the runtime answered (any status — a 401 is the
+ * runtime saying "who are you", which is the whole question here), or
+ * nothing is listening. `null` while the probe is in flight. */
+export type Probe = 'up' | 'down' | null;
+
+/**
+ * Asks the runtime whether it is there, WITHOUT a token: the point is to
+ * tell "your key is stale" from "nothing is running", and sending the
+ * stale key would not change either answer while giving a log one more
+ * copy of it. A plain `fetch`, not `client.ts` — that one reports 401s to
+ * the app, and this screen is already the app's answer to one.
+ */
+export async function probeRuntime(): Promise<Probe> {
+  try {
+    await fetch('/health', { cache: 'no-store' });
+    return 'up';
+  } catch {
+    return 'down';
+  }
+}
+
+export interface SessionLostProps {
+  /** A valid token was pasted and stored; the shell takes it from here. */
+  onRestored(): void;
+}
+
+/**
+ * The page a reader lands on when this tab has no usable key (spec §5).
+ *
+ * Two honest sentences instead of one line of jargon: which of the two
+ * things happened, what to do about it, and a place to paste the address
+ * the runtime printed. The token goes to `sessionStorage` and memory, the
+ * same as the fragment path — never back into the URL, never to the
+ * console.
+ */
+export function SessionLost({ onRestored }: SessionLostProps): JSX.Element {
+  const [probe, setProbe] = useState<Probe>(null);
+  const [pasted, setPasted] = useState('');
+  const [rejected, setRejected] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  const check = useCallback(async (): Promise<void> => {
+    setProbe(null);
+    setProbe(await probeRuntime());
+  }, []);
+
+  useEffect(() => {
+    void check();
+  }, [check]);
+
+  const submit = (): void => {
+    const token = tokenFromPaste(pasted);
+    if (token === null) {
+      setRejected(true);
+      return;
+    }
+    storeToken(token);
+    setPasted('');
+    setRejected(false);
+    onRestored();
+  };
+
+  const copy = async (): Promise<void> => {
+    try {
+      await navigator.clipboard.writeText(SERVE_COMMAND);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // No clipboard (an insecure context, a denied permission): the
+      // command is on screen to select by hand.
+    }
+  };
+
+  return (
+    <main className="v2-page v2-lost" aria-label="Session lost">
+      <div className="v2-lost-wrap">
+        <h1 className="v2-lost-title">Your session ended.</h1>
+
+        <p className="v2-lost-lede" role="status">
+          {probe === null
+            ? 'Checking whether counsel-os is running…'
+            : probe === 'up'
+              ? 'The runtime is running, but this tab no longer has its key. Paste the address it printed to get back in.'
+              : 'counsel-os is not running. Start it, then paste the address it prints.'}
+        </p>
+
+        <section className="v2-lost-group rule-double">
+          <h2 className="runin">Start it</h2>
+          <p className="muted">In a terminal, from the counsel-os checkout:</p>
+          <div className="v2-lost-cmd">
+            <code>{SERVE_COMMAND}</code>
+            <button type="button" className="v2-link" onClick={() => void copy()}>
+              {copied ? 'copied' : 'copy'}
+            </button>
+          </div>
+          <p className="muted">
+            It prints an address that starts with <code>http://127.0.0.1</code> and ends in <code>#token=…</code>. The browser it opens is already signed in; any other tab needs that address.
+          </p>
+        </section>
+
+        <section className="v2-lost-group rule-double">
+          <h2 className="runin">Get back in</h2>
+          <form
+            className="v2-lost-form"
+            onSubmit={event => {
+              event.preventDefault();
+              submit();
+            }}
+          >
+            <label htmlFor="v2-lost-paste">Paste the address the runtime printed</label>
+            <input
+              id="v2-lost-paste"
+              type="text"
+              autoComplete="off"
+              spellCheck={false}
+              placeholder="http://127.0.0.1:7431/#token=…"
+              value={pasted}
+              aria-invalid={rejected || undefined}
+              onChange={event => {
+                setPasted(event.target.value);
+                setRejected(false);
+              }}
+            />
+            <div className="v2-lost-acts">
+              <button type="submit" className="v2-ask-go" disabled={pasted.trim() === ''}>
+                Open
+              </button>
+              <button type="button" className="v2-link" onClick={() => void check()}>
+                check again
+              </button>
+            </div>
+            {rejected ? (
+              <p className="v2-lost-error" role="alert">
+                That is not an address the runtime printed. It ends in <code>#token=</code> followed by 64 letters and digits.
+              </p>
+            ) : null}
+          </form>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -649,3 +649,36 @@ describe('Shell', () => {
     expect(document.querySelector('.v2-foot .v2-dot')?.classList.contains('v2-dot-amber')).toBe(false);
   });
 });
+
+describe('Shell, a tab with no usable key (spec §5)', () => {
+  const hex = '0123456789abcdef'.repeat(4);
+
+  test('no token → the session-lost screen; a pasted address gets back in without a reload', async () => {
+    sessionStorage.clear();
+    const bearers: string[] = [];
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const auth = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      if (url === '/threads' && auth !== undefined) bearers.push(auth);
+      // The probe carries no token: the runtime says who-are-you.
+      if (url.startsWith('/health') && auth === undefined) return new Response('{"error":"unauthorized"}', { status: 401 });
+      return base(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(screen.getByLabelText('Session lost')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('The runtime is running'));
+    expect(document.querySelector('.v2-rail')).toBeNull();
+
+    await userEvent.type(screen.getByLabelText('Paste the address the runtime printed'), `http://127.0.0.1:7431/#token=${hex}`);
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    // Home renders, the list was fetched with the NEW bearer, and the URL
+    // never carried the token.
+    await waitFor(() => expect(screen.getAllByText('Acme NDA term').length).toBeGreaterThan(0));
+    expect(bearers).toContain(`Bearer ${hex}`);
+    expect(globalThis.location.hash).not.toContain('token');
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBe(hex);
+  });
+});

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -3,12 +3,13 @@ import { ApiError, fetchJson } from '../api/client';
 import { readToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
 import type { Health, SettingsView, ThreadHeader } from '../api/types';
-import { parseHash, threadFromHash, TOKEN_MESSAGE, vaultPathFromHash, type Route } from '../app';
+import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
 import type { ComposerSeed } from './chat/Composer';
 import { Drawer } from './Drawer';
 import { HomePage } from './home/HomePage';
 import { Rail } from './Rail';
+import { SessionLost } from './SessionLost';
 import { SettingsPage } from './settings/SettingsPage';
 import { VaultPage } from './vault/VaultPage';
 
@@ -309,16 +310,11 @@ export function Shell(): JSX.Element {
     }
   };
 
-  if (unauthorized) {
-    return (
-      <main className="page-message">
-        <h1>counsel-os</h1>
-        <p className="notice notice-error" role="alert">
-          {TOKEN_MESSAGE}
-        </p>
-      </main>
-    );
-  }
+  // No usable key in this tab (never had one, or the runtime refused it).
+  // Flipping the flag back re-runs the initial load above — it keys on
+  // `unauthorized` — so a pasted token picks up exactly where a fresh
+  // open would, with no reload and nothing written to the URL.
+  if (unauthorized) return <SessionLost onRestored={() => setUnauthorized(false)} />;
 
   return (
     <div className="v2-shell">


### PR DESCRIPTION
Pair-built per founder direction (2026-09-01 review, item "losing the tab loses the session"). QA reviews.

**Before:** a tab with no usable key dead-ended at `token missing or stale — restart \`counsel-os serve\` and open the printed URL`.

**Now** (`runtime/ui/src/v2/SessionLost.tsx`, ledger language, no rail):
- Probes `GET /health` **without a token** and says which of two things happened: *"The runtime is running, but this tab no longer has its key"* (runtime answered, 401) or *"counsel-os is not running"* (nothing listening). "check again" re-probes.
- Shows the command that starts the runtime today with a copy button: `bun runtime/src/cli.ts serve --vault <your vault> --open` — the invocation CHANGELOG 0.10.0 and roadmap §9 document; there is no installed binary yet, so none is invented. One constant (`SERVE_COMMAND`) to change when cou-75 ships one.
- A paste field for the address the runtime printed: whole URL, bare `#token=…`, or raw hex. `tokenFromPaste` (in `api/token.ts`) accepts only the 64-hex shape `serve` mints; a wrong paste gets an inline set-text error.
- A good paste is stored exactly as the fragment path stores it (sessionStorage + memory — never the URL, never the console); the Shell flips `unauthorized` off, which re-runs its initial load. No `location.reload()`. A later 401 brings the screen back through the existing `onUnauthorized` subscription.
- `TOKEN_MESSAGE` removed from `app.tsx`; nothing else used it.

Tests: `bun run ui:test` 359 pass (tokenFromPaste URL/fragment/raw/garbage/whitespace; SessionLost both probe outcomes, re-probe, paste ok/rejected; Shell stale token → screen → paste → Home renders and `/threads` is fetched with the new bearer, hash never carries the token) · `bun run test` 612 pass · `typecheck:ui` clean · `ui:build` ok.