### PR TITLE
ui: rename conversations in place, explicit matter link, on-row delete confirm

### DIFF
--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1111,3 +1111,38 @@ describe('docket', () => {
     expect(await res.json()).toEqual({ deadlines: [], skipped: 0 });
   });
 });
+
+describe('PATCH /threads/:id (rename + matter link)', () => {
+  test('renames, trims, and returns the presented header; updatedAt is unchanged', async () => {
+    const app = appWithFake();
+    const id = await newThread(app);
+    const before = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { header: { updatedAt: string } };
+    const res = await call(app, 'PATCH', `/threads/${id}`, { body: { title: '  Acme — residuals  ' } });
+    expect(res.status).toBe(200);
+    const header = (await res.json()) as { id: string; title?: string; updatedAt: string };
+    expect(header.title).toBe('Acme — residuals');
+    expect(header.updatedAt).toBe(before.header.updatedAt);
+  });
+
+  test('links a matter, then unlinks it with null', async () => {
+    const app = appWithFake();
+    const id = await newThread(app);
+    const linked = (await (await call(app, 'PATCH', `/threads/${id}`, { body: { matter: 'matters/acme.md' } })).json()) as { matter?: string };
+    expect(linked.matter).toBe('matters/acme.md');
+    const unlinked = (await (await call(app, 'PATCH', `/threads/${id}`, { body: { matter: null } })).json()) as { matter?: string };
+    expect(unlinked.matter).toBeUndefined();
+  });
+
+  test('404 on an unknown thread, 400 on a bad body', async () => {
+    const app = appWithFake();
+    expect((await call(app, 'PATCH', `/threads/${randomUUID()}`, { body: { title: 'x' } })).status).toBe(404);
+    const id = await newThread(app);
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { title: 42 } })).status).toBe(400);
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: {} })).status).toBe(400);
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { sessions: {} } })).status).toBe(400);
+    // A matter must be a vault-relative path.
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { matter: '../etc/passwd' } })).status).toBe(400);
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { matter: '/abs.md' } })).status).toBe(400);
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { matter: '.counsel/threads/x.json' } })).status).toBe(400);
+  });
+});

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -63,6 +63,26 @@ export function isApiPath(pathname: string): boolean {
 
 const CreateThreadBody = z.object({ title: z.string().optional(), matter: z.string().optional() });
 
+/** A vault-relative matter path a thread may link to: no absolute paths, no
+ * `..` segments, no backslashes, never the store's own `.counsel/`. The same
+ * shape the vault tools enforce, checked here so a header can never point
+ * outside the vault. */
+const MATTER_PATH = z
+  .string()
+  .min(1)
+  .max(500)
+  .refine(p => !p.startsWith('/') && !p.includes('\\') && !p.split('/').includes('..') && !p.toLowerCase().startsWith('.counsel'), {
+    message: 'matter must be a vault-relative path',
+  });
+
+/** `PATCH /threads/:id` — housekeeping only: a title (trimmed, `''` clears
+ * it) and/or a matter link (`null` unlinks). Nothing else on the header is
+ * client-writable. */
+const PatchThreadBody = z
+  .object({ title: z.string().max(200).optional(), matter: MATTER_PATH.nullable().optional() })
+  .strict()
+  .refine(b => b.title !== undefined || b.matter !== undefined, { message: 'nothing to change' });
+
 const StepBody = z.object({
   message: z.string().min(1),
   task: z.string().optional(),
@@ -344,6 +364,18 @@ export function createApp(deps: ServerDeps): App {
 
   const getThread = async (id: string): Promise<Response> => json(await loadThread(deps, id));
 
+  const patchThread = async (req: Request, id: string): Promise<Response> => {
+    const patch = await body(req, PatchThreadBody);
+    return withThreadLock(id, async () => {
+      await loadThread(deps, id);
+      return json(
+        await deps.store.update(deps.tenant, id, {
+          ...(patch.title === undefined ? {} : { title: patch.title.trim() }),
+          ...(patch.matter === undefined ? {} : { matter: patch.matter }),
+        }),
+      );
+    });
+  };
   const deleteThread = async (id: string): Promise<Response> =>
     withThreadLock(id, async () => {
       await loadThread(deps, id);
@@ -571,6 +603,7 @@ export function createApp(deps: ServerDeps): App {
 
       if (segments.length === 2 && first === 'threads' && second !== undefined) {
         if (method === 'GET') return await getThread(second);
+        if (method === 'PATCH') return await patchThread(req, second);
         if (method === 'DELETE') return await deleteThread(second);
       }
 

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -206,3 +206,37 @@ describe('ThreadStore', () => {
     expect(existsSync(join(root, '.counsel', 'threads', 'default', `${unknownId}.jsonl`))).toBe(false);
   });
 });
+
+describe('ThreadStore.update (rename + matter link)', () => {
+  test('renames without touching updatedAt, so the rail order holds', async () => {
+    const header = await store.create('default', { title: 'Acme NDA' });
+    await new Promise(resolve => setTimeout(resolve, 5));
+    const renamed = await store.update('default', header.id, { title: 'Acme — residuals' });
+    expect(renamed.title).toBe('Acme — residuals');
+    expect(renamed.updatedAt).toBe(header.updatedAt);
+    expect((await store.get('default', header.id)).header.title).toBe('Acme — residuals');
+  });
+
+  test('an empty title clears the name; the derived one comes back at read time', async () => {
+    const header = await store.create('default', { title: 'Named' });
+    await store.append('default', header.id, { t: 'user', at: header.createdAt, content: 'What is the cap?' });
+    const cleared = await store.update('default', header.id, { title: '' });
+    expect(cleared.title).toBe('What is the cap?');
+    // On disk the name is gone, not stored as ''.
+    const raw = JSON.parse(readFileSync(join(root, '.counsel', 'threads', 'default', `${header.id}.json`), 'utf8')) as { title?: string };
+    expect('title' in raw).toBe(false);
+  });
+
+  test('links and unlinks a matter; null removes the key', async () => {
+    const header = await store.create('default', {});
+    const linked = await store.update('default', header.id, { matter: 'matters/acme.md' });
+    expect(linked.matter).toBe('matters/acme.md');
+    const unlinked = await store.update('default', header.id, { matter: null });
+    expect(unlinked.matter).toBeUndefined();
+    expect((await store.list('default'))[0]!.matter).toBeUndefined();
+  });
+
+  test('rejects a malformed id before touching disk', async () => {
+    await expect(store.update('default', '../x', { title: 'x' })).rejects.toThrow('invalid thread id');
+  });
+});

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -169,6 +169,29 @@ export class ThreadStore {
     return header;
   }
 
+  /**
+   * Rename or re-link a thread. `updatedAt` is deliberately left alone: it
+   * orders the rail by conversation activity, and housekeeping — a better
+   * name, the right matter — is not a turn and must not jump the row to
+   * the top. A `title` of `''` clears the name, so the thread falls back to
+   * the derived one (`presentHeader`); `matter: null` unlinks.
+   */
+  async update(tenant: Tenant, id: string, patch: { title?: string; matter?: string | null }): Promise<ThreadHeader> {
+    this.validateTenant(tenant);
+    this.validateId(id);
+    const header = this.readHeader(tenant, id);
+    if (patch.title !== undefined) {
+      if (patch.title === '') delete header.title;
+      else header.title = patch.title;
+    }
+    if (patch.matter !== undefined) {
+      if (patch.matter === null) delete header.matter;
+      else header.matter = patch.matter;
+    }
+    this.writeHeader(tenant, header);
+    return this.presentHeader(tenant, header);
+  }
+
   async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {
     this.validateTenant(tenant);
     this.validateId(id);

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -326,6 +326,17 @@ a { color: var(--accent); }
 .v2-draft { font-style: italic; }
 .v2-thread-open { flex: 1; min-width: 0; text-align: left; background: none; border: none; padding: 6px 10px; color: inherit; }
 .v2-thread-title { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* A thread with an explicit matter link carries the matter's title as a
+   faint second line — the row's own dotted-leader-free ledger entry. */
+.v2-thread-sub { display: block; font-size: 11px; line-height: 1.3; color: var(--fg-faint); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+/* The delete question, on the row it concerns: set text and two words, no
+   modal, no dialog. Escape or Keep restores the row. */
+.v2-thread-confirm { flex: 1; min-width: 0; display: flex; align-items: baseline; gap: 8px; padding: 6px 10px; font-size: 12px; color: var(--fg-muted); }
+.v2-thread-confirm-q { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-thread-confirm button { background: none; border: none; padding: 0; font: 600 12px var(--sans); cursor: pointer; }
+.v2-thread-confirm-yes { color: var(--error); }
+.v2-thread-confirm-no { color: var(--fg-muted); }
+.v2-thread-confirm button:hover { text-decoration: underline; }
 /* The provider plate (cou-90): a designed two-line lockup, not a string.
  * `.v2-switch` owns the footer slot and anchors the popover; the button is
  * the plate. The dot pins to line 1 (flex-start + a line-height offset),
@@ -667,7 +678,19 @@ a { color: var(--accent); }
 /* ── Chat (mock-chat.html) ───────────────────────────────────────────── */
 
 .v2-thread-head { display: flex; align-items: baseline; gap: 12px; padding: 14px 40px 12px; border-bottom: 1px solid var(--border); }
-.v2-thread-head h1 { font: 600 18px/1.3 var(--serif); margin: 0; }
+.v2-thread-head h1 { font: 600 18px/1.3 var(--serif); margin: 0; min-width: 0; }
+/* Rename in place: the title IS the control. Click turns it into an input
+   set in the same face, underlined once, so the page does not reflow. */
+.v2-thread-rename { all: unset; cursor: text; font: inherit; color: inherit; border-bottom: 1px solid transparent; }
+.v2-thread-rename:hover { border-bottom-color: var(--border-strong); }
+.v2-thread-title-edit { font: inherit; color: var(--fg); background: none; border: none; border-bottom: 1px solid var(--border-strong); padding: 0; margin: 0; min-width: 16ch; width: 32ch; max-width: 100%; outline: none; }
+.v2-thread-inferred { font: italic 11.5px/1 var(--serif); color: var(--fg-faint); }
+/* The matter picker's trigger reads as a word in the header, not a button. */
+.v2-matter-pick { position: relative; display: inline-flex; }
+.v2-thread-link { background: none; border: none; padding: 0; font: 11.5px var(--sans); color: var(--fg-faint); cursor: pointer; text-decoration: underline dotted; text-underline-offset: 3px; }
+.v2-thread-link:hover { color: var(--fg-muted); }
+.v2-matter-pop { position: absolute; top: calc(100% + 6px); left: 0; z-index: 30; min-width: 280px; max-width: 440px; background: var(--bg-raised); border: 1px solid var(--border-strong); border-radius: var(--radius); box-shadow: var(--shadow); max-height: 20rem; overflow-y: auto; }
+.v2-matter-note { margin: 0; padding: 10px 12px; font-size: 12.5px; }
 /* The thread's matter: a small-caps run-in and the matter's real title, set
    as text and linked to the file (cou-93 item 7) — the ledger language has
    no pills. */

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -259,13 +259,48 @@ describe('Rail', () => {
     expect(opened).toBe(1);
   });
 
-  test('select and delete reach their handlers', async () => {
+  test('select reaches its handler; × asks on the row, and Delete is what deletes', async () => {
     const selected: string[] = [];
     const deleted: string[] = [];
     mount({ onSelect: id => selected.push(id), onDelete: id => deleted.push(id) });
     await userEvent.click(screen.getByText('NDA residuals fallback'));
     await userEvent.click(screen.getByRole('button', { name: 'Delete Untitled' }));
+    // Not yet: the row now carries the question in set text, no dialog.
+    expect(deleted).toEqual([]);
+    const row = screen.getByRole('group', { name: 'Delete Untitled?' });
+    expect(row.textContent).toContain('Delete this?');
+    await userEvent.click(within(row).getByRole('button', { name: 'Delete' }));
     expect(selected).toEqual(['t-1']);
     expect(deleted).toEqual(['t-2']);
+    expect(screen.queryByRole('group', { name: 'Delete Untitled?' })).toBeNull();
+  });
+
+  test('Keep and Escape both put the row back without deleting', async () => {
+    const deleted: string[] = [];
+    mount({ onDelete: id => deleted.push(id) });
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Untitled' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Keep' }));
+    expect(screen.queryByText('Delete this?')).toBeNull();
+    expect(screen.getByText('Untitled')).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Untitled' }));
+    await userEvent.setup({ document }).keyboard('{Escape}');
+    expect(screen.queryByText('Delete this?')).toBeNull();
+    expect(deleted).toEqual([]);
+  });
+
+  test('an explicit matter link reads as a faint second line; inferred ones do not exist here', () => {
+    const linked: ThreadHeader = { ...acme, id: 't-3', title: 'Term sheet', matter: 'matters/2026-06-acme-nda.md' };
+    mount({ threads: [linked, untitled], matterTitles: { 'matters/2026-06-acme-nda.md': 'Acme Corp — NDA' } });
+    const sub = document.querySelector('.v2-thread-sub');
+    expect(sub?.textContent).toBe('Acme Corp — NDA');
+    expect(sub?.getAttribute('title')).toBe('matters/2026-06-acme-nda.md');
+    expect(document.querySelectorAll('.v2-thread-sub')).toHaveLength(1);
+  });
+
+  test('a linked matter the overview does not know falls back to the prettified filename', () => {
+    const linked: ThreadHeader = { ...acme, matter: 'matters/2026-06-acme-nda.md' };
+    mount({ threads: [linked] });
+    expect(document.querySelector('.v2-thread-sub')?.textContent).toBe('Acme nda');
   });
 });

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -1,7 +1,9 @@
+import { useEffect, useState } from 'react';
 import type { Health, ThreadHeader } from '../api/types';
 import type { Route } from '../app';
 import { ChatIcon, HomeIcon, SettingsIcon, VaultIcon } from './icons';
 import { ModelSwitcher } from './ModelSwitcher';
+import { prettifyName } from './vault/frontmatter';
 
 export interface RailProps {
   route: Route;
@@ -22,16 +24,30 @@ export interface RailProps {
   /** The draft row: navigate back to the draft already live in the chat
    * pane — never a reset. `onNew` starts a draft; this one returns to it. */
   onOpenDraft: () => void;
+  /** The reader confirmed the delete on the row itself — the rail owns the
+   * "Delete · Keep" step, so this fires once, already confirmed. */
   onDelete: (id: string) => void;
   /** The footer switcher picked a loaded provider: save it as the default
    * (the settings round-trip lives in the Shell). */
   onSetDefault: (id: string) => void;
+  /** Matter path → title (from `/vault/overview`), for the faint second
+   * line under a thread with an EXPLICIT matter link. Absent or missing a
+   * path, the row falls back to the prettified filename. */
+  matterTitles?: Record<string, string>;
 }
 
 /** The title the first send gave the thread, or `Untitled`. */
 export function railLabel(thread: ThreadHeader): string {
   const title = thread.title?.trim() ?? '';
   return title !== '' ? title : 'Untitled';
+}
+
+/** The second line under a linked thread: the matter's title. Only an
+ * EXPLICIT link earns it — the rail has no transcript to infer from. */
+export function railMatter(thread: ThreadHeader, titles: Record<string, string> | undefined): string | null {
+  const path = thread.matter?.trim() ?? '';
+  if (path === '') return null;
+  return titles?.[path] ?? prettifyName(path.slice(path.lastIndexOf('/') + 1));
 }
 
 export function Rail({
@@ -47,7 +63,18 @@ export function Rail({
   onOpenDraft,
   onDelete,
   onSetDefault,
+  matterTitles,
 }: RailProps): JSX.Element {
+  /** The row whose × was clicked: it reads "Delete this? ·
+   * Delete · Keep" in set text until answered — no `window.confirm`, no
+   * modal. Escape anywhere on the row keeps. */
+  const [confirming, setConfirming] = useState<string | null>(null);
+  // A row that vanished (deleted elsewhere, list refetched) takes its
+  // question with it.
+  useEffect(() => {
+    if (confirming !== null && !threads.some(t => t.id === confirming)) setConfirming(null);
+  }, [threads, confirming]);
+
   return (
     <aside className={collapsed ? 'v2-rail v2-rail-icons' : 'v2-rail'} aria-label="Rail">
       <div className="v2-brand">
@@ -92,21 +119,59 @@ export function Rail({
                 </button>
               </li>
             ) : null}
-            {threads.map(thread => (
-              <li key={thread.id} className="v2-thread" aria-current={thread.id === selected && !draft ? 'true' : undefined}>
-                <button type="button" className="v2-thread-open" onClick={() => onSelect(thread.id)}>
-                  <span className="v2-thread-title">{railLabel(thread)}</span>
-                </button>
-                <button
-                  type="button"
-                  className="v2-thread-delete"
-                  aria-label={`Delete ${railLabel(thread)}`}
-                  onClick={() => onDelete(thread.id)}
-                >
-                  ×
-                </button>
-              </li>
-            ))}
+            {threads.map(thread => {
+              const matter = railMatter(thread, matterTitles);
+              return (
+                <li key={thread.id} className="v2-thread" aria-current={thread.id === selected && !draft ? 'true' : undefined}>
+                  {confirming === thread.id ? (
+                    <span
+                      className="v2-thread-confirm"
+                      role="group"
+                      aria-label={`Delete ${railLabel(thread)}?`}
+                      onKeyDown={event => {
+                        if (event.key === 'Escape') setConfirming(null);
+                      }}
+                    >
+                      <span className="v2-thread-confirm-q">Delete this?</span>
+                      <button
+                        type="button"
+                        className="v2-thread-confirm-yes"
+                        autoFocus
+                        onClick={() => {
+                          setConfirming(null);
+                          onDelete(thread.id);
+                        }}
+                      >
+                        Delete
+                      </button>
+                      <button type="button" className="v2-thread-confirm-no" onClick={() => setConfirming(null)}>
+                        Keep
+                      </button>
+                    </span>
+                  ) : (
+                    <>
+                      <button type="button" className="v2-thread-open" onClick={() => onSelect(thread.id)}>
+                        <span className="v2-thread-title">{railLabel(thread)}</span>
+                        {matter === null ? null : (
+                          <span className="v2-thread-sub" title={thread.matter}>
+                            {matter}
+                          </span>
+                        )}
+                      </button>
+                      <button
+                        type="button"
+                        className="v2-thread-delete"
+                        aria-label={`Delete ${railLabel(thread)}`}
+                        disabled={busy}
+                        onClick={() => setConfirming(thread.id)}
+                      >
+                        ×
+                      </button>
+                    </>
+                  )}
+                </li>
+              );
+            })}
           </ul>
           {/* No "No threads yet." note: a fresh Home already carries the one
               getting-started copy, and a second empty-state line in the rail

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -364,8 +364,6 @@ describe('Shell', () => {
   });
 
   test('deleting the open thread from Home stays on Home', async () => {
-    const confirmed = globalThis.confirm;
-    globalThis.confirm = () => true;
     try {
       history.replaceState(null, '', '/#/');
       const base = globalThis.fetch;
@@ -381,13 +379,15 @@ describe('Shell', () => {
       await waitFor(() => expect(screen.getAllByText('Acme NDA term')).toHaveLength(2));
 
       await userEvent.click(screen.getByRole('button', { name: 'Delete Acme NDA term' }));
+      // No window.confirm: the rail row asks, and Delete answers.
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
 
       // Home is still the page, and the fragment never became a chat one.
       await waitFor(() => expect(document.querySelector('.v2-home')).toBeTruthy());
       expect(routeFromHash(location.hash)).toBe('home');
       expect(workNode()?.hasAttribute('hidden')).toBe(true);
     } finally {
-      globalThis.confirm = confirmed;
+      globalThis.fetch = realFetch;
     }
   });
 

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import { readToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
-import type { Health, SettingsView, ThreadHeader } from '../api/types';
+import type { Health, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
 import type { ComposerSeed } from './chat/Composer';
@@ -100,13 +100,32 @@ export function Shell(): JSX.Element {
     }
   }, []);
 
+  /**
+   * Matter path → title, for the rail's second line under a thread with an
+   * explicit matter link. One read of `/vault/overview` beside `/health`,
+   * refreshed when a proposal lands (it may have created or renamed a
+   * matter). HomePage keeps its own read — the two are not coupled.
+   */
+  const [matterTitles, setMatterTitles] = useState<Record<string, string>>({});
+  const loadMatterTitles = useCallback(async (): Promise<void> => {
+    try {
+      const overview = await fetchJson<VaultOverview>('/vault/overview');
+      const titles: Record<string, string> = {};
+      for (const matter of overview.matters) titles[matter.path] = matter.title;
+      setMatterTitles(titles);
+    } catch {
+      // The rail falls back to prettified filenames; nothing to say here.
+    }
+  }, []);
+
   const fileDecided = useCallback(
     (path: string): void => {
       const open = drawerRef.current;
       if (open.open && open.path === path) setDrawerRevision(revision => revision + 1);
       void loadIndex();
+      void loadMatterTitles();
     },
-    [loadIndex],
+    [loadIndex, loadMatterTitles],
   );
 
   const selectThread = (id: string): void => {
@@ -247,6 +266,7 @@ export function Shell(): JSX.Element {
       try {
         setHealth(await fetchJson<Health>('/health'));
         void loadIndex();
+        void loadMatterTitles();
         const { threads: list, fresh } = await loadThreads();
         if (!fresh) return;
         // The fragment may already name the thread (a pasted link, the
@@ -272,7 +292,7 @@ export function Shell(): JSX.Element {
         setListed(true);
       }
     })();
-  }, [unauthorized, loadThreads, loadIndex]);
+  }, [unauthorized, loadThreads, loadIndex, loadMatterTitles]);
 
   /**
    * The rail footer's switcher picked a loaded provider (cou-90): make it
@@ -308,8 +328,9 @@ export function Shell(): JSX.Element {
     }
   };
 
+  /** Already confirmed: the rail's row asked "Delete this conversation?"
+   * and the reader answered on the row itself (no `window.confirm`). */
   const deleteThread = async (id: string): Promise<void> => {
-    if (!globalThis.confirm('Delete this thread? Its transcript cannot be recovered from here.')) return;
     setBusy(true);
     setError(null);
     try {
@@ -354,6 +375,7 @@ export function Shell(): JSX.Element {
         onOpenDraft={returnToDraft}
         onDelete={id => void deleteThread(id)}
         onSetDefault={id => void setDefaultProvider(id)}
+        matterTitles={matterTitles}
       />
       <div className="v2-main-col">
         {error === null ? null : (

--- a/runtime/ui/src/v2/chat/Chat.test.tsx
+++ b/runtime/ui/src/v2/chat/Chat.test.tsx
@@ -1,4 +1,4 @@
-import { act, cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
+import { act, cleanup, render, screen, userEvent, waitFor, within } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { clearToken, TOKEN_KEY } from '../../api/token';
@@ -425,5 +425,142 @@ describe('v2 Chat, retrying a failed step (cou-95)', () => {
     const step = calls.find(c => c.method === 'POST' && c.url.endsWith('/steps'))!;
     expect((step.body as { message: string; provider: string }).message).toBe(QUESTION);
     expect((step.body as { message: string; provider: string }).provider).toBe('fake/fake');
+  });
+});
+
+describe('v2 Chat, rename and matter link', () => {
+  const overview = {
+    matters: [
+      { path: 'matters/acme-nda.md', title: 'Acme Corp — NDA', frontmatter: {}, mtimeMs: 2 },
+      { path: 'matters/beta-msa.md', title: 'Beta — MSA', frontmatter: {}, mtimeMs: 1 },
+    ],
+    groups: { practice: 0, knowledge: 0, other: 0 },
+  };
+
+  /** A thread the tests can PATCH: the mock applies the patch and serves the
+   * updated header on the next GET, the way the runtime does. */
+  function installPatchable(initial: Thread): { patches: Array<Record<string, unknown>> } {
+    let current = initial;
+    const patches: Array<Record<string, unknown>> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      if (url.startsWith('/runs')) return json([]);
+      if (url.startsWith('/vault/read')) return json({ path: 'x', content: '# Acme NDA\n', version: 'v1', mtimeMs: 1 });
+      if (url.startsWith('/vault/overview')) return json(overview);
+      if (method === 'PATCH' && url.startsWith('/threads/')) {
+        const patch = JSON.parse(String(init?.body)) as { title?: string; matter?: string | null };
+        patches.push(patch);
+        const header = { ...current.header };
+        if (patch.title !== undefined) header.title = patch.title;
+        if (patch.matter === null) delete header.matter;
+        else if (patch.matter !== undefined) header.matter = patch.matter;
+        current = { ...current, header };
+        return json(header);
+      }
+      if (url.startsWith('/threads/')) return json(current);
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as unknown as typeof fetch;
+    return { patches };
+  }
+
+  const readsAcme: ThreadEvent[] = [
+    { t: 'user', at, content: 'check it' },
+    { t: 'step', at, runId: 'r-1', provider: 'fake/fake' },
+    { type: 'tool_call', at, id: 'c1', name: 'vault_read', input: { path: 'matters/acme-nda.md' } },
+    { type: 'done', at, output: null, usage: { inputTokens: 1, outputTokens: 1 } },
+  ];
+
+  function named(title: string, extra: Partial<Thread['header']> = {}, events: ThreadEvent[] = readsAcme): Thread {
+    return { header: { id: 't-1', title, createdAt: at, updatedAt: at, sessions: {}, ...extra }, events };
+  }
+
+  test('click the title, type a new one, Enter — PATCH {title}, and the header shows it', async () => {
+    const { patches } = installPatchable(named('Old name'));
+    let touched = 0;
+    render(<Chat threadId="t-1" health={health} onThreadTouched={() => (touched += 1)} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Old name' })).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Old name' }));
+    const input = screen.getByLabelText('Conversation title') as HTMLInputElement;
+    expect(input.value).toBe('Old name');
+    const user = userEvent.setup({ document });
+    await user.clear(input);
+    await user.type(input, 'Acme — residuals{Enter}');
+
+    await waitFor(() => expect(patches).toEqual([{ title: 'Acme — residuals' }]));
+    await waitFor(() => expect(document.querySelector('.v2-thread-head h1')?.textContent).toBe('Acme — residuals'));
+    expect(screen.queryByLabelText('Conversation title')).toBeNull();
+    // The rail is told, so its row re-reads.
+    expect(touched).toBe(1);
+  });
+
+  test('Escape puts the old title back and sends nothing', async () => {
+    const { patches } = installPatchable(named('Old name'));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Old name' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Old name' }));
+    const input = screen.getByLabelText('Conversation title') as HTMLInputElement;
+    await userEvent.type(input, 'zzz{Escape}');
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Old name' })).toBeTruthy());
+    expect(patches).toEqual([]);
+  });
+
+  test('an unchanged title on blur sends nothing', async () => {
+    const { patches } = installPatchable(named('Same'));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Same' })).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'Same' }));
+    (screen.getByLabelText('Conversation title') as HTMLInputElement).blur();
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Same' })).toBeTruthy());
+    expect(patches).toEqual([]);
+  });
+
+  test('an inferred matter says so; an explicit link wins over inference', async () => {
+    installPatchable(named('T'));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(document.querySelector('a.v2-thread-matter')).toBeTruthy());
+    expect(document.querySelector('a.v2-thread-matter')?.getAttribute('href')).toBe('#/vault?path=matters%2Facme-nda.md');
+    expect(screen.getByText('inferred')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'change' })).toBeTruthy();
+    cleanup();
+
+    installPatchable(named('T', { matter: 'matters/beta-msa.md' }));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(document.querySelector('a.v2-thread-matter')).toBeTruthy());
+    expect(document.querySelector('a.v2-thread-matter')?.getAttribute('href')).toBe('#/vault?path=matters%2Fbeta-msa.md');
+    expect(screen.queryByText('inferred')).toBeNull();
+  });
+
+  test('no matter at all offers "link a matter"', async () => {
+    installPatchable(named('T', {}, [{ t: 'user', at, content: 'hi' }]));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'link a matter' })).toBeTruthy());
+    expect(document.querySelector('a.v2-thread-matter')).toBeNull();
+  });
+
+  test('the picker lists the vault\'s matters; a pick PATCHes {matter}; "No matter" unlinks', async () => {
+    const { patches } = installPatchable(named('T'));
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'change' })).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'change' }));
+    const menu = await waitFor(() => screen.getByRole('menu', { name: 'Link a matter' }));
+    expect(within(menu).getByText('Beta — MSA')).toBeTruthy();
+    // Nothing explicit yet, so no unlink row.
+    expect(within(menu).queryByText('No matter')).toBeNull();
+
+    await userEvent.click(within(menu).getByText('Beta — MSA'));
+    await waitFor(() => expect(patches).toEqual([{ matter: 'matters/beta-msa.md' }]));
+    await waitFor(() => expect(document.querySelector('a.v2-thread-matter')?.getAttribute('href')).toBe('#/vault?path=matters%2Fbeta-msa.md'));
+    expect(screen.queryByText('inferred')).toBeNull();
+    expect(screen.queryByRole('menu')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'change' }));
+    const again = await waitFor(() => screen.getByRole('menu', { name: 'Link a matter' }));
+    await userEvent.click(within(again).getByText('No matter'));
+    await waitFor(() => expect(patches).toEqual([{ matter: 'matters/beta-msa.md' }, { matter: null }]));
+    // Back to inference.
+    await waitFor(() => expect(screen.getByText('inferred')).toBeTruthy());
   });
 });

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -7,6 +7,7 @@ import { createThread, defaultProviderId, titleFor } from '../threads';
 import { relTime } from '../time';
 import { prettifyName, readerModel } from '../vault/frontmatter';
 import { Composer, type ComposerSeed } from './Composer';
+import { MatterPicker } from './MatterPicker';
 import { TurnView } from './Turn';
 
 export interface ChatProps {
@@ -356,7 +357,61 @@ export function Chat({
   const isDraft = threadId === null && pending === null && frozen.length === 0;
   const empty = !loading && threadId !== null && turns.length === 0 && frozen.length === 0 && pending === null;
 
-  const matterPath = thread === null ? null : matterPathOf(thread.events);
+  /**
+   * The header's matter: the EXPLICIT link on the thread header when there
+   * is one, else the first matter file the thread read (inferred). An
+   * explicit link is the lawyer's word and inference never overwrites it;
+   * the inferred one is shown as such so it can be confirmed or changed.
+   */
+  const explicitMatter = thread?.header.matter ?? null;
+  const inferredMatter = thread === null ? null : matterPathOf(thread.events);
+  const matterPath = explicitMatter ?? inferredMatter;
+  const matterInferred = explicitMatter === null && inferredMatter !== null;
+
+  /**
+   * Housekeeping on the header — a rename, a matter link — through
+   * `PATCH /threads/:id`, then a refetch so the header reads as the server
+   * has it and the rail hears that this thread's row changed. Neither bumps
+   * `updatedAt`, so the row keeps its place.
+   */
+  const patchThread = async (patch: { title?: string; matter?: string | null }): Promise<void> => {
+    const id = idRef.current;
+    if (id === null) return;
+    setError(null);
+    try {
+      await fetchJson<ThreadHeader>(`/threads/${encodeURIComponent(id)}`, { method: 'PATCH', body: JSON.stringify(patch) });
+      await load();
+      onThreadTouched?.();
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setError(detail(err));
+    }
+  };
+
+  /** Inline rename: the title becomes a text input; Enter or blur saves a
+   * changed name, Escape puts the old one back. `editingRef` makes the
+   * commit idempotent — Enter commits and the input's unmount may still
+   * blur once more. */
+  const [editing, setEditing] = useState(false);
+  const [titleDraft, setTitleDraft] = useState('');
+  const editingRef = useRef(false);
+  const startRename = (): void => {
+    if (thread === null) return;
+    setTitleDraft(thread.header.title?.trim() ?? '');
+    editingRef.current = true;
+    setEditing(true);
+  };
+  const commitRename = (): void => {
+    if (!editingRef.current || thread === null) return;
+    editingRef.current = false;
+    setEditing(false);
+    const next = titleDraft.trim();
+    if (next === (thread.header.title?.trim() ?? '')) return;
+    void patchThread({ title: next });
+  };
+  const cancelRename = (): void => {
+    editingRef.current = false;
+    setEditing(false);
+  };
 
   /** Retry for a step that FAILED (cou-95): send the last user message
    * again, on the default provider, the way the composer would. Only the
@@ -397,15 +452,42 @@ export function Chat({
     <section className="v2-chat">
       {thread === null ? null : (
         <header className="v2-thread-head">
-          <h1>{titleOf(thread.header)}</h1>
+          <h1>
+            {editing ? (
+              <input
+                className="v2-thread-title-edit"
+                aria-label="Conversation title"
+                value={titleDraft}
+                autoFocus
+                onChange={event => setTitleDraft(event.target.value)}
+                onKeyDown={event => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    commitRename();
+                  } else if (event.key === 'Escape') {
+                    event.preventDefault();
+                    cancelRename();
+                  }
+                }}
+                onBlur={commitRename}
+              />
+            ) : (
+              <button type="button" className="v2-thread-rename" title="Rename this conversation" onClick={startRename}>
+                {titleOf(thread.header)}
+              </button>
+            )}
+          </h1>
           {/* Set text with a small-caps run-in, linked to the file — not a
-              pill (the ledger language has none). */}
+              pill (the ledger language has none). An inferred matter says
+              so; the picker beside it makes the link explicit. */}
           {matterPath === null || matterTitle === null ? null : (
             <a className="v2-thread-matter" href={`#/vault?path=${encodeURIComponent(matterPath)}`} title={matterPath}>
               <span className="v2-tag">Matter</span>
               <span className="v2-thread-matter-name">{matterTitle}</span>
             </a>
           )}
+          {matterInferred ? <span className="v2-thread-inferred">inferred</span> : null}
+          <MatterPicker current={explicitMatter} label={matterPath === null ? 'link a matter' : 'change'} onPick={path => void patchThread({ matter: path })} />
           <span className="v2-thread-date">{relTime(thread.header.createdAt)}</span>
         </header>
       )}

--- a/runtime/ui/src/v2/chat/MatterPicker.tsx
+++ b/runtime/ui/src/v2/chat/MatterPicker.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from 'react';
+import { useButton, useMenuTrigger } from 'react-aria';
+import { Item, useMenuTriggerState } from 'react-stately';
+import { ApiError, fetchJson } from '../../api/client';
+import type { MatterOverview, VaultOverview } from '../../api/types';
+import { HeadlessMenu } from '../menu';
+
+/** The unlink row's key. A vault path always has a `/` or a `.`; this has neither. */
+const NONE_KEY = 'none';
+
+export interface MatterPickerProps {
+  /** The thread's EXPLICIT matter, or `null` (inferred does not count). */
+  current: string | null;
+  /** The trigger's text — "link a matter" when nothing is linked, "change" otherwise. */
+  label: string;
+  /** A pick: a matter path, or `null` to unlink. */
+  onPick(path: string | null): void;
+}
+
+interface Row {
+  id: string;
+}
+
+/**
+ * The thread header's matter picker: a small set-text affordance that opens a
+ * popover of the vault's matters (`GET /vault/overview`, read the first time
+ * it opens). Picking one makes the link EXPLICIT on the thread header, which
+ * inference never overwrites. Headless react-aria menu, no portal, no pill.
+ */
+export function MatterPicker({ current, label, onPick }: MatterPickerProps): JSX.Element {
+  const state = useMenuTriggerState({});
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const wrapRef = useRef<HTMLSpanElement | null>(null);
+  const { menuTriggerProps, menuProps } = useMenuTrigger<Row>({}, state, triggerRef);
+  const { buttonProps } = useButton(menuTriggerProps, triggerRef);
+  const [matters, setMatters] = useState<MatterOverview[] | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  // The overview is read once, on first open — the header does not need it
+  // until the reader reaches for the picker.
+  useEffect(() => {
+    if (!state.isOpen || matters !== null) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const overview = await fetchJson<VaultOverview>('/vault/overview');
+        if (!cancelled) setMatters(overview.matters);
+      } catch (err) {
+        if (!cancelled && !(err instanceof ApiError && err.status === 401)) setFailed(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [state.isOpen, matters]);
+
+  // Outside click closes (no overlay layer, so this is the dismiss story).
+  const closeRef = useRef(state.close);
+  closeRef.current = state.close;
+  useEffect(() => {
+    if (!state.isOpen) return;
+    const onDown = (event: Event): void => {
+      const target = event.target;
+      if (wrapRef.current !== null && target instanceof globalThis.Node && !wrapRef.current.contains(target)) {
+        closeRef.current();
+      }
+    };
+    document.addEventListener('pointerdown', onDown);
+    return () => document.removeEventListener('pointerdown', onDown);
+  }, [state.isOpen]);
+
+  const rows: Row[] = [...(current === null ? [] : [{ id: NONE_KEY }]), ...(matters ?? []).map(m => ({ id: m.path }))];
+  const children = (row: Row): JSX.Element => {
+    if (row.id === NONE_KEY) {
+      return (
+        <Item textValue="No matter">
+          <span className="v2-switch-settings">No matter</span>
+        </Item>
+      );
+    }
+    const matter = matters?.find(m => m.path === row.id);
+    return (
+      <Item textValue={matter?.title ?? row.id}>
+        <span className="v2-plate">
+          <span className="v2-plate-vendor">
+            <span className={row.id === current ? 'v2-dot' : 'v2-dot v2-dot-off'} aria-hidden="true" />
+            {matter?.title ?? row.id}
+          </span>
+          <span className="v2-plate-detail">{row.id}</span>
+        </span>
+      </Item>
+    );
+  };
+
+  const act = (key: React.Key): void => {
+    state.close();
+    const id = String(key);
+    if (id === NONE_KEY) {
+      if (current !== null) onPick(null);
+      return;
+    }
+    if (id !== current) onPick(id);
+  };
+
+  return (
+    <span className="v2-matter-pick" ref={wrapRef}>
+      <button {...buttonProps} ref={triggerRef} type="button" className="v2-thread-link">
+        {label}
+      </button>
+      {state.isOpen ? (
+        <div
+          className="v2-matter-pop"
+          onKeyDown={event => {
+            if (event.key === 'Escape') {
+              state.close();
+              triggerRef.current?.focus();
+            }
+          }}
+        >
+          {failed ? (
+            <p className="muted v2-matter-note" role="alert">
+              Could not read the vault&rsquo;s matters.
+            </p>
+          ) : matters === null ? (
+            <p className="muted v2-matter-note">Loading…</p>
+          ) : rows.length === 0 ? (
+            <p className="muted v2-matter-note">No matters in the vault yet.</p>
+          ) : (
+            <HeadlessMenu {...menuProps} label="Link a matter" items={rows} autoFocus={state.focusStrategy || true} onAction={act} onClose={state.close}>
+              {children}
+            </HeadlessMenu>
+          )}
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/runtime/ui/src/v2/menu.tsx
+++ b/runtime/ui/src/v2/menu.tsx
@@ -1,0 +1,47 @@
+import { useRef } from 'react';
+import { useMenu, useMenuItem, type AriaMenuProps } from 'react-aria';
+import { useTreeState, type TreeState } from 'react-stately';
+import type { Node } from '@react-types/shared';
+
+export interface HeadlessMenuProps<T extends object> extends AriaMenuProps<T> {
+  /** The menu's own accessible name. It REPLACES the trigger's
+   * `aria-labelledby` (which would otherwise name the menu after the whole
+   * trigger text and outrank any `aria-label`). */
+  label: string;
+  className?: string;
+  itemClassName?: string;
+  onClose(): void;
+}
+
+/**
+ * The headless react-aria menu under our own markup — the pattern
+ * `ModelSwitcher` established (cou-90), lifted so the next popover (the
+ * thread header's matter picker) does not copy it. No portal: the caller
+ * positions the list inside its own DOM.
+ *
+ * `onAction`/`onClose` register HERE and reach every row through the menu's
+ * own plumbing; passing them to `useMenuItem` again would fire each pick
+ * twice.
+ */
+export function HeadlessMenu<T extends object>(props: HeadlessMenuProps<T>): JSX.Element {
+  const state = useTreeState(props);
+  const ref = useRef<HTMLUListElement | null>(null);
+  const { menuProps } = useMenu({ ...props, 'aria-label': props.label, 'aria-labelledby': undefined }, state, ref);
+  return (
+    <ul {...menuProps} ref={ref} className={props.className ?? 'v2-switch-list'}>
+      {[...state.collection].map(item => (
+        <MenuRow key={item.key} item={item} state={state} className={props.itemClassName ?? 'v2-switch-item'} />
+      ))}
+    </ul>
+  );
+}
+
+function MenuRow<T extends object>({ item, state, className }: { item: Node<T>; state: TreeState<T>; className: string }): JSX.Element {
+  const ref = useRef<HTMLLIElement | null>(null);
+  const { menuItemProps, isFocused } = useMenuItem({ key: item.key }, state, ref);
+  return (
+    <li {...menuItemProps} ref={ref} className={className} data-focused={isFocused ? true : undefined}>
+      {item.rendered}
+    </li>
+  );
+}


### PR DESCRIPTION
Pair-built (formerly cou-96). Three things a lawyer could not do with a conversation: name it, say which matter it belongs to, and delete it without a browser dialog.

**Runtime**
- `PATCH /threads/:id` — `{ title }` (trimmed; `''` clears back to the derived title) and/or `{ matter }` (vault-relative path; `null` unlinks). Strict body; 400 on anything else; 404 on an unknown thread; under the thread lock.
- `ThreadStore.update` writes the header **without** bumping `updatedAt`, so a rename never jumps the row in the rail.

**Thread header**
- The title is the control: click it, edit in the same face, Enter or blur saves, Escape restores. Unchanged text sends nothing.
- Matter line: the explicit link when there is one, else the inferred first-matter-read marked *inferred*. "link a matter" / "change" opens a headless react-aria popover over `/vault/overview` matters (title + path), with a "No matter" row to unlink. Inference never overwrites an explicit link. `v2/menu.tsx` lifts the ModelSwitcher's menu pattern so the two share one implementation.

**Rail**
- An explicitly linked thread shows the matter's title as a faint second line (titles from `/vault/overview`, read once beside `/health`; prettified filename fallback).
- × turns the row into `Delete this? · Delete · Keep` in set text. Escape or Keep restores. `window.confirm` is gone.

Tests: `bun run test` 621 pass · `bun run ui:test` 372 pass · both typechecks clean. Checked in a real browser on a seeded throwaway vault (header, picker, confirm row, rename input).