### PR TITLE
One docket on Home: deadlines from matter frontmatter (runtime sweep, TS) + pending proposals

### DIFF
--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1074,3 +1074,40 @@ describe('vault index (cou-93 item 8)', () => {
     expect(paths.some(p => p.toLowerCase().startsWith('.counsel'))).toBe(false);
   });
 });
+
+describe('docket', () => {
+  test('GET /docket sweeps deadlines off the matter files, dated and classified; malformed dates are counted', async () => {
+    const app = appWithFake();
+    const soon = new Date();
+    soon.setDate(soon.getDate() + 3);
+    const soonIso = soon.toISOString().slice(0, 10);
+    await vault.write(
+      'default',
+      'matters/acme.md',
+      `---\ntitle: Acme — NDA\ndeadlines:\n  - date: 2020-01-01\n    action: long gone\n  - date: ${soonIso}\n    action: renewal notice\n    type: renewal\n  - date: nope\n    action: bad\n---\n\nBody.\n`,
+    );
+    await vault.write('default', 'matters/vendora.md', '---\ndeadline: 2099-12-31\nnext_action: send document list\n---\n\n# Vendora\n');
+    await vault.write('default', 'matters/quiet.md', '---\nstage: working\n---\n\n# Quiet\n');
+
+    const res = await call(app, 'GET', '/docket');
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { deadlines: Array<Record<string, unknown>>; skipped: number };
+    expect(body.skipped).toBe(1);
+    expect(body.deadlines.map(d => [d['date'], d['status'], (d['matter'] as { title: string }).title])).toEqual([
+      ['2020-01-01', 'overdue', 'Acme — NDA'],
+      [soonIso, 'soon', 'Acme — NDA'],
+      ['2099-12-31', 'later', 'Vendora'],
+    ]);
+    expect(body.deadlines[2]!['action']).toBe('send document list');
+    // API surface: no token, no answer.
+    expect((await call(app, 'GET', '/docket', { token: null })).status).toBe(401);
+    expect(API_PREFIXES).toContain('docket');
+  });
+
+  test('GET /docket on a vault with no matters dir is an empty docket, not an error', async () => {
+    const app = appWithFake();
+    const res = await call(app, 'GET', '/docket');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ deadlines: [], skipped: 0 });
+  });
+});

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -6,6 +6,7 @@ import { applyProposal } from '../loop/proposals';
 import { listRuns, readRun, type RunRecord } from '../loop/run-record';
 import { RegistryFile } from '../providers/registry';
 import type { ThreadEvent, ThreadHeader } from '../threads/store';
+import { vaultDocket } from '../vault/docket';
 import { normalizeVaultPath } from '../vault/knowledge-paths';
 import { vaultOverview } from '../vault/overview';
 import { readVaultConfig } from '../vault/resolve-root';
@@ -51,7 +52,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -479,6 +480,12 @@ export function createApp(deps: ServerDeps): App {
   const vaultOverviewRoute = async (): Promise<Response> =>
     json(await vaultOverview(deps.vault, deps.tenant, readVaultConfig(deps.vaultRoot)));
 
+  /** The deadline docket (roadmap §1, in the runtime): every dated
+   * obligation the matter files carry, classified against today. Same
+   * matter discovery as the overview, read-only. */
+  const docketRoute = async (): Promise<Response> =>
+    json(await vaultDocket(deps.vault, deps.tenant, readVaultConfig(deps.vaultRoot)));
+
   /** The vault search the ⌘K field runs (spec §3.4) — the same `SearchFn`
    * behind the model's `vault_search` tool, read-only. */
   const vaultSearchRoute = async (url: URL): Promise<Response> => {
@@ -598,6 +605,8 @@ export function createApp(deps: ServerDeps): App {
       if (segments.length === 1 && first === 'proposals' && method === 'GET') {
         return await proposalsRoute(url);
       }
+
+      if (segments.length === 1 && first === 'docket' && method === 'GET') return await docketRoute();
 
       return fail(404, `no route for ${method} ${url.pathname}`);
     } catch (err) {

--- a/runtime/src/vault/docket.test.ts
+++ b/runtime/src/vault/docket.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'bun:test';
+import { daysUntil, parseDeadlineEntries, parseIsoDate, statusFor, sweepDocket, type DocketMatter } from './docket';
+
+const NOW = new Date('2026-09-01T14:00:00');
+
+function matter(path: string, frontmatter: string, title = path): DocketMatter {
+  return { path, title, source: `---\n${frontmatter}\n---\n\n# ${title}\n\nBody.\n` };
+}
+
+describe('parseDeadlineEntries', () => {
+  test('a block sequence of mappings, first field on the dash line or not', () => {
+    const entries = parseDeadlineEntries(
+      [
+        'counsel-os-type: matter',
+        'deadlines:',
+        '  - date: 2026-09-10',
+        '    action: "renewal notice due"',
+        '    type: renewal',
+        "    source: 'MSA §9.2'",
+        '  -',
+        '    date: 2026-10-01',
+        '    action: objection window closes',
+        '',
+        '  - date: 2026-12-31',
+        '    action: done one',
+        '    done: true',
+        'stage: working',
+      ].join('\n'),
+    );
+    expect(entries).toEqual([
+      { date: '2026-09-10', action: 'renewal notice due', type: 'renewal', source: 'MSA §9.2' },
+      { date: '2026-10-01', action: 'objection window closes' },
+      { date: '2026-12-31', action: 'done one', done: 'true' },
+    ]);
+  });
+
+  test('the next top-level key ends the block; unknown fields are dropped; no block is no entries', () => {
+    expect(parseDeadlineEntries('deadlines:\n  - date: 2026-09-10\n    notes: x\nstage: working\n  - date: 2027-01-01\n')).toEqual([
+      { date: '2026-09-10' },
+    ]);
+    expect(parseDeadlineEntries('stage: working\n')).toEqual([]);
+  });
+});
+
+describe('parseIsoDate / daysUntil / statusFor', () => {
+  test('only a real YYYY-MM-DD parses', () => {
+    expect(parseIsoDate('2026-09-15')?.toISOString()).toBe('2026-09-15T00:00:00.000Z');
+    expect(parseIsoDate('2026-02-30')).toBeNull();
+    expect(parseIsoDate('Sept 15 2026')).toBeNull();
+    expect(parseIsoDate('2026-09-15T10:00:00Z')).toBeNull();
+    expect(parseIsoDate('')).toBeNull();
+  });
+
+  test('overdue below zero, soon through the 14th day, later after', () => {
+    expect(statusFor(-1)).toBe('overdue');
+    expect(statusFor(0)).toBe('soon');
+    expect(statusFor(14)).toBe('soon');
+    expect(statusFor(15)).toBe('later');
+    expect(daysUntil(parseIsoDate('2026-09-15')!, NOW)).toBe(14);
+    expect(daysUntil(parseIsoDate('2026-09-16')!, NOW)).toBe(15);
+    expect(daysUntil(parseIsoDate('2026-08-31')!, NOW)).toBe(-1);
+  });
+});
+
+describe('sweepDocket', () => {
+  test('sorted by date across matters, classified against now, done hidden, optional fields only when set', () => {
+    const view = sweepDocket(
+      [
+        matter(
+          'matters/acme.md',
+          'deadlines:\n  - date: 2026-10-01\n    action: objection window\n  - date: 2026-08-30\n    action: file response\n    source: "Order ¶3"\n  - date: 2026-09-20\n    action: closed\n    done: yes',
+          'Acme — NDA',
+        ),
+        matter('matters/vendora.md', 'deadlines:\n  - date: 2026-09-10\n    action: renewal notice\n    type: renewal', 'Vendora'),
+      ],
+      NOW,
+    );
+    expect(view.skipped).toBe(0);
+    expect(view.deadlines).toEqual([
+      { date: '2026-08-30', action: 'file response', source: 'Order ¶3', matter: { path: 'matters/acme.md', title: 'Acme — NDA' }, status: 'overdue' },
+      { date: '2026-09-10', action: 'renewal notice', type: 'renewal', matter: { path: 'matters/vendora.md', title: 'Vendora' }, status: 'soon' },
+      { date: '2026-10-01', action: 'objection window', matter: { path: 'matters/acme.md', title: 'Acme — NDA' }, status: 'later' },
+    ]);
+  });
+
+  test('a bad or missing date is counted, never dropped silently', () => {
+    const view = sweepDocket(
+      [matter('matters/a.md', 'deadlines:\n  - date: soon\n    action: x\n  - action: no date at all\n  - date: 2026-09-05\n    action: real')],
+      NOW,
+    );
+    expect(view.skipped).toBe(2);
+    expect(view.deadlines.map(d => d.action)).toEqual(['real']);
+  });
+
+  test('the scalar deadline key is one entry, the next action as its action', () => {
+    const view = sweepDocket(
+      [
+        matter('matters/a.md', 'deadline: 2026-09-12\nnext_action: send document list', 'A'),
+        matter('matters/b.md', 'due: 2026-09-13', 'B'),
+        matter('matters/c.md', 'deadline: TBD\nnext_action: x', 'C'),
+      ],
+      NOW,
+    );
+    expect(view.deadlines).toEqual([
+      { date: '2026-09-12', action: 'send document list', matter: { path: 'matters/a.md', title: 'A' }, status: 'soon' },
+      { date: '2026-09-13', action: 'deadline', matter: { path: 'matters/b.md', title: 'B' }, status: 'soon' },
+    ]);
+    expect(view.skipped).toBe(1);
+  });
+
+  test('a note with no frontmatter, or none of the keys, contributes nothing', () => {
+    const view = sweepDocket(
+      [{ path: 'matters/x.md', title: 'X', source: '# X\n\nno frontmatter\n' }, matter('matters/y.md', 'stage: working')],
+      NOW,
+    );
+    expect(view).toEqual({ deadlines: [], skipped: 0 });
+  });
+
+  test('same date sorts by matter title', () => {
+    const view = sweepDocket(
+      [matter('matters/z.md', 'deadline: 2026-09-12', 'Zeta'), matter('matters/a.md', 'deadline: 2026-09-12', 'Alpha')],
+      NOW,
+    );
+    expect(view.deadlines.map(d => d.matter.title)).toEqual(['Alpha', 'Zeta']);
+  });
+});

--- a/runtime/src/vault/docket.ts
+++ b/runtime/src/vault/docket.ts
@@ -1,0 +1,218 @@
+import type { Entry, Tenant, VaultStore } from '../core/types';
+import { MAX_MATTER_BYTES, MAX_MATTERS, parseFrontmatter, splitFrontmatterBlock, titleOf } from './overview';
+import type { VaultConfig } from './resolve-root';
+
+/**
+ * The deadline docket (`GET /docket`): every dated obligation the matter
+ * files carry, classified against today. The runtime's own sweep, in
+ * TypeScript — the plugin's `scripts/docket_sweep.py` does the same job for
+ * the Claude Code front end, and the standalone app cannot assume Python.
+ * Read-only: it changes nothing, emits into nothing (roadmap §1).
+ *
+ * Frontmatter convention (primitives/remember.md, mirrored from the Python
+ * sweep — the same shapes, nothing more):
+ *
+ *     deadlines:
+ *       - date: 2026-07-15
+ *         action: "renewal notice due"
+ *         type: renewal          # optional
+ *         source: "MSA §9.2"     # optional
+ *         done: false            # true/done/yes… hides it, kept for audit
+ *
+ * plus the scalar `deadline:` / `due:` key the home page already reads,
+ * which counts as one entry whose action is the matter's next action.
+ */
+
+export type DocketStatus = 'overdue' | 'soon' | 'later';
+
+export interface DocketEntry {
+  /** `YYYY-MM-DD`, as written. */
+  date: string;
+  action: string;
+  type?: string;
+  source?: string;
+  matter: { path: string; title: string };
+  status: DocketStatus;
+}
+
+export interface DocketView {
+  /** Sorted by date, then matter title. */
+  deadlines: DocketEntry[];
+  /** Entries whose date could not be read (missing, or not `YYYY-MM-DD`).
+   * Counted so a malformed deadline is a number on the page, never a
+   * silent absence — a missed date is the practice's #1 malpractice vector. */
+  skipped: number;
+}
+
+/** A matter as the sweep reads it: the whole note, already located. */
+export interface DocketMatter {
+  path: string;
+  title: string;
+  source: string;
+}
+
+/** "Due soon" = within this many calendar days, the home page's own edge. */
+export const SOON_DAYS = 14;
+
+const DONE_VALUES: ReadonlySet<string> = new Set(['true', 'yes', 'done', '1', 'satisfied', 'complete', 'completed']);
+const ENTRY_KEYS: ReadonlySet<string> = new Set(['date', 'action', 'type', 'source', 'done', 'status']);
+const KEY_LINE = /^([A-Za-z0-9_-]+):\s*(.*)$/;
+
+function unquote(value: string): string {
+  const v = value.trim();
+  if (v.length >= 2 && v[0] === v[v.length - 1] && (v[0] === '"' || v[0] === "'")) return v.slice(1, -1);
+  return v;
+}
+
+/**
+ * The `deadlines:` block as the Python sweep reads it: a block sequence of
+ * mappings, the first field allowed on the dash line. Blank lines, indented
+ * lines and column-0 `- ` items belong to the block; the next top-level key
+ * ends it. Not a YAML parser — the schema is fixed and this stays
+ * deterministic on the hand-edited notes it will meet.
+ */
+export function parseDeadlineEntries(block: string): Array<Record<string, string>> {
+  const lines = block.split(/\r?\n/);
+  const start = lines.findIndex(line => /^deadlines:\s*(.*)$/.test(line));
+  if (start === -1) return [];
+  const body: string[] = [];
+  for (const line of lines.slice(start + 1)) {
+    if (line.trim() === '') continue;
+    if (/^[ \t]/.test(line) || line.trimStart().startsWith('-')) {
+      body.push(line);
+      continue;
+    }
+    break;
+  }
+  const entries: Array<Record<string, string>> = [];
+  let current: Record<string, string> | null = null;
+  const apply = (entry: Record<string, string>, text: string): void => {
+    const m = KEY_LINE.exec(text);
+    if (m === null) return;
+    const key = m[1]!.toLowerCase();
+    if (ENTRY_KEYS.has(key)) entry[key] = unquote(m[2]!);
+  };
+  for (const line of body) {
+    const stripped = line.trim();
+    if (stripped.startsWith('-')) {
+      if (current !== null) entries.push(current);
+      current = {};
+      const rest = stripped.slice(1).trim();
+      if (rest !== '') apply(current, rest);
+    } else if (current !== null) {
+      apply(current, stripped);
+    }
+  }
+  if (current !== null) entries.push(current);
+  return entries;
+}
+
+function isDone(entry: Record<string, string>): boolean {
+  return DONE_VALUES.has((entry['done'] ?? '').trim().toLowerCase()) || DONE_VALUES.has((entry['status'] ?? '').trim().toLowerCase());
+}
+
+/** `YYYY-MM-DD` and a real calendar date, or `null`. Anything looser (a
+ * month name, a time, `TBD`) is malformed and counted, not guessed at. */
+export function parseIsoDate(raw: string): Date | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw.trim());
+  if (m === null) return null;
+  const [y, mo, d] = [Number(m[1]), Number(m[2]), Number(m[3])];
+  const date = new Date(Date.UTC(y, mo - 1, d));
+  if (date.getUTCFullYear() !== y || date.getUTCMonth() !== mo - 1 || date.getUTCDate() !== d) return null;
+  return date;
+}
+
+/**
+ * Whole calendar days from `now` to the deadline — date parts, not
+ * instants, so the 14-day edge does not move with the reader's timezone
+ * (the same rule as the home page's `daysUntil`).
+ */
+export function daysUntil(deadline: Date, now: Date): number {
+  const then = Date.UTC(deadline.getUTCFullYear(), deadline.getUTCMonth(), deadline.getUTCDate());
+  const today = Date.UTC(now.getFullYear(), now.getMonth(), now.getDate());
+  return Math.round((then - today) / 86_400_000);
+}
+
+export function statusFor(days: number): DocketStatus {
+  if (days < 0) return 'overdue';
+  if (days <= SOON_DAYS) return 'soon';
+  return 'later';
+}
+
+/** Pure: the docket for these matters as of `now`. */
+export function sweepDocket(matters: DocketMatter[], now: Date = new Date()): DocketView {
+  const deadlines: DocketEntry[] = [];
+  let skipped = 0;
+  for (const matter of matters) {
+    const { block } = splitFrontmatterBlock(matter.source);
+    if (block === null) continue;
+    const { frontmatter } = parseFrontmatter(matter.source);
+    const raw: Array<Record<string, string>> = parseDeadlineEntries(block);
+    // The scalar key the home page reads: one entry, the matter's next
+    // action as its action, so a matter dated the old way is not undated
+    // here. Missing next action → the row says "deadline" and no more.
+    const scalar = (frontmatter['deadline'] ?? frontmatter['due'] ?? '').trim();
+    if (scalar !== '') {
+      const action = (frontmatter['next_action'] ?? frontmatter['nextAction'] ?? '').trim();
+      raw.push({ date: scalar, action: action === '' ? 'deadline' : action });
+    }
+    for (const entry of raw) {
+      if (isDone(entry)) continue;
+      const date = parseIsoDate(entry['date'] ?? '');
+      if (date === null) {
+        skipped += 1;
+        continue;
+      }
+      const out: DocketEntry = {
+        date: (entry['date'] ?? '').trim(),
+        action: (entry['action'] ?? '').trim(),
+        matter: { path: matter.path, title: matter.title },
+        status: statusFor(daysUntil(date, now)),
+      };
+      const type = (entry['type'] ?? '').trim();
+      const source = (entry['source'] ?? '').trim();
+      if (type !== '') out.type = type;
+      if (source !== '') out.source = source;
+      deadlines.push(out);
+    }
+  }
+  deadlines.sort((a, b) => a.date.localeCompare(b.date) || a.matter.title.localeCompare(b.matter.title));
+  return { deadlines, skipped };
+}
+
+async function listOr(vault: VaultStore, tenant: Tenant, dir: string): Promise<Entry[]> {
+  try {
+    return await vault.list(tenant, dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'ENOTDIR') return [];
+    throw err;
+  }
+}
+
+/**
+ * The matters the sweep reads: the SAME discovery and bounds as the
+ * overview (newest `MAX_MATTERS` markdown files under the matters dir; a
+ * file over `MAX_MATTER_BYTES` is not read), so the docket can never name a
+ * matter the home page does not list. Every matter file counts — a note
+ * without `counsel-os-type: matter` still carries dates a lawyer cares
+ * about, and the home page lists it too.
+ */
+export async function vaultDocket(vault: VaultStore, tenant: Tenant, cfg: VaultConfig, now: Date = new Date()): Promise<DocketView> {
+  const candidates = (await listOr(vault, tenant, cfg.mattersPath))
+    .filter(entry => entry.kind === 'file' && entry.path.endsWith('.md'))
+    .filter(entry => entry.size === undefined || entry.size <= MAX_MATTER_BYTES)
+    .sort((a, b) => (b.mtimeMs ?? 0) - (a.mtimeMs ?? 0))
+    .slice(0, MAX_MATTERS);
+  const matters: DocketMatter[] = [];
+  for (const entry of candidates) {
+    let source: string;
+    try {
+      source = await vault.read(tenant, entry.path);
+    } catch {
+      continue; // vanished between list and read — skip, never fail the call
+    }
+    matters.push({ path: entry.path, title: titleOf(source, entry.path), source });
+  }
+  return sweepDocket(matters, now);
+}

--- a/runtime/src/vault/overview.ts
+++ b/runtime/src/vault/overview.ts
@@ -46,29 +46,41 @@ export const MAX_MATTERS = 200;
 export const MAX_MATTER_BYTES = 512 * 1024;
 
 /**
- * Splits `---` frontmatter off a markdown source. `Bun.YAML` (the same
- * parser `providers/registry.ts` trusts) reads the block; anything that is
- * not a flat map of scalars degrades to `{}` rather than failing the
- * listing — a matter with odd frontmatter is still a matter.
+ * The raw text between the `---` fences, and the body after them — `block`
+ * is `null` when the note has no frontmatter. `parseFrontmatter` reads the
+ * block as a flat map; `docket.ts` reads its `deadlines:` list from the
+ * same text, so the two never disagree about where the block ends.
  */
-export function parseFrontmatter(input: string): { frontmatter: Record<string, string>; body: string } {
+export function splitFrontmatterBlock(input: string): { block: string | null; body: string } {
   // A leading BOM would fail the `---` check and hide the whole block.
   // Windows-authored and some Obsidian-exported notes carry one.
   const source = input.charCodeAt(0) === 0xfeff ? input.slice(1) : input;
-  if (!source.startsWith('---\n') && !source.startsWith('---\r\n')) return { frontmatter: {}, body: source };
+  if (!source.startsWith('---\n') && !source.startsWith('---\r\n')) return { block: null, body: source };
   const firstNl = source.indexOf('\n');
   const rest = source.slice(firstNl + 1);
   // The terminator has to BE the line, not just start it: a bare
   // `indexOf('\n---')` let `----` and `--- note` close the block, and would
   // cut a multi-line YAML value short at a `---` in column 0.
   const term = /^---[ \t]*\r?$/m.exec(rest);
-  if (term === null) return { frontmatter: {}, body: source };
+  if (term === null) return { block: null, body: source };
   const afterTerm = term.index + term[0].length;
   const bodyNl = rest.indexOf('\n', afterTerm);
   const body = bodyNl === -1 ? '' : rest.slice(bodyNl + 1);
+  return { block: rest.slice(0, term.index), body };
+}
+
+/**
+ * Splits `---` frontmatter off a markdown source. `Bun.YAML` (the same
+ * parser `providers/registry.ts` trusts) reads the block; anything that is
+ * not a flat map of scalars degrades to `{}` rather than failing the
+ * listing — a matter with odd frontmatter is still a matter.
+ */
+export function parseFrontmatter(input: string): { frontmatter: Record<string, string>; body: string } {
+  const { block, body } = splitFrontmatterBlock(input);
+  if (block === null) return { frontmatter: {}, body };
   let parsed: unknown;
   try {
-    parsed = Bun.YAML.parse(rest.slice(0, term.index));
+    parsed = Bun.YAML.parse(block);
   } catch {
     return { frontmatter: {}, body };
   }

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -197,6 +197,27 @@ export interface PendingProposal {
   at: string;
 }
 
+/** `GET /docket`. COPIED from `runtime/src/vault/docket.ts`; a change there
+ * is a change here. */
+export type DocketStatus = 'overdue' | 'soon' | 'later';
+
+export interface DocketEntry {
+  /** `YYYY-MM-DD`, as written on the matter. */
+  date: string;
+  action: string;
+  type?: string;
+  source?: string;
+  matter: { path: string; title: string };
+  status: DocketStatus;
+}
+
+export interface DocketView {
+  /** Sorted by date, then matter title. */
+  deadlines: DocketEntry[];
+  /** Entries whose date could not be read — counted, never silently dropped. */
+  skipped: number;
+}
+
 /** One hit of `GET /vault/search`. COPIED from `Hit` in
  * `runtime/src/core/types.ts`. */
 export interface VaultHit {

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -612,6 +612,16 @@ a { color: var(--accent); }
 .v2-docket-go::after { content: " →"; }
 /* The bounded-scan hedge: set text under the rows, never a banner. */
 .v2-docket-note { font: italic 12.5px/1.5 var(--serif); color: var(--fg-muted); margin-top: 10px; }
+/* One docket, two groups. The small-caps run-in names a group only when
+   both are present; a deadline row is date · action ···· matter, the date
+   hot when it has passed. "Later" folds behind one set-text line. */
+.v2-docket-sub { margin: 6px 0 2px; font: 600 10.5px/1 var(--sans); letter-spacing: 0.09em; text-transform: uppercase; color: var(--fg-faint); }
+.v2-dl-group { margin-bottom: 6px; }
+.v2-dl-date { font: 600 12.5px var(--sans); color: var(--fg-muted); flex-shrink: 0; min-width: 52px; }
+.v2-dl-action { font: 15px/1.45 var(--serif); color: var(--fg); min-width: 0; }
+.v2-dl-matter { font-size: 12.5px; color: var(--fg-faint); text-decoration: none; flex-shrink: 0; max-width: 40%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-dl-matter:hover { color: var(--fg); text-decoration: underline; }
+.v2-dl-later { display: block; margin: 4px 0 0 64px; font-size: 12.5px; color: var(--fg-muted); }
 /* A read that failed speaks where its own content would have been. */
 .v2-docket-error { margin: 22px 0 0; }
 .v2-home-card .v2-notice { margin: 10px 0 0; font-size: 13px; }

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -72,6 +72,7 @@ function install(opts: { events?: ThreadEvent[] } = {}): void {
     if (url.startsWith('/vault/read')) return json({ path: 'practice/standards/nda.md', content: '# NDA\nTerm: 2 years\n', version: 'abc1234def0', mtimeMs: 1 });
     if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
     if (url.startsWith('/proposals')) return json([]);
+    if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
     if (url.startsWith('/vault/list')) return json([]);
     if (url.startsWith('/settings')) return json(settings);
     const match = /^\/threads\/(.+)$/.exec(url);

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -2,8 +2,8 @@ import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { TOKEN_KEY } from '../../api/token';
-import type { PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
-import { HomePage } from './HomePage';
+import type { DocketView, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import { docketDate, docketHeadParts, HomePage } from './HomePage';
 
 const realFetch = globalThis.fetch;
 
@@ -32,6 +32,7 @@ const overview: VaultOverview = {
 const empty: VaultOverview = { matters: [], groups: { practice: 0, knowledge: 0, other: 0 } };
 
 let pending: PendingProposal[] = [];
+let docketBody: DocketView = { deadlines: [], skipped: 0 };
 let overviewBody: VaultOverview = overview;
 let truncatedHeader = false;
 
@@ -55,6 +56,7 @@ const TRUNCATION_NOTE = 'Older conversations were not scanned — some proposals
 
 beforeEach(() => {
   pending = [];
+  docketBody = { deadlines: [], skipped: 0 };
   overviewBody = overview;
   truncatedHeader = false;
   sessionStorage.setItem(TOKEN_KEY, 'test-token');
@@ -63,6 +65,7 @@ beforeEach(() => {
     const url = String(input);
     if (url.startsWith('/vault/overview')) return json(overviewBody);
     if (url.startsWith('/proposals')) return json(pending, truncatedHeader ? { 'x-counsel-truncated': '1' } : {});
+    if (url.startsWith('/docket')) return json(docketBody);
     if (url.startsWith('/vault/list')) return json([]);
     throw new Error(`unexpected fetch: ${url}`);
   }) as unknown as typeof fetch;
@@ -275,5 +278,100 @@ describe('HomePage matter rows without a deadline (cou-93 item 6)', () => {
     // The row with neither has no slot and no leader pointing at nothing.
     expect(rows[1]!.querySelector('.v2-due')).toBeNull();
     expect(rows[1]!.querySelector('.leader')).toBeNull();
+  });
+});
+
+describe('HomePage, one docket: deadlines + proposals', () => {
+  const iso = (daysFromNow: number): string => {
+    const d = new Date();
+    d.setDate(d.getDate() + daysFromNow);
+    return d.toISOString().slice(0, 10);
+  };
+  const entry = (date: string, action: string, status: DocketView['deadlines'][number]['status'], title = 'Acme — NDA') => ({
+    date,
+    action,
+    matter: { path: `matters/${title.toLowerCase().replace(/[^a-z]+/g, '-')}.md`, title },
+    status,
+  });
+
+  test('deadlines by date, overdue hot, later folded behind one line that unfolds in place', async () => {
+    docketBody = {
+      deadlines: [
+        entry('2020-01-01', 'file the response', 'overdue'),
+        entry(iso(3), 'renewal notice due', 'soon', 'Vendora × Worldpay'),
+        entry(iso(40), 'objection window closes', 'later'),
+        entry(iso(90), 'term ends', 'later', 'Vendora × Worldpay'),
+      ],
+      skipped: 0,
+    };
+    mount();
+    await waitFor(() => expect(document.querySelector('.v2-docket')).toBeTruthy());
+    expect(document.querySelector('.v2-docket-head')?.textContent).toBe('Docket · 4 deadlines');
+    // No proposals, so no group run-ins — one list, no labels to read past.
+    expect(document.querySelector('.v2-docket-sub')).toBeNull();
+
+    const rows = () => Array.from(document.querySelectorAll('.v2-dl'));
+    expect(rows()).toHaveLength(2);
+    expect(rows()[0]!.querySelector('.v2-dl-date')?.className).toContain('v2-due-hot');
+    expect(rows()[0]!.querySelector('.v2-dl-date')?.textContent).toBe('Jan 1, 2020');
+    expect(rows()[0]!.querySelector('.v2-dl-action')?.textContent).toBe('file the response');
+    expect(rows()[0]!.querySelector('a.v2-dl-matter')?.getAttribute('href')).toBe('#/vault?path=matters%2Facme-nda.md');
+    expect(rows()[1]!.querySelector('.v2-dl-date')?.className).not.toContain('v2-due-hot');
+
+    const fold = screen.getByRole('button', { name: '2 later →' });
+    await userEvent.click(fold);
+    expect(rows()).toHaveLength(4);
+    expect(screen.queryByRole('button', { name: '2 later →' })).toBeNull();
+    expect(rows()[3]!.querySelector('.v2-dl-action')?.textContent).toBe('term ends');
+  });
+
+  test('deadlines and proposals share the docket, each under its run-in', async () => {
+    docketBody = { deadlines: [entry(iso(2), 'renewal notice due', 'soon')], skipped: 1 };
+    pending = [proposal];
+    mount();
+    await waitFor(() => expect(document.querySelector('.v2-docket')).toBeTruthy());
+    expect(document.querySelector('.v2-docket-head')?.textContent).toBe('Docket · 1 deadline · 1 awaiting your decision');
+    expect(Array.from(document.querySelectorAll('.v2-docket-sub'), el => el.textContent)).toEqual(['Deadlines', 'Awaiting your decision']);
+    // The proposal row is unchanged, Review still anchors.
+    expect(screen.getByText('Record the narrow residuals carve-out as your NDA fallback')).toBeTruthy();
+    await userEvent.click(screen.getByRole('button', { name: 'Review' }));
+    expect(location.hash).toBe('#/chat?thread=t-1&proposal=p-1');
+    // A malformed date is a number on the page, never a silent absence.
+    expect(document.querySelector('.v2-dl-group .v2-docket-note')?.textContent).toContain('1 deadline could not be read');
+  });
+
+  test('a failed deadline sweep says so and leaves the proposals standing', async () => {
+    pending = [proposal];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.startsWith('/docket')) return new Response('nope', { status: 500 });
+      if (url.startsWith('/proposals')) return json(pending);
+      if (url.startsWith('/vault/overview')) return json(overviewBody);
+      return json([]);
+    }) as unknown as typeof fetch;
+    mount();
+    await waitFor(() => expect(document.querySelector('.v2-docket')).toBeTruthy());
+    expect(document.querySelector('.v2-docket-head')?.textContent).toBe('Docket · 1 awaiting your decision');
+    expect(screen.getByRole('alert').textContent).toContain('could not read the deadlines');
+    expect(screen.getByText('Record the narrow residuals carve-out as your NDA fallback')).toBeTruthy();
+  });
+
+  test('an older runtime that answers /docket in another shape is no deadlines, not a crash', async () => {
+    docketBody = [] as unknown as DocketView;
+    pending = [proposal];
+    mount();
+    await waitFor(() => expect(document.querySelector('.v2-docket')).toBeTruthy());
+    expect(document.querySelectorAll('.v2-dl')).toHaveLength(0);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+
+  test('docketDate and docketHeadParts', () => {
+    const now = new Date('2026-09-01T12:00:00');
+    expect(docketDate('2026-09-12', now)).toBe('Sep 12');
+    expect(docketDate('2027-01-05', now)).toBe('Jan 5, 2027');
+    expect(docketDate('garbage', now)).toBe('garbage');
+    expect(docketHeadParts(0, 0)).toEqual([]);
+    expect(docketHeadParts(1, 0)).toEqual(['1 deadline']);
+    expect(docketHeadParts(3, 2)).toEqual(['3 deadlines', '2 awaiting your decision']);
   });
 });

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, fetchJsonWithHeaders } from '../../api/client';
-import type { PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import type { DocketEntry, DocketView, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
 import { Tree } from '../../vault/Tree';
 import { railLabel } from '../Rail';
 import { relTime } from '../time';
@@ -23,6 +23,33 @@ const TRUNCATED_HEADER = 'x-counsel-truncated';
  * itself caps at 200 ("a recent docket, not an archive"); a 200-row column
  * under the ask box is an archive. */
 const MAX_MATTERS = 8;
+
+/** `Sep 12`, or `Jan 5, 2027` once the year is not this one. The date is a
+ * bare `YYYY-MM-DD`, read in UTC so it prints as written everywhere. */
+export function docketDate(iso: string, now: Date = new Date()): string {
+  const t = Date.parse(`${iso}T00:00:00Z`);
+  if (Number.isNaN(t)) return iso;
+  const d = new Date(t);
+  const sameYear = d.getUTCFullYear() === now.getFullYear();
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', ...(sameYear ? {} : { year: 'numeric' }), timeZone: 'UTC' });
+}
+
+/** The docket head's run-in: each non-zero part, joined. */
+export function docketHeadParts(deadlines: number, proposals: number): string[] {
+  const parts: string[] = [];
+  if (deadlines > 0) parts.push(`${deadlines} deadline${deadlines === 1 ? '' : 's'}`);
+  if (proposals > 0) parts.push(`${proposals} awaiting your decision`);
+  return parts;
+}
+
+/** The docket body, or nothing usable. A read that came back in another
+ * shape (an older runtime without the route answers with the HTML shell,
+ * a mock answers with `[]`) is treated as no deadlines, not as a crash. */
+function docketOf(value: unknown): DocketView {
+  const view = value as Partial<DocketView> | null;
+  if (typeof view !== 'object' || view === null || !Array.isArray(view.deadlines)) return { deadlines: [], skipped: 0 };
+  return { deadlines: view.deadlines, skipped: typeof view.skipped === 'number' ? view.skipped : 0 };
+}
 
 /** A read that failed, said plainly. A 401 is the shell's message to give,
  * not this page's, so it is silent here. */
@@ -53,38 +80,65 @@ export interface HomePageProps {
 export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.Element {
   const [overview, setOverview] = useState<VaultOverview | null>(null);
   const [pending, setPending] = useState<PendingProposal[]>([]);
-  /** The docket scan was bounded — there may be proposals it never saw. */
+  /** The proposal scan was bounded — there may be proposals it never saw. */
   const [truncated, setTruncated] = useState(false);
+  /** The deadline sweep (`GET /docket`): dated obligations off the matters. */
+  const [docket, setDocket] = useState<DocketView>({ deadlines: [], skipped: 0 });
+  /** The "later" group unfolds in place; it starts folded. */
+  const [laterOpen, setLaterOpen] = useState(false);
   const [vaultError, setVaultError] = useState<string | null>(null);
   const [docketError, setDocketError] = useState<string | null>(null);
+  const [deadlinesError, setDeadlinesError] = useState<string | null>(null);
   const [text, setText] = useState('');
   const [attached, setAttached] = useState<string[]>([]);
   const [picking, setPicking] = useState(false);
   const box = useRef<HTMLTextAreaElement | null>(null);
 
   /**
-   * The two reads settle INDEPENDENTLY. They answer different questions and
-   * one failing says nothing about the other: a docket that cannot be read
-   * must not blank the matters column (which would then assert an empty
-   * vault), and a vault that cannot be read must not take a founder gate off
-   * the page.
+   * The three reads settle INDEPENDENTLY. They answer different questions
+   * and one failing says nothing about the others: a docket that cannot be
+   * read must not blank the matters column (which would then assert an
+   * empty vault), a vault that cannot be read must not take a founder gate
+   * off the page, and a deadline sweep that fails must not hide the
+   * proposals that did load.
    */
   useEffect(() => {
     void (async () => {
-      const [ov, docket] = await Promise.allSettled([
+      const [ov, proposals, sweep] = await Promise.allSettled([
         fetchJson<VaultOverview>('/vault/overview'),
         fetchJsonWithHeaders<PendingProposal[]>('/proposals?status=pending'),
+        fetchJson<unknown>('/docket'),
       ]);
       if (ov.status === 'fulfilled') setOverview(ov.value);
       else setVaultError(failureNote(ov.reason, 'could not read the vault'));
-      if (docket.status === 'fulfilled') {
-        setPending(docket.value.body);
-        setTruncated(docket.value.headers.get(TRUNCATED_HEADER) !== null);
+      if (proposals.status === 'fulfilled') {
+        setPending(proposals.value.body);
+        setTruncated(proposals.value.headers.get(TRUNCATED_HEADER) !== null);
       } else {
-        setDocketError(failureNote(docket.reason, 'could not read the docket'));
+        setDocketError(failureNote(proposals.reason, 'could not read the docket'));
       }
+      if (sweep.status === 'fulfilled') setDocket(docketOf(sweep.value));
+      else setDeadlinesError(failureNote(sweep.reason, 'could not read the deadlines'));
     })();
   }, []);
+
+  const overdueOrSoon = docket.deadlines.filter(d => d.status !== 'later');
+  const later = docket.deadlines.filter(d => d.status === 'later');
+  const headParts = docketHeadParts(docket.deadlines.length, pending.length);
+  const bothGroups = docket.deadlines.length > 0 && pending.length > 0;
+
+  const deadlineRow = (entry: DocketEntry): JSX.Element => (
+    <div className="v2-docket-row v2-dl" key={`${entry.matter.path}|${entry.date}|${entry.action}`}>
+      <span className={entry.status === 'overdue' ? 'v2-dl-date v2-due-hot' : 'v2-dl-date'}>{docketDate(entry.date)}</span>
+      <span className="v2-dl-action" title={entry.source === undefined ? undefined : entry.source}>
+        {entry.action === '' ? 'deadline' : entry.action}
+      </span>
+      <span className="leader" aria-hidden="true" />
+      <a className="v2-dl-matter" href={`#/vault?path=${encodeURIComponent(entry.matter.path)}`}>
+        {entry.matter.title}
+      </a>
+    </div>
+  );
 
   const matters = overview === null ? [] : sortMatters(overview.matters);
   const nextActions = matters.filter(m => nextActionOf(m.frontmatter) !== null).length;
@@ -166,12 +220,47 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
             {docketError}
           </p>
         )}
+        {deadlinesError === null ? null : (
+          <p className="v2-notice v2-notice-error v2-docket-error" role="alert">
+            {deadlinesError}
+          </p>
+        )}
 
-        {pending.length === 0 ? null : (
+        {/* ONE docket: the dated obligations off the matter files, then the
+            proposals awaiting the founder's decision. Hidden when both are
+            empty. */}
+        {headParts.length === 0 ? null : (
           <section className="v2-docket" aria-label="Docket">
             <div className="v2-docket-head runin">
-              Docket · <em>{pending.length} awaiting your decision</em>
+              Docket
+              {headParts.map(part => (
+                <span key={part}>
+                  {' · '}
+                  <em>{part}</em>
+                </span>
+              ))}
             </div>
+
+            {docket.deadlines.length === 0 ? null : (
+              <div className="v2-dl-group">
+                {bothGroups ? <div className="v2-docket-sub">Deadlines</div> : null}
+                {overdueOrSoon.map(deadlineRow)}
+                {later.length === 0 ? null : laterOpen ? (
+                  later.map(deadlineRow)
+                ) : (
+                  <button type="button" className="v2-link v2-dl-later" aria-expanded={false} onClick={() => setLaterOpen(true)}>
+                    {later.length} later →
+                  </button>
+                )}
+                {docket.skipped === 0 ? null : (
+                  <p className="v2-docket-note">
+                    {docket.skipped} deadline{docket.skipped === 1 ? '' : 's'} could not be read — the date is not YYYY-MM-DD.
+                  </p>
+                )}
+              </div>
+            )}
+
+            {bothGroups ? <div className="v2-docket-sub">Awaiting your decision</div> : null}
             {pending.map(proposal => (
               <div className="v2-docket-row" key={proposal.id}>
                 <div>

--- a/skills/docket/SKILL.md
+++ b/skills/docket/SKILL.md
@@ -74,7 +74,7 @@ deadlines:
     done: false                # optional: true drops it from the sweep, kept for audit
 ```
 
-`read` proposes these entries whenever it extracts key dates from a contract, and `remember --matter` persists them. If a user's matters have no `deadlines:` blocks yet, the sweep comes back empty — tell them the feature captures dates as `read` encounters them, and offer to backfill a matter's known dates now.
+`read` proposes these entries whenever it extracts key dates from a contract, and `remember --matter` persists them. The runtime's web UI (`counsel-os serve`) sweeps the same `deadlines:` blocks itself (`GET /docket`, TypeScript, no Python) and shows them on Home as the Docket, beside the proposals awaiting a decision — one docket, two front ends. If a user's matters have no `deadlines:` blocks yet, the sweep comes back empty — tell them the feature captures dates as `read` encounters them, and offer to backfill a matter's known dates now.
 
 ## Cowork / no-shell runtimes
 


### PR DESCRIPTION
Pair-built per founder direction (the board task cou-94 was cancelled; QA reviews the pair's work).

**Why.** Two things were called "docket": Home's list of proposals awaiting a decision, and the plugin's `/counsel-os:docket` sweep of `deadlines:` frontmatter (`scripts/docket_sweep.py`). A lawyer expects one. The standalone app cannot assume Python, so the sweep now lives in the runtime, in TypeScript.

**Runtime**
- `runtime/src/vault/docket.ts` — `parseDeadlineEntries` reads the `deadlines:` block exactly as the Python sweep does (block sequence of mappings, first field allowed on the dash line, `done`/`status` hides an entry). The scalar `deadline:` / `due:` key the home page already reads counts as one entry whose action is the matter's next action. `sweepDocket` is pure: sorted by date then matter title; status `overdue` / `soon` (within 14 calendar days, the home page's own edge) / `later`; an unreadable date is **counted** in `skipped`, never dropped silently. `vaultDocket` reuses the overview's matter discovery and bounds.
- `overview.ts` — `splitFrontmatterBlock` factored out of `parseFrontmatter` so both readers agree on where the block ends.
- `GET /docket` → `{ deadlines, skipped }`; `docket` added to `API_PREFIXES` (token-gated).

**UI**
- Home's Docket is one docket: `Docket · n deadlines · m awaiting your decision` (zero parts omitted). Deadline rows: date · action ···· matter (linked to the file); overdue dates hot; next 14 days plain; anything later folded behind one `k later →` set-text line that unfolds in place. Then the proposal rows, unchanged (Review → still anchors). Small-caps run-ins (`Deadlines`, `Awaiting your decision`) only when both groups are present. Ledger language kept: no pills, no accent panels.
- A failed sweep says so in the existing notice style and leaves the proposals standing; an older runtime answering `/docket` in another shape reads as no deadlines.
- `skills/docket/SKILL.md` notes the runtime's web UI shows the same docket on Home. The Python skill is unchanged (it remains the Claude Code front end).

**Decisions the brief left open**
- Every matter file is swept, not only `counsel-os-type: matter` (the Python sweep filters on that; Home's matters column does not, and the docket must never name a matter Home does not list).
- Done entries are hidden silently (by design, as the Python sweep does); only malformed dates are counted.
- The inline `[{...}]` list form is not accepted — the Python sweep does not accept it either.

**Tests.** `bun run test` 623 pass · `bun run ui:test` 351 pass · both typechecks clean. New: `docket.test.ts` (parser shapes, bad dates, scalar key, ordering, the 14-day edge), a `routes.test.ts` case (`/docket`, 401, empty vault), five `HomePage.test.tsx` cases (fold/unfold, hot overdue, both groups + skipped note, failed sweep, odd shape).