### PR TITLE
ui: reader dochead and frontmatter stack on a narrow pane

### DIFF
--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -531,13 +531,18 @@ a { color: var(--accent); }
 .v2-drawer-file .v2-doc { padding: 8px 4px 40px; }
 .v2-doc-crumbs { font: 12.5px var(--mono); color: var(--fg-faint); margin-bottom: 8px; }
 .v2-doc-crumbs b { color: var(--fg-muted); font-weight: 500; }
-.v2-doc-head { display: flex; align-items: baseline; gap: 14px; border-bottom: 1px solid var(--border); padding-bottom: 14px; margin-bottom: 24px; }
-.v2-doc-head h1 { font: 600 24px/1.25 var(--serif); margin: 0; }
+/* The title owns the line. The meta sits beside it only while there is room
+   for a real measure (~24ch); on a narrow pane it drops UNDER the title
+   instead of squeezing it to one word per line. */
+.v2-doc-head { display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px 14px; border-bottom: 1px solid var(--border); padding-bottom: 14px; margin-bottom: 24px; }
+.v2-doc-head h1 { font: 600 24px/1.25 var(--serif); margin: 0; flex: 1 1 24ch; min-width: 0; }
 .v2-doc-meta { margin-left: auto; font: 12px var(--mono); color: var(--fg-faint); flex-shrink: 0; white-space: nowrap; }
-.v2-fm { columns: 2; gap: 40px; margin: 0 0 26px; border-bottom: 1px solid var(--border); padding-bottom: 16px; }
-.v2-fm-row { display: flex; align-items: baseline; font-size: 13px; color: var(--fg-faint); padding: 2px 0; break-inside: avoid; }
+/* Two columns while each can hold ~280px, one column below that — and values
+   wrap at words, never mid-word (`anywhere` split "Publishing" in three). */
+.v2-fm { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); column-gap: 40px; margin: 0 0 26px; border-bottom: 1px solid var(--border); padding-bottom: 16px; }
+.v2-fm-row { display: flex; align-items: baseline; font-size: 13px; color: var(--fg-faint); padding: 2px 0; min-width: 0; }
 .v2-fm-row dt { color: var(--fg-faint); white-space: nowrap; }
-.v2-fm-row dd { margin: 0; color: var(--fg); font-weight: 600; text-align: right; overflow-wrap: anywhere; min-width: 0; }
+.v2-fm-row dd { margin: 0; color: var(--fg); font-weight: 600; text-align: right; overflow-wrap: break-word; min-width: 0; }
 .v2-doc-md { font: 16.5px/1.7 var(--serif); color: var(--fg); max-width: 68ch; }
 .v2-doc-md h2 { font: 600 18px/1.3 var(--serif); margin: 26px 0 10px; }
 .v2-doc-md code, .v2-doc-md pre { font-family: var(--mono); }


### PR DESCRIPTION
Founder screenshot 2026-09-01: at a narrow window the reader title wrapped one word per line and frontmatter values broke mid-word. Fix: the dochead wraps (title keeps a 24ch measure, meta drops under), the frontmatter is an auto-fit grid (two columns ≥ ~280px each, else one) and values wrap at words. Tokens-only CSS change; vault UI tests pass (41), typecheck clean; verified by screenshot at 900px and 1440px.