### PR TITLE
ui: provider-not-available notice at the composer; humanized step failures with Retry

### DIFF
--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -250,6 +250,12 @@ a { color: var(--accent); }
 .v2-notice { padding: var(--s2) var(--s3); border-radius: var(--radius); border: 1px solid currentColor; margin: var(--s2) var(--s4); }
 .v2-notice p:last-child { margin-bottom: 0; }
 .v2-notice-error { color: var(--error); }
+/* The swap notice (cou-95): one faint line of set text, no box, no pill. */
+.v2-swap-notice { margin: 0 0 8px; font-size: 12.5px; color: var(--fg-faint); }
+.v2-swap-notice a { margin-left: 8px; color: var(--fg-muted); }
+.v2-step-failure p { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
+.v2-retry { background: none; border: 1px solid currentColor; border-radius: var(--radius); color: inherit; font: inherit; font-size: 12.5px; padding: 1px 9px; cursor: pointer; }
+.v2-error-raw { font: 12.5px var(--mono); color: var(--fg-muted); margin: 6px 0 0; word-break: break-word; }
 .v2-notice-warn { color: var(--warn); }
 /* Quiet, not alarming: a dead `?thread=` is a fact to state, not an error. */
 .v2-notfound { margin: var(--s3) var(--s6) 0; font-style: italic; }

--- a/runtime/ui/src/v2/ProviderNotice.tsx
+++ b/runtime/ui/src/v2/ProviderNotice.tsx
@@ -1,0 +1,22 @@
+import type { Health } from '../api/types';
+import { swapPlates } from './plate';
+
+/**
+ * The swap, said where the lawyer is about to act (cou-95): the saved
+ * default is not loaded, so the next send goes elsewhere. Set text, faint,
+ * no box, no pill, no icon — and nothing at all when everything is fine.
+ * Sits above the composer and above Home's ask box.
+ */
+export function ProviderNotice({ health }: { health: Health | null | undefined }): JSX.Element | null {
+  const swap = swapPlates(health ?? null);
+  if (swap === null) return null;
+  const saved = swap.saved.vendor;
+  return (
+    <p className="v2-swap-notice" role="status">
+      {swap.effective === null
+        ? `${saved} is not available, and no other model is loaded.`
+        : `${saved} is not available. Counsel will answer on ${swap.effective.vendor} (${swap.effective.model}).`}
+      <a href="#/settings">change</a>
+    </p>
+  );
+}

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -413,7 +413,7 @@ export function Shell(): JSX.Element {
           ) : null}
         </div>
 
-        {route === 'home' ? <HomePage threads={threads} onAsk={startAsk} onOpenThread={openThread} /> : null}
+        {route === 'home' ? <HomePage threads={threads} onAsk={startAsk} onOpenThread={openThread} health={health} /> : null}
 
         {route === 'vault' ? (
           <VaultPage

--- a/runtime/ui/src/v2/chat/Chat.test.tsx
+++ b/runtime/ui/src/v2/chat/Chat.test.tsx
@@ -406,3 +406,24 @@ describe('v2 Chat, the docket anchor', () => {
     }
   });
 });
+
+describe('v2 Chat, retrying a failed step (cou-95)', () => {
+  test('Retry on the last failed turn sends the same message again on the default provider', async () => {
+    install(async () =>
+      json(
+        thread('t-1', [
+          { t: 'user', at, content: QUESTION },
+          { t: 'step', at, runId: 'r-1', provider: 'fake/fake' },
+          { type: 'error', at, message: 'claude harness: Not logged in · Please run /login' },
+        ]),
+      ),
+    );
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    await waitFor(() => expect(calls.some(c => c.method === 'POST' && c.url.endsWith('/steps'))).toBe(true));
+    const step = calls.find(c => c.method === 'POST' && c.url.endsWith('/steps'))!;
+    expect((step.body as { message: string; provider: string }).message).toBe(QUESTION);
+    expect((step.body as { message: string; provider: string }).provider).toBe('fake/fake');
+  });
+});

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -358,6 +358,13 @@ export function Chat({
 
   const matterPath = thread === null ? null : matterPathOf(thread.events);
 
+  /** Retry for a step that FAILED (cou-95): send the last user message
+   * again, on the default provider, the way the composer would. Only the
+   * transcript's final assistant turn offers it — an older failure has
+   * been answered since. */
+  const lastUser = [...turns].reverse().find((turn): turn is Extract<Turn, { kind: 'user' }> => turn.kind === 'user');
+  const retryLast = lastUser === undefined ? undefined : (): void => void send(lastUser.content, defaultProviderId(health));
+
   /**
    * The matter's REAL title for the header (cou-93 item 7): a slug
    * prettified (`Sinai lerner k12 partnership`) is not what the lawyer calls
@@ -418,6 +425,7 @@ export function Chat({
             onDecided={decided}
             onOpenFile={onOpenFile}
             vaultPaths={vaultPaths}
+            {...(i === turns.length - 1 && turn.kind === 'assistant' && turn.error !== undefined && !streaming ? { onRetry: retryLast } : {})}
           />
         ))}
         {frozen.map((turn, i) => (
@@ -440,6 +448,7 @@ export function Chat({
 
       <Composer
         streaming={streaming}
+        health={health}
         seed={seed}
         onSeedUsed={onSeedUsed}
         onSend={message => void send(message, defaultProviderId(health))}

--- a/runtime/ui/src/v2/chat/Composer.test.tsx
+++ b/runtime/ui/src/v2/chat/Composer.test.tsx
@@ -1,7 +1,17 @@
 import { cleanup, fireEvent, render, screen, userEvent } from '../../test/dom';
 
 import { afterEach, describe, expect, test } from 'bun:test';
+import type { Health } from '../../api/types';
 import { Composer } from './Composer';
+
+const amber: Health = {
+  vault: '/tmp/vault',
+  tenant: 'default',
+  default: 'claude-sub/claude-opus-5',
+  stepTimeoutMs: 600_000,
+  providers: [{ id: 'ollama/gemma4:e4b', kind: 'direct', auth: 'local', capabilities: { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'local' } }],
+};
+const fine: Health = { ...amber, default: 'ollama/gemma4:e4b' };
 
 function noop(): void {}
 
@@ -62,5 +72,23 @@ describe('v2 Composer', () => {
     expect((screen.getByLabelText('Message') as HTMLTextAreaElement).disabled).toBe(true);
     await userEvent.click(screen.getByRole('button', { name: 'Stop' }));
     expect(stopped).toBe(1);
+  });
+});
+
+describe('v2 Composer swap notice (cou-95)', () => {
+  test('says which model will answer when the saved default is not loaded, and links to Settings', () => {
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={amber} />);
+    const notice = screen.getByRole('status');
+    expect(notice.textContent).toBe('Claude is not available. Counsel will answer on Ollama (gemma4:e4b).change');
+    expect(notice.querySelector('a')?.getAttribute('href')).toBe('#/settings');
+    expect(notice.className).toContain('v2-swap-notice');
+  });
+
+  test('silent when the default is loaded, or health is not in yet', () => {
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={fine} />);
+    expect(screen.queryByRole('status')).toBeNull();
+    cleanup();
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={null} />);
+    expect(screen.queryByRole('status')).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/chat/Composer.tsx
+++ b/runtime/ui/src/v2/chat/Composer.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
+import type { Health } from '../../api/types';
+import { ProviderNotice } from '../ProviderNotice';
 
 /** A prefill pushed in from outside — the vault's "Ask counsel about this
  * file" (spec §3.4). The nonce distinguishes two asks about the same file. */
@@ -19,6 +21,10 @@ export interface ComposerProps {
    * drop it — a seed still in the parent's state would refill the box on the
    * next remount. */
   onSeedUsed?: () => void;
+  /** For the swap notice above the box (cou-95): shown only when the saved
+   * default is not loaded, so the reader learns which model will answer
+   * BEFORE sending. Absent = no notice. */
+  health?: Health | null;
 }
 
 /**
@@ -30,7 +36,7 @@ export interface ComposerProps {
  * picker under every message asked the reader to make a choice they had
  * already made once, in the one place that remembers it.
  */
-export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed }: ComposerProps): JSX.Element {
+export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed, health }: ComposerProps): JSX.Element {
   const [message, setMessage] = useState('');
   // Derived-from-props during render (React's own pattern), not an effect:
   // an effect would paint the empty box first and steal a keystroke typed
@@ -63,6 +69,7 @@ export function Composer({ streaming, disabled = false, onSend, onStop, seed, on
         send();
       }}
     >
+      <ProviderNotice health={health} />
       <div className="v2-composer-box">
         <textarea
           aria-label="Message"

--- a/runtime/ui/src/v2/chat/Turn.test.tsx
+++ b/runtime/ui/src/v2/chat/Turn.test.tsx
@@ -60,7 +60,8 @@ describe('TurnView prose', () => {
         onReload={() => {}}
       />,
     );
-    expect(screen.getByText('the model returned no answer')).toBeTruthy();
+    // Humanized in front, the provider's own words kept (cou-95).
+    expect(screen.getByText(/the model returned no answer/)).toBeTruthy();
     expect(document.querySelector('.v2-notice-error pre')?.textContent).toBe('**not markdown**');
   });
 });
@@ -198,5 +199,32 @@ describe('TurnView vault-index chips (cou-93 item 8)', () => {
     const turn: AssistantTurn = emptyAssistantTurn({ status: 'done', text: 'See `matters/acme.md`.' });
     render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} onOpenFile={() => {}} />);
     expect(document.querySelector('.v2-prose code.v2-cite')).toBeNull();
+  });
+});
+
+describe('TurnView step failure (cou-95)', () => {
+  test('the provider\'s words become a plain line; the original stays under details; Retry sends again', async () => {
+    let retried = 0;
+    const turn = emptyAssistantTurn({
+      status: 'error',
+      provider: 'claude-sub/claude-opus-5',
+      error: { message: 'claude harness: Not logged in · Please run /login' },
+    });
+    render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} onRetry={() => { retried += 1; }} />);
+    const notice = document.querySelector('.v2-step-failure')!;
+    expect(notice.querySelector('p')?.textContent).toContain('Claude did not answer: your Claude login has expired. Run `claude login` in a terminal, then retry.');
+    expect(notice.querySelector('details summary')?.textContent).toBe('show details');
+    expect(notice.querySelector('.v2-error-raw')?.textContent).toBe('claude harness: Not logged in · Please run /login');
+    await userEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(retried).toBe(1);
+  });
+
+  test('no Retry when the chat offers none; a partial answer keeps "show answer"', () => {
+    const turn = emptyAssistantTurn({ status: 'error', provider: 'ollama/gemma4:e4b', error: { message: 'fetch failed', text: 'partial' } });
+    render(<TurnView turn={turn} threadId="t-1" onReload={() => {}} />);
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    expect(document.querySelector('.v2-step-failure p')?.textContent).toBe('Ollama is not running on this machine. Start it, then retry.');
+    expect(document.querySelector('details summary')?.textContent).toBe('show answer');
+    expect(document.querySelector('details pre')?.textContent).toBe('partial');
   });
 });

--- a/runtime/ui/src/v2/chat/Turn.tsx
+++ b/runtime/ui/src/v2/chat/Turn.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import type { RunRecord } from '../../api/types';
 import type { ToolCallView, Turn } from '../../chat/turns';
 import { renderMarkdown } from '../../vault/markdown';
+import { humanizeStepError } from '../errors';
 import { citationMap, markCitations, readPathsOf } from './cite';
 import { ProposalCard } from './ProposalCard';
 import { Strip } from './Strip';
@@ -24,6 +25,8 @@ export interface TurnProps {
    * names becomes a click target when it is one of these (cou-93 item 8) —
    * the second gate beside the derivation set, never a third source. */
   vaultPaths?: ReadonlySet<string>;
+  /** Offered on a turn whose step FAILED: sends the same message again. */
+  onRetry?: () => void;
 }
 
 /** The record's per-call timings, keyed onto this turn's tool ids. The
@@ -109,12 +112,49 @@ function Prose({
 }
 
 /**
+ * A failed step, said plainly (cou-95): the humanized line, Retry when the
+ * chat offers one, and the provider's original words (and any partial
+ * answer) folded under "show details" — never lost, never leading.
+ */
+function StepFailure({
+  error,
+  providerId,
+  onRetry,
+}: {
+  error: { message: string; text?: string };
+  providerId: string;
+  onRetry?: () => void;
+}): JSX.Element {
+  const human = humanizeStepError(error.message, providerId);
+  const hasDetail = human.detail !== undefined || error.text !== undefined;
+  return (
+    <div className="v2-notice v2-notice-error v2-step-failure" role="alert">
+      <p>
+        {human.line}
+        {onRetry === undefined ? null : (
+          <button type="button" className="v2-retry" onClick={onRetry}>
+            Retry
+          </button>
+        )}
+      </p>
+      {hasDetail ? (
+        <details>
+          <summary>{error.text === undefined ? 'show details' : 'show answer'}</summary>
+          {human.detail === undefined ? null : <p className="v2-error-raw">{human.detail}</p>}
+          {error.text === undefined ? null : <pre>{error.text}</pre>}
+        </details>
+      ) : null}
+    </div>
+  );
+}
+
+/**
  * One turn (spec §3.3): a user bubble, or the quiet work line, the
  * assistant's answer, its proposal slips, then the strip. The work line runs
  * above the text on both paths, so the reader sees the work as it happens
  * and can still find it after the answer lands.
  */
-export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onReload, onDecided, onOpenFile, vaultPaths }: TurnProps): JSX.Element {
+export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onReload, onDecided, onOpenFile, vaultPaths, onRetry }: TurnProps): JSX.Element {
   if (turn.kind === 'user') {
     return (
       <article className="v2-turn v2-turn-user">
@@ -154,17 +194,7 @@ export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onRel
 
           {/* The turn owns its error text: it reads here, unfolded, and the
               strip's record leaves out the identical copy it holds. */}
-          {turn.error === undefined ? null : (
-            <div className="v2-notice v2-notice-error" role="alert">
-              <p>{turn.error.message}</p>
-              {turn.error.text === undefined ? null : (
-                <details>
-                  <summary>show answer</summary>
-                  <pre>{turn.error.text}</pre>
-                </details>
-              )}
-            </div>
-          )}
+          {turn.error === undefined ? null : <StepFailure error={turn.error} providerId={turn.provider ?? ''} onRetry={onRetry} />}
 
           {threadId === null
             ? null

--- a/runtime/ui/src/v2/errors.test.ts
+++ b/runtime/ui/src/v2/errors.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { humanizeStepError } from './errors';
+
+const CLAUDE = 'claude-sub/claude-opus-5';
+const CODEX = 'codex-sub/gpt-5.6-terra';
+const OLLAMA = 'ollama/gemma4:e4b';
+
+describe('humanizeStepError', () => {
+  test('the runtime\'s own shapes', () => {
+    expect(humanizeStepError('step timed out after 600s', CLAUDE).line).toBe(
+      'The step ran past its 10-minute limit. Ask something smaller, or raise the step timeout in Settings.',
+    );
+    expect(humanizeStepError('step timed out after 45s', CLAUDE).line).toContain('45-second limit');
+    expect(humanizeStepError("system prompt exceeds the provider's context window (40000 > 32000)", OLLAMA).line).toBe(
+      'Ollama could not take this much at once: the instructions and the document together exceed its context window.',
+    );
+    expect(humanizeStepError('unknown provider: openai/gpt-5.6', 'openai/gpt-5.6').line).toBe(
+      'No provider called openai/gpt-5.6 is loaded. Pick one in Settings, then retry.',
+    );
+    expect(humanizeStepError('unknown thread: t-9', CLAUDE).line).toContain('no longer exists');
+    expect(humanizeStepError('claude-sub/claude-opus-5 ended the step without a done or error event', CLAUDE).line).toBe('Claude stopped without answering. Retry.');
+    expect(humanizeStepError('structured output failed validation: expected number', CODEX).line).toContain('ChatGPT answered in the wrong shape');
+  });
+
+  test('the Claude harness: login, CLI missing, busy', () => {
+    expect(humanizeStepError('claude harness: Not logged in · Please run /login', CLAUDE)).toEqual({
+      line: 'Claude did not answer: your Claude login has expired. Run `claude login` in a terminal, then retry.',
+      detail: 'claude harness: Not logged in · Please run /login',
+    });
+    expect(humanizeStepError('claude harness: spawn claude ENOENT', CLAUDE).line).toContain('Claude Code CLI is not installed');
+    expect(humanizeStepError('claude harness: error_max_turns', CLAUDE).line).toContain('too many tool calls');
+    expect(humanizeStepError('claude harness: 429 rate_limit_error', CLAUDE).line).toBe('Claude is busy right now. Retry in a moment.');
+  });
+
+  test('the Codex harness and Ollama', () => {
+    expect(humanizeStepError('codex harness: not authenticated', CODEX).line).toContain('Run `codex login`');
+    expect(humanizeStepError('codex harness: spawn codex ENOENT', CODEX).line).toContain('Codex CLI is not installed');
+    expect(humanizeStepError('fetch failed', OLLAMA).line).toBe('Ollama is not running on this machine. Start it, then retry.');
+    expect(humanizeStepError('connect ECONNREFUSED 127.0.0.1:11434', OLLAMA).line).toContain('Ollama is not running');
+    expect(humanizeStepError("model 'gemma4:e4b' not found, try pulling it first", OLLAMA).line).toBe(
+      'Ollama does not have the model gemma4:e4b. Run `ollama pull gemma4:e4b`, then retry.',
+    );
+  });
+
+  test('API-key providers', () => {
+    expect(humanizeStepError('401 invalid x-api-key', 'anthropic/claude-opus-5').line).toContain('Claude did not answer: the API key was rejected');
+    expect(humanizeStepError('Incorrect API key provided', 'openai/gpt-5.6').line).toContain('OpenAI did not answer: the API key was rejected');
+    expect(humanizeStepError('429 Too Many Requests', 'openai/gpt-5.6').line).toBe('OpenAI is busy right now. Retry in a moment.');
+  });
+
+  test('anything unmatched keeps the original words, with the vendor in front', () => {
+    expect(humanizeStepError('something odd happened', CLAUDE)).toEqual({ line: 'Claude did not answer: something odd happened' });
+    // No provider recorded: "Counsel", never an invented vendor.
+    expect(humanizeStepError('something odd happened', '')).toEqual({ line: 'Counsel did not answer: something odd happened' });
+    // An unknown vendor is named by its raw id.
+    expect(humanizeStepError('boom', 'acme/model-1').line).toBe('acme/model-1 did not answer: boom');
+  });
+
+  test('detail is the original text only when the line does not already carry it', () => {
+    expect(humanizeStepError('boom', CLAUDE).detail).toBeUndefined();
+    expect(humanizeStepError('step timed out after 600s', CLAUDE).detail).toBe('step timed out after 600s');
+  });
+});

--- a/runtime/ui/src/v2/errors.ts
+++ b/runtime/ui/src/v2/errors.ts
@@ -1,0 +1,106 @@
+import { plateFor } from './plate';
+
+/**
+ * A step failure, said plainly (cou-95).
+ *
+ * The runtime's error events carry the provider's own words — `claude
+ * harness: Not logged in · Please run /login`, `step timed out after 600s`,
+ * `fetch failed` — which tell a lawyer nothing about what to do. The `line`
+ * is what the turn shows; `detail` is the original text, kept one click away
+ * whenever the line does not already contain it. Matching is by the strings
+ * the runtime actually produces (`runtime/src/loop/counsel-loop.ts`,
+ * `runtime/src/providers/*.ts`) and by what the SDKs and CLIs are known to
+ * say; anything unmatched falls back to `<Vendor> did not answer: <text>`,
+ * so nothing is ever hidden behind a guess.
+ */
+export interface HumanError {
+  line: string;
+  detail?: string;
+}
+
+/** The vendor a lawyer knows, or "Counsel" when the turn never named one
+ * (a step that failed before its provider was recorded). */
+function vendorOf(providerId: string): string {
+  if (providerId === '') return 'Counsel';
+  const plate = plateFor(providerId);
+  return plate.known ? plate.vendor : providerId;
+}
+
+function prefixOf(providerId: string): string {
+  const slash = providerId.indexOf('/');
+  return slash === -1 ? providerId : providerId.slice(0, slash);
+}
+
+function modelOf(providerId: string): string {
+  const slash = providerId.indexOf('/');
+  return slash === -1 ? providerId : providerId.slice(slash + 1);
+}
+
+const TIMEOUT = /step timed out after (\d+)s/;
+const CONTEXT = /exceeds the provider's context window/;
+const UNKNOWN_PROVIDER = /unknown provider: (\S+)/;
+const UNKNOWN_THREAD = /^unknown thread: /;
+const NO_TERMINAL = /ended the step without a done or error event/;
+const SHAPE = /structured output/;
+const LOGIN = /not logged in|please run \/login|\/login|login expired|oauth|not authenticated/i;
+const API_KEY = /invalid (x-)?api[ -]?key|incorrect api key|api key|authentication_error|\b401\b|unauthori[sz]ed|forbidden|\b403\b/i;
+const NOT_INSTALLED = /ENOENT|spawn .* (ENOENT|failed)|command not found|not installed|no such file/i;
+const BUSY = /rate[ _-]?limit|\b429\b|overloaded|\b529\b|too many requests|capacity/i;
+const UNREACHABLE = /ECONNREFUSED|ECONNRESET|ENOTFOUND|EAI_AGAIN|fetch failed|connection refused|network/i;
+const MODEL_MISSING = /model ['"]?([^'" ]+)['"]? not found|pull (the )?model|no such model/i;
+const MAX_TURNS = /error_max_turns/;
+const MAX_BUDGET = /error_max_budget/;
+
+function minutes(seconds: number): string {
+  if (seconds < 60) return `${seconds}-second`;
+  const m = Math.round(seconds / 60);
+  return `${m}-minute`;
+}
+
+export function humanizeStepError(message: string, providerId: string): HumanError {
+  const raw = message.trim();
+  const vendor = vendorOf(providerId);
+  const prefix = prefixOf(providerId);
+  const withDetail = (line: string): HumanError => (line.includes(raw) ? { line } : { line, detail: raw });
+
+  const timeout = TIMEOUT.exec(raw);
+  if (timeout !== null) return withDetail(`The step ran past its ${minutes(Number(timeout[1]))} limit. Ask something smaller, or raise the step timeout in Settings.`);
+  if (CONTEXT.test(raw)) return withDetail(`${vendor} could not take this much at once: the instructions and the document together exceed its context window.`);
+  const unknown = UNKNOWN_PROVIDER.exec(raw);
+  if (unknown !== null) return withDetail(`No provider called ${unknown[1]} is loaded. Pick one in Settings, then retry.`);
+  if (UNKNOWN_THREAD.test(raw)) return withDetail('This conversation no longer exists on the runtime. Start a new one.');
+  if (NO_TERMINAL.test(raw)) return withDetail(`${vendor} stopped without answering. Retry.`);
+  if (SHAPE.test(raw)) return withDetail(`${vendor} answered in the wrong shape for this step. Retry, or try another model.`);
+  if (MAX_TURNS.test(raw)) return withDetail(`${vendor} stopped after too many tool calls without finishing. Ask something narrower.`);
+  if (MAX_BUDGET.test(raw)) return withDetail(`${vendor} stopped: the step's spending limit was reached.`);
+
+  // Vendor-specific: the harnesses wrap their CLI's words; the direct
+  // providers surface the SDK's.
+  if (prefix === 'claude-sub') {
+    if (NOT_INSTALLED.test(raw)) return withDetail('Claude did not answer: the Claude Code CLI is not installed on this machine.');
+    if (LOGIN.test(raw) || API_KEY.test(raw)) return withDetail('Claude did not answer: your Claude login has expired. Run `claude login` in a terminal, then retry.');
+    if (BUSY.test(raw)) return withDetail('Claude is busy right now. Retry in a moment.');
+    if (UNREACHABLE.test(raw)) return withDetail('Claude could not be reached. Check your connection, then retry.');
+  }
+  if (prefix === 'codex-sub' || prefix === 'codex') {
+    if (NOT_INSTALLED.test(raw)) return withDetail('ChatGPT did not answer: the Codex CLI is not installed on this machine.');
+    if (LOGIN.test(raw) || API_KEY.test(raw)) return withDetail('ChatGPT did not answer: your ChatGPT login has expired. Run `codex login` in a terminal, then retry.');
+    if (BUSY.test(raw)) return withDetail('ChatGPT is busy right now. Retry in a moment.');
+    if (UNREACHABLE.test(raw)) return withDetail('ChatGPT could not be reached. Check your connection, then retry.');
+  }
+  if (prefix === 'ollama') {
+    const missing = MODEL_MISSING.exec(raw);
+    if (missing !== null) {
+      const model = missing[1] ?? modelOf(providerId);
+      return withDetail(`Ollama does not have the model ${model}. Run \`ollama pull ${model}\`, then retry.`);
+    }
+    if (UNREACHABLE.test(raw)) return withDetail('Ollama is not running on this machine. Start it, then retry.');
+  }
+  if (prefix === 'anthropic' || prefix === 'openai' || prefix === 'openai-compatible') {
+    if (API_KEY.test(raw) || LOGIN.test(raw)) return withDetail(`${vendor} did not answer: the API key was rejected. Check the key in your environment, restart the runtime, then retry.`);
+    if (BUSY.test(raw)) return withDetail(`${vendor} is busy right now. Retry in a moment.`);
+    if (UNREACHABLE.test(raw)) return withDetail(`${vendor} could not be reached. Check your connection, then retry.`);
+  }
+
+  return { line: `${vendor} did not answer: ${raw}` };
+}

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -2,10 +2,19 @@ import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { TOKEN_KEY } from '../../api/token';
-import type { DocketView, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import type { DocketView, Health, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
 import { docketDate, docketHeadParts, HomePage } from './HomePage';
 
 const realFetch = globalThis.fetch;
+
+const amber: Health = {
+  vault: '/tmp/vault',
+  tenant: 'default',
+  default: 'claude-sub/claude-opus-5',
+  stepTimeoutMs: 600_000,
+  providers: [{ id: 'ollama/gemma4:e4b', kind: 'direct', auth: 'local', capabilities: { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'local' } }],
+};
+const fine: Health = { ...amber, default: 'ollama/gemma4:e4b' };
 
 const threads: ThreadHeader[] = [
   {
@@ -373,5 +382,20 @@ describe('HomePage, one docket: deadlines + proposals', () => {
     expect(docketHeadParts(0, 0)).toEqual([]);
     expect(docketHeadParts(1, 0)).toEqual(['1 deadline']);
     expect(docketHeadParts(3, 2)).toEqual(['3 deadlines', '2 awaiting your decision']);
+  });
+});
+
+describe('HomePage swap notice (cou-95)', () => {
+  test('above the ask box only when the saved default is not loaded', async () => {
+    render(<HomePage threads={threads} onAsk={() => {}} onOpenThread={() => {}} health={amber} />);
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    const notice = document.querySelector('.v2-swap-notice')!;
+    expect(notice.textContent).toContain('Claude is not available. Counsel will answer on Ollama (gemma4:e4b).');
+    // Above the box, in reading order.
+    expect(notice.compareDocumentPosition(document.querySelector('.v2-ask')!) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    cleanup();
+    render(<HomePage threads={threads} onAsk={() => {}} onOpenThread={() => {}} health={fine} />);
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    expect(document.querySelector('.v2-swap-notice')).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, fetchJsonWithHeaders } from '../../api/client';
-import type { DocketEntry, DocketView, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import type { DocketEntry, DocketView, Health, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import { ProviderNotice } from '../ProviderNotice';
 import { Tree } from '../../vault/Tree';
 import { railLabel } from '../Rail';
 import { relTime } from '../time';
@@ -67,6 +68,8 @@ export interface HomePageProps {
    * does).
    */
   onAsk: (message: string) => void;
+  /** For the swap notice above the ask box (cou-95). Absent = no notice. */
+  health?: Health | null;
   onOpenThread: (id: string) => void;
 }
 
@@ -77,7 +80,7 @@ export interface HomePageProps {
  * `/vault/overview` + `/proposals?status=pending`, fetched on mount — the
  * shell mounts this page per visit to Home, so the docket is always current.
  */
-export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.Element {
+export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps): JSX.Element {
   const [overview, setOverview] = useState<VaultOverview | null>(null);
   const [pending, setPending] = useState<PendingProposal[]>([]);
   /** The proposal scan was bounded — there may be proposals it never saw. */
@@ -168,6 +171,7 @@ export function HomePage({ threads, onAsk, onOpenThread }: HomePageProps): JSX.E
         <div className="v2-hi">{greetingFor()}</div>
         {subline === null ? null : <div className="v2-sub">{subline}</div>}
 
+        <ProviderNotice health={health} />
         <div className="v2-ask">
           <textarea
             ref={box}

--- a/runtime/ui/src/v2/plate.test.ts
+++ b/runtime/ui/src/v2/plate.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { Health } from '../api/types';
-import { footerLabel, modelName, plateFor, swapNote } from './plate';
+import { footerLabel, modelName, plateFor, swapNote, swapPlates } from './plate';
 
 describe('plateFor', () => {
   // The founder's table (cou-90), row by row.
@@ -108,5 +108,30 @@ describe('footerLabel / swapNote', () => {
     expect(swapNote(swapped)).toBe('saved default openai/nope not loaded');
     expect(swapNote(health)).toBeNull();
     expect(swapNote(null)).toBeNull();
+  });
+});
+
+describe('swapPlates (cou-95)', () => {
+  const ollama = { id: 'ollama/gemma4:e4b', kind: 'direct' as const, auth: 'local' as const, capabilities: { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'local' as const } };
+  const base = { vault: '/v', tenant: 'default', stepTimeoutMs: 1 };
+
+  test('null when the saved default is loaded, or nothing is saved', () => {
+    expect(swapPlates(null)).toBeNull();
+    expect(swapPlates({ ...base, default: 'ollama/gemma4:e4b', providers: [ollama] })).toBeNull();
+    expect(swapPlates({ ...base, default: null, providers: [ollama] })).toBeNull();
+  });
+
+  test('the saved plate and the effective plate with its bare model', () => {
+    const swap = swapPlates({ ...base, default: 'claude-sub/claude-opus-5', providers: [ollama] })!;
+    expect(swap.saved.vendor).toBe('Claude');
+    expect(swap.effective?.vendor).toBe('Ollama');
+    expect(swap.effective?.model).toBe('gemma4:e4b');
+  });
+
+  test('nothing loaded at all: effective is null', () => {
+    expect(swapPlates({ ...base, default: 'claude-sub/claude-opus-5', providers: [] })).toEqual({
+      saved: expect.objectContaining({ vendor: 'Claude' }),
+      effective: null,
+    });
   });
 });

--- a/runtime/ui/src/v2/plate.ts
+++ b/runtime/ui/src/v2/plate.ts
@@ -100,3 +100,21 @@ export function swapNote(health: Health | null): string | null {
   if (saved === null || saved === '' || health.providers.some(p => p.id === saved)) return null;
   return `saved default ${saved} not loaded`;
 }
+
+/**
+ * The same swap as plates (cou-95), for the notice above the composer: the
+ * saved default's plate, and the plate of what a send will ACTUALLY use —
+ * `null` when nothing at all is loaded. `null` overall when there is no
+ * swap, so callers render nothing. Derived from `swapNote`, never a second
+ * rule.
+ */
+export function swapPlates(health: Health | null): { saved: Plate; effective: (Plate & { model: string }) | null } | null {
+  if (health === null || swapNote(health) === null) return null;
+  const saved = plateFor(health.default ?? '');
+  const effectiveId = defaultProviderId(health);
+  if (effectiveId === '') return { saved, effective: null };
+  const plate = plateFor(effectiveId, health.providers.find(p => p.id === effectiveId)?.auth);
+  // The detail line is `<Model> · <connection>`; the notice wants the model alone.
+  const model = plate.known ? plate.detail.split(' · ')[0]! : effectiveId;
+  return { saved, effective: { ...plate, model } };
+}


### PR DESCRIPTION
Formerly cou-95 (pair-built; QA reviews).

**Swap notice.** When Settings' saved default is not loaded, a faint set-text line appears above the composer and above Home's ask box: `Claude is not available. Counsel will answer on Ollama (gemma4:e4b). change` — vendor and model from the plate humanizer, derived from the same rule as the footer's amber dot (`swapPlates` wraps `swapNote`; no second derivation). `change` links to `#/settings`. Hidden when everything is fine. No box, no pill, no icon.

**Humanized step failure.** `runtime/ui/src/v2/errors.ts` `humanizeStepError(message, providerId)` maps the strings the runtime actually emits to one plain line with what to do next:
- runtime: `step timed out after Ns` · `exceeds the provider's context window` · `unknown provider: X` · `unknown thread:` · `ended the step without a done or error event` · `structured output …`
- Claude harness (`claude harness: …`): `Not logged in · Please run /login` / 401 → "your Claude login has expired. Run `claude login`…"; `spawn claude ENOENT` → CLI not installed; `error_max_turns` / `error_max_budget`; 429/overloaded → busy
- Codex harness: not authenticated / ENOENT / busy
- Ollama: `fetch failed` / `ECONNREFUSED` → "Ollama is not running…"; `model 'x' not found` → "Run `ollama pull x`"
- anthropic / openai / openai-compatible: API key rejected · busy · unreachable
- fallback: `<Vendor> did not answer: <original>`; no provider on the turn → "Counsel did not answer: …"

The original text stays under `show details` (or `show answer` when a partial answer exists). The transcript's last failed turn offers **Retry**, which re-sends the same user message on the default provider (small additive change in Chat.tsx; `onRetry` prop on TurnView).

Tests: `bun run ui:test` 378 pass (was 363) · `bun run test` 614 pass · typecheck:ui clean · ui:build ok.