### PR TITLE
runtime+ui: document intake — upload and drag-and-drop for Word documents (stage 1 step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Word documents in TypeScript — stage 1, the read path (spec: docs/superpowers/
 - CLI: `bun runtime/src/cli.ts docx read|extract|check <file>` for the plugin path and the shell; the `read` primitive no longer prescribes pandoc.
 - API: `GET /vault/read` converts a `.docx` (`kind: "docx"`, markdown, warnings) instead of returning bytes as text; `GET /vault/download` streams any vault file with the right headers.
 - Reader: a Word document renders as a document — converted body, its own tracked changes in the redline tints, comments as quiet notes, a WORD DOCUMENT line with download.
+- Intake: drop a Word document on Home's ask box or the chat composer — it uploads (`POST /vault/upload`) into the linked matter's folder or `matters/inbox/`, never overwriting (`nda-2.docx`), and lands in the message as a path chip; the result line offers "move to a matter" (`POST /vault/move`). Only `.docx`, 25 MB cap, hostile packages refused before they are stored. `matters/inbox/` is now a documented convention (CONFIGURATION.md).
 
 
 ## [0.11.2] — 2026-08-31

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -65,6 +65,20 @@ For per-file ownership, set `managed-by: user` in an individual law file's
 frontmatter — update skips marked files (even under auto-apply) and law-refresh
 maintains them. Custom law areas the user creates are user-owned automatically.
 
+## Documents in matters
+
+A matter's documents live beside it. A matter that is its own folder
+(`{matters_path}/acme/matter.md`) keeps its Word documents in that folder; a
+flat matter file (`{matters_path}/acme.md`) gets a folder named after it
+(`{matters_path}/acme/`) the first time a document is added.
+
+A document added with no matter chosen — dropped on Home's ask box, say —
+lands in **`{matters_path}/inbox/`**. The inbox is a holding folder, not a
+matter: nothing reads it as one, and the runtime offers "move to a matter"
+right after the drop. Uploaded files are never overwritten; a second
+`nda.docx` in the same folder becomes `nda-2.docx`. Only Word documents
+(`.docx`) can be added this way for now; the size limit is 25 MB.
+
 ## Path resolution
 
 Legal framework (`law/`, `practice/`, `memory/`) reads from `{legal_root}`.

--- a/e2e/intake.spec.ts
+++ b/e2e/intake.spec.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { expect, test } from '@playwright/test';
+import { ROOT, RUNTIME_FILE } from './paths';
+
+/**
+ * Document intake, end to end (docx spec §6): the demo NDA dropped on
+ * Home's ask box goes to `matters/inbox/` through `POST /vault/upload`, the
+ * chip appears in the message row, and the result line says where it went.
+ * Runs against the same `serve --fake` as `ui.spec.ts`; it creates no
+ * thread, so the other story's counts are untouched.
+ */
+
+async function token(): Promise<string> {
+  let last: unknown;
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      const parsed = JSON.parse(readFileSync(RUNTIME_FILE, 'utf8')) as { token?: string };
+      if (typeof parsed.token === 'string' && parsed.token !== '') return parsed.token;
+    } catch (err) {
+      last = err;
+    }
+    await new Promise(done => setTimeout(done, 100));
+  }
+  throw new Error(`no token in ${RUNTIME_FILE}: ${String(last)}`);
+}
+
+test('a Word document dropped on the ask box lands in the inbox and in the message', async ({ page }) => {
+  await page.goto(`/#token=${await token()}`);
+  await expect(page.locator('.v2-hi')).toHaveText(/Good (morning|afternoon|evening)\./);
+
+  const bytes = Array.from(readFileSync(join(ROOT, 'skills', 'demo', 'assets', 'sample-mutual-nda.docx')));
+  const transfer = await page.evaluateHandle(({ bytes: raw, name }) => {
+    const dt = new DataTransfer();
+    dt.items.add(new File([new Uint8Array(raw)], name, { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }));
+    return dt;
+  }, { bytes, name: 'sample-mutual-nda.docx' });
+
+  const box = page.locator('.v2-ask');
+  await box.dispatchEvent('dragenter', { dataTransfer: transfer });
+  await expect(page.locator('.v2-drop em')).toHaveText('Drop a Word document to add it to the matter');
+  await box.dispatchEvent('drop', { dataTransfer: transfer });
+
+  await expect(page.locator('.v2-intake')).toContainText('Added sample-mutual-nda.docx to matters/inbox');
+  await expect(page.locator('.v2-intake')).toContainText('KB');
+  await expect(page.getByRole('button', { name: 'move to a matter' })).toBeVisible();
+  await expect(page.locator('.v2-ask-attached')).toHaveText('matters/inbox/sample-mutual-nda.docx');
+  await expect(page.locator('.v2-drop')).toHaveCount(0);
+
+  // The file is real: the reader converts it.
+  await page.goto(`/#/vault?path=${encodeURIComponent('matters/inbox/sample-mutual-nda.docx')}`);
+  await expect(page.locator('.v2-doc-head h1')).toHaveText('MUTUAL NON-DISCLOSURE AGREEMENT');
+  await expect(page.locator('.v2-doc-word')).toContainText('converted for reading');
+});

--- a/runtime/src/core/types.ts
+++ b/runtime/src/core/types.ts
@@ -118,6 +118,11 @@ export interface VaultStore {
   /** The file's raw bytes — a Word document, a PDF — under the same path
    * guards as `read`. Optional: an in-memory store may hold only text. */
   readBytes?(tenant: Tenant, path: string): Promise<Uint8Array>;
+  /** Writes raw bytes (an uploaded Word document) under the same path
+   * guards as `write`. Never overwrites: the caller picks a free name. */
+  writeBytes?(tenant: Tenant, path: string, bytes: Uint8Array): Promise<Version>;
+  /** Moves a file inside the vault. Both paths pass the same guards. */
+  rename?(tenant: Tenant, from: string, to: string): Promise<void>;
 }
 
 // ── Tools with platform gating (subprocess scripts, browse, docx) ─────────

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import { randomUUID } from 'node:crypto';
-import { mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { FakeModelProvider, runToolDef } from '../core/fake-provider';
@@ -10,7 +10,7 @@ import { ThreadStore, type ThreadEvent } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
 import { fsSearch } from '../vault/search';
 import { buildDocx } from '../docx/test/builder';
-import { API_PREFIXES, createApp, TRUNCATED_HEADER, type App, type ServerDeps } from './routes';
+import { API_PREFIXES, createApp, safeBasename, suffixed, TRUNCATED_HEADER, UPLOAD_MAX_BYTES, type App, type ServerDeps } from './routes';
 import type { RuntimeState } from './settings';
 
 const TOKEN = 'test-token-0123456789';
@@ -1220,5 +1220,88 @@ describe('Word documents (docx read path, stage 1)', () => {
     const app = appWithFake();
     expect((await call(app, 'GET', '/vault/download?path=matters/acme/notes.md', { token: null })).status).toBe(401);
     expect((await call(app, 'GET', '/vault/download?path=matters/acme/notes.md', { token: 'wrong' })).status).toBe(401);
+  });
+});
+
+describe('POST /vault/upload and /vault/move (docx intake, stage 1 step 3)', () => {
+  const AT = '2026-08-28T10:00:00Z';
+  function upload(app: App, name: string, bytes: Uint8Array, dest?: string, token: string | null = TOKEN): Promise<Response> {
+    const form = new FormData();
+    form.set('file', new File([bytes], name, { type: 'application/octet-stream' }));
+    if (dest !== undefined) form.set('dest', dest);
+    const headers: Record<string, string> = {};
+    if (token !== null) headers['authorization'] = `Bearer ${token}`;
+    return app(new Request('http://127.0.0.1:7431/vault/upload', { method: 'POST', headers, body: form }));
+  }
+  const nda = () => buildDocx({ blocks: [{ runs: ['Term: ', { text: 'two', del: { author: 'R', date: AT } }, { text: 'one', ins: { author: 'R', date: AT } }] }] });
+
+  test('lands in matters/inbox by default, never overwrites, and reads back converted', async () => {
+    const app = appWithFake();
+    const first = await upload(app, 'Acme NDA v3.docx', nda());
+    expect(first.status).toBe(201);
+    expect(await first.json()).toEqual({ path: 'matters/inbox/Acme NDA v3.docx', size: nda().byteLength });
+    const second = await upload(app, 'Acme NDA v3.docx', nda());
+    expect((await second.json()) as { path: string }).toMatchObject({ path: 'matters/inbox/Acme NDA v3-2.docx' });
+    const third = await upload(app, 'Acme NDA v3.docx', nda());
+    expect((await third.json()) as { path: string }).toMatchObject({ path: 'matters/inbox/Acme NDA v3-3.docx' });
+    const read = (await (await call(app, 'GET', `/vault/read?path=${encodeURIComponent('matters/inbox/Acme NDA v3.docx')}`)).json()) as { kind: string; content: string };
+    expect(read.kind).toBe('docx');
+    expect(read.content).toContain('{--two--}{++one++}');
+    expect(readFileSync(join(vaultRoot, 'matters/inbox/Acme NDA v3.docx')).byteLength).toBe(nda().byteLength);
+  });
+
+  test('a matter folder as dest; a path outside matters/, an escape, or the runtime dir is 400', async () => {
+    const app = appWithFake();
+    const ok = await upload(app, 'nda.docx', nda(), 'matters/acme');
+    expect(ok.status).toBe(201);
+    expect((await ok.json()) as { path: string }).toMatchObject({ path: 'matters/acme/nda.docx' });
+    for (const dest of ['practice/standards', '../x', 'matters/../practice', '.counsel', 'mattersx']) {
+      const res = await upload(app, 'nda.docx', nda(), dest);
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test('the filename is reduced to a safe basename', async () => {
+    const app = appWithFake();
+    const res = await upload(app, '../../evil/..secret:ver|sion?.docx', nda());
+    expect(res.status).toBe(201);
+    expect((await res.json()) as { path: string }).toMatchObject({ path: 'matters/inbox/secret_ver_sion_.docx' });
+    expect(safeBasename('')).toBe('document');
+    expect(suffixed('a.b.docx', 2)).toBe('a.b-2.docx');
+    expect(suffixed('noext', 3)).toBe('noext-3');
+  });
+
+  test('only .docx (415), a non-Word .docx (415), a DOCTYPE part (422), over the cap (413)', async () => {
+    const app = appWithFake();
+    expect((await upload(app, 'Acme-NDA.pages', nda())).status).toBe(415);
+    const pdf = await upload(app, 'scan.pdf', new TextEncoder().encode('%PDF-1.4'));
+    expect(pdf.status).toBe(415);
+    expect(((await pdf.json()) as { error: string }).error).toContain('only Word documents (.docx)');
+    expect((await upload(app, 'fake.docx', new TextEncoder().encode('not a zip'))).status).toBe(415);
+    const hostile = '<?xml version="1.0"?><!DOCTYPE hdr [ <!ENTITY x SYSTEM "file:///etc/hostname"> ]><w:hdr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:p><w:r><w:t>&x;</w:t></w:r></w:p></w:hdr>';
+    const bad = await upload(app, 'bad.docx', buildDocx({ blocks: [{ runs: ['x'] }], rawParts: { 'word/header1.xml': hostile } }));
+    expect(bad.status).toBe(422);
+    expect(((await bad.json()) as { error: string }).error).toContain('word/header1.xml');
+    expect(existsSync(join(vaultRoot, 'matters/inbox/bad.docx'))).toBe(false);
+    const big = new Uint8Array(UPLOAD_MAX_BYTES + 1);
+    expect((await upload(app, 'big.docx', big)).status).toBe(413);
+    expect((await upload(app, 'nda.docx', nda(), undefined, null)).status).toBe(401);
+    const noFile = await app(new Request('http://127.0.0.1:7431/vault/upload', { method: 'POST', headers: { authorization: `Bearer ${TOKEN}` }, body: new FormData() }));
+    expect(noFile.status).toBe(400);
+  });
+
+  test('move: inbox → a matter folder, never overwriting; outside matters/ is 400; missing is 404', async () => {
+    const app = appWithFake();
+    await upload(app, 'nda.docx', nda());
+    await upload(app, 'nda.docx', nda(), 'matters/acme');
+    const moved = await call(app, 'POST', '/vault/move', { body: { from: 'matters/inbox/nda.docx', to: 'matters/acme' } });
+    expect(moved.status).toBe(200);
+    expect(await moved.json()).toEqual({ path: 'matters/acme/nda-2.docx' });
+    expect(existsSync(join(vaultRoot, 'matters/inbox/nda.docx'))).toBe(false);
+    expect(existsSync(join(vaultRoot, 'matters/acme/nda-2.docx'))).toBe(true);
+    expect((await call(app, 'POST', '/vault/move', { body: { from: 'practice/standards/nda.md', to: 'matters/acme' } })).status).toBe(400);
+    expect((await call(app, 'POST', '/vault/move', { body: { from: 'matters/acme/nda.docx', to: 'practice' } })).status).toBe(400);
+    expect((await call(app, 'POST', '/vault/move', { body: { from: 'matters/inbox/none.docx', to: 'matters/acme' } })).status).toBe(404);
+    expect((await call(app, 'POST', '/vault/move', { body: { from: '' } })).status).toBe(400);
   });
 });

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -5,6 +5,7 @@ import { pendingProposals } from '../loop/pending-proposals';
 import { applyProposal } from '../loop/proposals';
 import { listRuns, readRun, type RunRecord } from '../loop/run-record';
 import { DOCX_CONTENT_TYPE, docxToMarkdown, isDocxPath, NotADocxError, openDocx, UnsafeXmlError } from '../docx';
+import { assertSafeXml } from '../docx/safety';
 import { RegistryFile } from '../providers/registry';
 import type { ThreadEvent, ThreadHeader } from '../threads/store';
 import { vaultDocket } from '../vault/docket';
@@ -211,6 +212,36 @@ export function contentTypeFor(name: string): string {
 export function contentDisposition(name: string): string {
   const ascii = name.replace(/[^\x20-\x7e]/g, '_').replace(/["\\]/g, '_');
   return `attachment; filename="${ascii}"; filename*=UTF-8''${encodeURIComponent(name)}`;
+}
+
+/** How large an upload may be. A contract is tens of kilobytes; a 25 MB
+ * Word file is a scanned exhibit, which the reader cannot show anyway. */
+export const UPLOAD_MAX_BYTES = 25 * 1024 * 1024;
+
+/** The folder a drop lands in when no matter is chosen (spec §10). */
+export const INBOX_DIR = 'inbox';
+
+/**
+ * A safe file name from whatever the browser sent: the basename only (a
+ * path in a filename is an escape attempt or a browser quirk, never a
+ * wish), control characters and the characters no filesystem accepts
+ * replaced, no leading dots (a dotfile would vanish from the tree).
+ */
+export function safeBasename(name: string): string {
+  const base = name.split(/[\\/]/).pop() ?? '';
+  const cleaned = base
+    .replace(/[\x00-\x1f\x7f]/g, '')
+    .replace(/[<>:"|?*]/g, '_')
+    .replace(/^\.+/, '')
+    .trim();
+  return cleaned === '' ? 'document' : cleaned;
+}
+
+/** `name-2.ext`, `name-3.ext`, … for the given ordinal (1 = the name itself). */
+export function suffixed(name: string, n: number): string {
+  if (n <= 1) return name;
+  const dot = name.lastIndexOf('.');
+  return dot <= 0 ? `${name}-${n}` : `${name.slice(0, dot)}-${n}${name.slice(dot)}`;
 }
 
 /** Maps a store failure on a normalized path: `.counsel/` is reserved (400),
@@ -564,6 +595,88 @@ export function createApp(deps: ServerDeps): App {
     }
   };
 
+  /** A directory under the matters directory, normalized, or a 400. `''`
+   * (omitted) is the inbox. */
+  const mattersDest = (raw: string | null): string => {
+    const { mattersPath } = readVaultConfig(deps.vaultRoot);
+    if (raw === null || raw.trim() === '') return `${mattersPath}/${INBOX_DIR}`;
+    const dest = vaultPath(raw).replace(/\/+$/, '');
+    if (dest !== mattersPath && !dest.startsWith(`${mattersPath}/`)) {
+      throw new HttpError(400, `documents go under ${mattersPath}/ — a matter folder, or the inbox`);
+    }
+    return dest;
+  };
+
+  /** `dir/name`, or `dir/name-2`, … — the first path nothing is at. */
+  const freePath = async (dir: string, name: string): Promise<string> => {
+    for (let n = 1; n < 1000; n += 1) {
+      const candidate = `${dir}/${suffixed(name, n)}`;
+      if ((await deps.vault.mtime?.(deps.tenant, candidate)) === null) return candidate;
+    }
+    throw new HttpError(409, `too many files called ${name} in ${dir}`);
+  };
+
+  /**
+   * `POST /vault/upload` (multipart: `file`, optional `dest`): a Word
+   * document into a matter folder or the inbox. The package is opened once
+   * here — not a zip, or not a Word document, is 415; any part with a
+   * DOCTYPE is 422 — so nothing the reader will refuse later gets stored.
+   * The name is never reused: a second `nda.docx` becomes `nda-2.docx`.
+   */
+  const vaultUpload = async (req: Request): Promise<Response> => {
+    if (deps.vault.writeBytes === undefined) throw new HttpError(501, 'this vault store holds text only');
+    let form: Awaited<ReturnType<Request['formData']>>;
+    try {
+      form = await req.formData();
+    } catch {
+      throw new HttpError(400, 'expected multipart form data with a `file` field');
+    }
+    const file = form.get('file');
+    if (!(file instanceof Blob)) throw new HttpError(400, 'a `file` field is required');
+    const name = safeBasename((file as File).name ?? '');
+    if (!isDocxPath(name)) throw new HttpError(415, `only Word documents (.docx) can be added for now: ${name}`);
+    if (file.size > UPLOAD_MAX_BYTES) throw new HttpError(413, `${name} is ${Math.round(file.size / 1024 / 1024)} MB; the limit is ${UPLOAD_MAX_BYTES / 1024 / 1024} MB`);
+    const destRaw = form.get('dest');
+    const dir = mattersDest(typeof destRaw === 'string' ? destRaw : null);
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    try {
+      const pkg = openDocx(bytes);
+      for (const part of pkg.partNames()) {
+        if (/\.(xml|rels)$/i.test(part)) assertSafeXml(pkg.partText(part), part);
+      }
+    } catch (err) {
+      if (err instanceof NotADocxError) throw new HttpError(415, `${name} is not a Word document`);
+      if (err instanceof UnsafeXmlError) throw new HttpError(422, `refused: ${err.message}`);
+      throw err;
+    }
+    const path = await freePath(dir, name);
+    try {
+      await deps.vault.writeBytes(deps.tenant, path, bytes);
+    } catch (err) {
+      vaultFailure(err);
+    }
+    return json({ path, size: bytes.byteLength }, 201);
+  };
+
+  /** `POST /vault/move` `{ from, to }`: a file from one matter folder (or
+   * the inbox) to another, never overwriting. Both under the matters dir. */
+  const vaultMove = async (req: Request): Promise<Response> => {
+    if (deps.vault.rename === undefined) throw new HttpError(501, 'this vault store cannot move files');
+    const body = z.object({ from: z.string().min(1), to: z.string().min(1) }).safeParse(await req.json().catch(() => null));
+    if (!body.success) throw new HttpError(400, 'expected { from, to }');
+    const from = vaultPath(body.data.from);
+    const { mattersPath } = readVaultConfig(deps.vaultRoot);
+    if (!from.startsWith(`${mattersPath}/`)) throw new HttpError(400, `only files under ${mattersPath}/ can be moved`);
+    const dir = mattersDest(body.data.to);
+    const path = await freePath(dir, from.slice(from.lastIndexOf('/') + 1));
+    try {
+      await deps.vault.rename(deps.tenant, from, path);
+    } catch (err) {
+      vaultFailure(err);
+    }
+    return json({ path });
+  };
+
   /** A vault file as bytes, for the reader's download link. Same path
    * guards as `read`; the content type follows the extension. */
   const vaultDownload = async (url: URL): Promise<Response> => {
@@ -710,6 +823,11 @@ export function createApp(deps: ServerDeps): App {
 
       if (segments.length === 2 && first === 'settings' && second === 'test' && method === 'POST') {
         return await runProviderTest(req);
+      }
+
+      if (segments.length === 2 && first === 'vault' && method === 'POST') {
+        if (second === 'upload') return await vaultUpload(req);
+        if (second === 'move') return await vaultMove(req);
       }
 
       if (segments.length === 2 && first === 'vault' && method === 'GET') {

--- a/runtime/src/vault/fs-store.ts
+++ b/runtime/src/vault/fs-store.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import { existsSync, realpathSync } from 'node:fs';
-import { mkdir, readdir, readFile, writeFile, appendFile, lstat, stat } from 'node:fs/promises';
+import { mkdir, readdir, readFile, writeFile, appendFile, lstat, stat, link, unlink } from 'node:fs/promises';
 import { dirname, join, relative, resolve, sep } from 'node:path';
 import type { Entry, Hit, Tenant, VaultStore, Version } from '../core/types';
 import { VaultConflictError } from '../core/types';
@@ -128,6 +128,30 @@ export class FsVaultStore implements VaultStore {
   async readBytes(tenant: Tenant, path: string): Promise<Uint8Array> {
     const buf = await readFile(this.abs(tenant, path));
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
+  }
+
+  /** Bytes in, with the same history line a text write leaves — the version
+   * is the SHA-256 of the bytes, so a re-upload of the same file has the
+   * same version. `wx`: the file must not exist; the route picks the name. */
+  async writeBytes(tenant: Tenant, path: string, bytes: Uint8Array): Promise<Version> {
+    const full = this.abs(tenant, path);
+    await mkdir(dirname(full), { recursive: true });
+    await writeFile(full, bytes, { flag: 'wx' });
+    const v = createHash('sha256').update(bytes).digest('hex');
+    const hf = this.historyFile(tenant, path);
+    await mkdir(dirname(hf), { recursive: true });
+    await appendFile(hf, JSON.stringify({ version: v, at: new Date().toISOString() }) + '\n', 'utf8');
+    return v;
+  }
+
+  async rename(tenant: Tenant, from: string, to: string): Promise<void> {
+    const src = this.abs(tenant, from);
+    const dst = this.abs(tenant, to);
+    await mkdir(dirname(dst), { recursive: true });
+    // `link` + `unlink` rather than `rename`: never clobbers an existing
+    // target (EEXIST), where `rename` would silently replace it.
+    await link(src, dst);
+    await unlink(src);
   }
 
   async version(tenant: Tenant, path: string): Promise<Version | null> {

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -106,6 +106,31 @@ export async function fetchBlob(path: string): Promise<Blob> {
   return res.blob();
 }
 
+export interface Uploaded {
+  path: string;
+  size: number;
+}
+
+/**
+ * A Word document into the vault (`POST /vault/upload`): into `dest` (a
+ * matter folder under the matters directory) or, with no `dest`, the inbox.
+ * Multipart, so the browser sets the boundary; the bearer rides in the
+ * header as everywhere else.
+ */
+export async function uploadFile(file: File, dest?: string): Promise<Uploaded> {
+  const form = new FormData();
+  form.set('file', file, file.name);
+  if (dest !== undefined && dest !== '') form.set('dest', dest);
+  const res = await fetch('/vault/upload', { method: 'POST', headers: authHeaders(), body: form });
+  if (!res.ok) throw await failure(res);
+  return (await res.json()) as Uploaded;
+}
+
+/** Moves a vault file into another matter folder (`POST /vault/move`). */
+export async function moveFile(from: string, to: string): Promise<{ path: string }> {
+  return fetchJson<{ path: string }>('/vault/move', { method: 'POST', body: JSON.stringify({ from, to }) });
+}
+
 /**
  * Hands `blob` to the browser as a download named `filename`, through a
  * one-shot object URL that is revoked once the click has been dispatched.

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -634,6 +634,17 @@ a { color: var(--accent); }
 .v2-ask-chip { font-size: 12px; color: var(--fg-muted); border: 1px solid var(--border-strong); border-radius: 999px; padding: 3px 10px; background: var(--bg); cursor: pointer; }
 .v2-ask-attached { font-family: var(--mono); }
 .v2-ask-attached::after { content: " ×"; color: var(--fg-faint); }
+/* Document intake (docx spec §6): the drop zone is a dashed inset drawn
+   INSIDE the existing box — no new container — with one italic serif line;
+   the result and any refusal are one set-text line under the box. */
+.v2-ask, .v2-composer-box { position: relative; }
+.v2-drop { position: absolute; inset: 8px; border: 1px dashed var(--border-strong); border-radius: 10px; background: var(--bg-raised); display: flex; align-items: center; justify-content: center; font: italic 15px var(--serif); color: var(--fg-muted); pointer-events: none; z-index: 2; }
+.v2-intake { display: flex; flex-wrap: wrap; align-items: baseline; gap: 6px; margin: 6px 4px 0; font-size: 12.5px; color: var(--fg-muted); }
+.v2-intake-error { color: var(--error); }
+.v2-composer-matter { max-width: 720px; margin: 0 auto 8px; display: flex; align-items: baseline; gap: 8px; font-size: 12.5px; color: var(--fg-muted); }
+.v2-composer-matter .v2-tag { font-size: 9.5px; }
+.v2-composer-matter-title { color: var(--fg); }
+.v2-composer-actions .v2-ask-chip { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .v2-ask-go { margin-left: auto; background: var(--accent); color: var(--accent-ink); border: none; border-radius: 9px; padding: 7px 16px; font-weight: 600; font-size: 13.5px; cursor: pointer; }
 .v2-ask-go:disabled { opacity: 0.5; cursor: default; }
 .v2-ask-picker { margin-top: 10px; max-height: 16rem; overflow-y: auto; border-top: 1px solid var(--border); }

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -6,6 +6,7 @@ import { applyStepEvent, buildTurns, emptyAssistantTurn, type AssistantTurn, typ
 import { createThread, defaultProviderId, titleFor } from '../threads';
 import { relTime } from '../time';
 import { prettifyName, readerModel } from '../vault/frontmatter';
+import { matterFolderOf } from '../intake';
 import { Composer, type ComposerSeed } from './Composer';
 import { MatterPicker } from './MatterPicker';
 import { TurnView } from './Turn';
@@ -531,6 +532,8 @@ export function Chat({
       <Composer
         streaming={streaming}
         health={health}
+        matter={explicitMatter === null || matterTitle === null ? null : { path: explicitMatter, title: matterTitle }}
+        {...(explicitMatter === null ? {} : { dropDest: matterFolderOf(explicitMatter) })}
         seed={seed}
         onSeedUsed={onSeedUsed}
         onSend={message => void send(message, defaultProviderId(health))}

--- a/runtime/ui/src/v2/chat/Composer.test.tsx
+++ b/runtime/ui/src/v2/chat/Composer.test.tsx
@@ -92,3 +92,63 @@ describe('v2 Composer swap notice (cou-95)', () => {
     expect(screen.queryByRole('status')).toBeNull();
   });
 });
+
+describe('v2 Composer document intake (docx spec §6)', () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+    sessionStorage.clear();
+  });
+  const dt = (files: File[]) => ({ files, types: ['Files'], items: [] });
+  const NDA = () => new File([new Uint8Array([80, 75])], 'Lerner-draft.docx');
+
+  test('the matter line shows for an explicit matter, and drops go to its folder', async () => {
+    sessionStorage.setItem('counsel-os.token', 'tok');
+    const uploads: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const form = init?.body as FormData;
+      uploads.push(`${String(input)} ${(form.get('file') as File).name}→${form.get('dest') as string}`);
+      return new Response(JSON.stringify({ path: 'matters/sinai-lerner/Lerner-draft.docx', size: 2048 }), { status: 201, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    const sent: string[] = [];
+    render(
+      <Composer
+        streaming={false}
+        onSend={m => sent.push(m)}
+        onStop={noop}
+        matter={{ path: 'matters/sinai-lerner.md', title: 'Sinai × Lerner — K-12 AI Education Platform Partnership' }}
+        dropDest="matters/sinai-lerner"
+      />,
+    );
+    const line = document.querySelector('.v2-composer-matter')!;
+    expect(line.textContent).toContain('Matter');
+    expect(line.textContent).toContain('Sinai × Lerner — K-12 AI Education Platform Partnership');
+    expect(line.textContent).toContain("dropped files go into this matter's folder");
+
+    const box = document.querySelector('.v2-composer-box')!;
+    fireEvent.dragEnter(box, { dataTransfer: dt([NDA()]) });
+    expect(document.querySelector('.v2-drop em')?.textContent).toBe('Drop a Word document to add it to the matter');
+    fireEvent.drop(box, { dataTransfer: dt([NDA()]) });
+    await screen.findByRole('status');
+    await new Promise(r => setTimeout(r, 0));
+    expect(uploads).toEqual(['/vault/upload Lerner-draft.docx→matters/sinai-lerner']);
+    expect(document.querySelector('.v2-drop')).toBeNull();
+    expect(document.querySelector('.v2-ask-attached')?.textContent).toBe('matters/sinai-lerner/Lerner-draft.docx');
+    expect(screen.getByRole('status').textContent).toBe('Added Lerner-draft.docx to matters/sinai-lerner · 2 KB');
+
+    // The chip alone is a sendable message; it rides as a backticked path.
+    const send = screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement;
+    expect(send.disabled).toBe(false);
+    await userEvent.click(send);
+    expect(sent).toEqual(['`matters/sinai-lerner/Lerner-draft.docx`']);
+    expect(document.querySelector('.v2-ask-attached')).toBeNull();
+  });
+
+  test('no matter: no line, and a non-Word drop is refused in one line', async () => {
+    render(<Composer streaming={false} onSend={noop} onStop={noop} />);
+    expect(document.querySelector('.v2-composer-matter')).toBeNull();
+    fireEvent.drop(document.querySelector('.v2-composer-box')!, { dataTransfer: dt([new File(['x'], 'scan.pdf')]) });
+    await screen.findByRole('alert');
+    expect(screen.getByRole('alert').textContent).toContain('only Word documents (.docx) can be added for now');
+  });
+});

--- a/runtime/ui/src/v2/chat/Composer.tsx
+++ b/runtime/ui/src/v2/chat/Composer.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import type { Health } from '../../api/types';
+import { withAttachments } from '../home/home';
+import { carriesFiles, droppedFiles, intake, type IntakeStatus } from '../intake';
 import { ProviderNotice } from '../ProviderNotice';
 
 /** A prefill pushed in from outside — the vault's "Ask counsel about this
@@ -25,6 +27,12 @@ export interface ComposerProps {
    * default is not loaded, so the reader learns which model will answer
    * BEFORE sending. Absent = no notice. */
   health?: Health | null;
+  /** The thread's EXPLICIT matter, for the line above the box and for where
+   * a dropped document lands. Absent or `null`: drops go to the inbox. */
+  matter?: { path: string; title: string } | null;
+  /** The folder a dropped Word document is uploaded into (the matter's
+   * folder). Undefined = the inbox. */
+  dropDest?: string;
 }
 
 /**
@@ -36,8 +44,13 @@ export interface ComposerProps {
  * picker under every message asked the reader to make a choice they had
  * already made once, in the one place that remembers it.
  */
-export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed, health }: ComposerProps): JSX.Element {
+export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed, health, matter = null, dropDest }: ComposerProps): JSX.Element {
   const [message, setMessage] = useState('');
+  /** Vault paths riding along with the message — a dropped document lands
+   * here as a chip, the way Home's "attach from vault" chips do. */
+  const [attached, setAttached] = useState<string[]>([]);
+  const [dragDepth, setDragDepth] = useState(0);
+  const [status, setStatus] = useState<IntakeStatus | null>(null);
   // Derived-from-props during render (React's own pattern), not an effect:
   // an effect would paint the empty box first and steal a keystroke typed
   // in between.
@@ -54,12 +67,26 @@ export function Composer({ streaming, disabled = false, onSend, onStop, seed, on
     if (seenSeed !== 0) usedRef.current?.();
   }, [seenSeed]);
 
+  const full = withAttachments(message, attached);
   const send = (): void => {
-    const trimmed = message.trim();
-    if (trimmed === '' || streaming || disabled) return;
-    onSend(trimmed);
+    if (full === '' || streaming || disabled) return;
+    onSend(full);
     setMessage('');
+    setAttached([]);
+    setStatus(null);
   };
+
+  /** A drop: one Word document into the matter's folder (or the inbox),
+   * then its path as a chip. The drag counter survives the enter/leave
+   * pairs a child element fires. */
+  const onDrop = (event: React.DragEvent): void => {
+    event.preventDefault();
+    setDragDepth(0);
+    void intake(droppedFiles(event.dataTransfer), dropDest, setStatus).then(up => {
+      if (up !== null) setAttached(current => (current.includes(up.path) ? current : [...current, up.path]));
+    });
+  };
+  const dragging = dragDepth > 0;
 
   return (
     <form
@@ -70,7 +97,31 @@ export function Composer({ streaming, disabled = false, onSend, onStop, seed, on
       }}
     >
       <ProviderNotice health={health} />
-      <div className="v2-composer-box">
+      {matter === null ? null : (
+        <p className="v2-composer-matter">
+          <span className="v2-tag">Matter</span>
+          <span className="v2-composer-matter-title">{matter.title}</span>
+          <span className="muted">· dropped files go into this matter's folder</span>
+        </p>
+      )}
+      <div
+        className={dragging ? 'v2-composer-box v2-dragging' : 'v2-composer-box'}
+        onDragEnter={event => {
+          if (!carriesFiles(event.dataTransfer)) return;
+          event.preventDefault();
+          setDragDepth(d => d + 1);
+        }}
+        onDragOver={event => {
+          if (carriesFiles(event.dataTransfer)) event.preventDefault();
+        }}
+        onDragLeave={() => setDragDepth(d => Math.max(0, d - 1))}
+        onDrop={onDrop}
+      >
+        {dragging ? (
+          <div className="v2-drop" aria-hidden="true">
+            <em>Drop a Word document to add it to the matter</em>
+          </div>
+        ) : null}
         <textarea
           aria-label="Message"
           placeholder="Ask counsel…"
@@ -86,18 +137,34 @@ export function Composer({ streaming, disabled = false, onSend, onStop, seed, on
           }}
         />
         <div className="v2-composer-actions">
+          {attached.map(path => (
+            <button
+              type="button"
+              key={path}
+              className="v2-ask-chip v2-ask-attached"
+              aria-label={`Remove ${path}`}
+              onClick={() => setAttached(current => current.filter(p => p !== path))}
+            >
+              {path}
+            </button>
+          ))}
           <span className="v2-composer-hint muted">⌘⏎ to send</span>
           {streaming ? (
             <button type="button" onClick={onStop}>
               Stop
             </button>
           ) : (
-            <button type="submit" className="v2-primary" disabled={disabled || message.trim() === ''}>
+            <button type="submit" className="v2-primary" disabled={disabled || full === ''}>
               Send
             </button>
           )}
         </div>
       </div>
+      {status === null ? null : (
+        <p className={status.kind === 'error' ? 'v2-intake v2-intake-error' : 'v2-intake'} role={status.kind === 'error' ? 'alert' : 'status'}>
+          {status.text}
+        </p>
+      )}
     </form>
   );
 }

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
+import { cleanup, fireEvent, render, screen, userEvent, waitFor } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { TOKEN_KEY } from '../../api/token';
@@ -397,5 +397,83 @@ describe('HomePage swap notice (cou-95)', () => {
     render(<HomePage threads={threads} onAsk={() => {}} onOpenThread={() => {}} health={fine} />);
     await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
     expect(document.querySelector('.v2-swap-notice')).toBeNull();
+  });
+});
+
+describe('HomePage document intake (docx spec §6)', () => {
+  const NDA = () => new File([new Uint8Array([80, 75, 3, 4])], 'Acme-Mutual-NDA-v3.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' });
+  function withUpload(status = 201, body: unknown = { path: 'matters/inbox/Acme-Mutual-NDA-v3.docx', size: 41 * 1024 }): string[] {
+    const uploads: string[] = [];
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/vault/upload') {
+        const form = init?.body as FormData;
+        uploads.push(`${(form.get('file') as File).name}→${(form.get('dest') as string | null) ?? '(inbox)'}`);
+        return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/vault/move') return json({ path: 'matters/acme/Acme-Mutual-NDA-v3.docx' });
+      return base(input, init);
+    }) as unknown as typeof fetch;
+    return uploads;
+  }
+  const dt = (files: File[]) => ({ files, types: ['Files'], items: [] });
+
+  test('dragging a file over the ask box shows the dashed inset with the italic line; leaving hides it', async () => {
+    mount();
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    const box = document.querySelector('.v2-ask')!;
+    fireEvent.dragEnter(box, { dataTransfer: dt([NDA()]) });
+    expect(box.classList.contains('v2-dragging')).toBe(true);
+    expect(document.querySelector('.v2-drop em')?.textContent).toBe('Drop a Word document to add it to the matter');
+    fireEvent.dragLeave(box);
+    expect(document.querySelector('.v2-drop')).toBeNull();
+    // A dragged text selection does not light the zone.
+    fireEvent.dragEnter(box, { dataTransfer: { files: [], types: ['text/plain'], items: [] } });
+    expect(document.querySelector('.v2-drop')).toBeNull();
+  });
+
+  test('a drop uploads to the inbox, adds the chip, and says where it went — with "move to a matter"', async () => {
+    const uploads = withUpload();
+    mount();
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    fireEvent.drop(document.querySelector('.v2-ask')!, { dataTransfer: dt([NDA()]) });
+    await waitFor(() => expect(screen.getByRole('status')).toBeTruthy());
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('Added Acme-Mutual-NDA-v3.docx to matters/inbox · 41 KB'));
+    expect(uploads).toEqual(['Acme-Mutual-NDA-v3.docx→(inbox)']);
+    expect(document.querySelector('.v2-ask-attached')?.textContent).toBe('matters/inbox/Acme-Mutual-NDA-v3.docx');
+    expect(screen.getByRole('button', { name: 'move to a matter' })).toBeTruthy();
+    // The chip rides into the message.
+    const asked: string[] = [];
+    cleanup();
+    withUpload();
+    render(<HomePage threads={threads} onAsk={m => asked.push(m)} onOpenThread={() => {}} />);
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    fireEvent.drop(document.querySelector('.v2-ask')!, { dataTransfer: dt([NDA()]) });
+    await waitFor(() => expect(document.querySelector('.v2-ask-attached')).toBeTruthy());
+    await userEvent.type(screen.getByLabelText('Ask counsel'), 'Review this.');
+    await userEvent.click(screen.getByRole('button', { name: 'Ask' }));
+    expect(asked).toEqual(['Review this.\n\n`matters/inbox/Acme-Mutual-NDA-v3.docx`']);
+  });
+
+  test('a file that is not a Word document is refused in one line, without a request', async () => {
+    const uploads = withUpload();
+    mount();
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    fireEvent.drop(document.querySelector('.v2-ask')!, { dataTransfer: dt([new File(['x'], 'Acme-NDA.pages')]) });
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('alert').textContent).toBe('Could not add Acme-NDA.pages: only Word documents (.docx) can be added for now. Export it from Pages as Word and drop it again.');
+    expect(screen.getByRole('alert').className).toContain('v2-intake-error');
+    expect(uploads).toEqual([]);
+    expect(document.querySelector('.v2-ask-attached')).toBeNull();
+  });
+
+  test('a server refusal reads as a sentence too', async () => {
+    withUpload(413, { error: 'too big' });
+    mount();
+    await waitFor(() => expect(screen.getByLabelText('Ask counsel')).toBeTruthy());
+    fireEvent.drop(document.querySelector('.v2-ask')!, { dataTransfer: dt([NDA()]) });
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('alert').textContent).toContain('larger than the 25 MB limit');
   });
 });

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useRef, useState } from 'react';
-import { ApiError, fetchJson, fetchJsonWithHeaders } from '../../api/client';
+import { ApiError, fetchJson, fetchJsonWithHeaders, moveFile } from '../../api/client';
 import type { DocketEntry, DocketView, Health, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
 import { ProviderNotice } from '../ProviderNotice';
 import { Tree } from '../../vault/Tree';
+import { MatterPicker } from '../chat/MatterPicker';
+import { addedLine, carriesFiles, droppedFiles, intake, matterFolderOf, type IntakeStatus } from '../intake';
 import { railLabel } from '../Rail';
 import { relTime } from '../time';
 import {
@@ -96,6 +98,34 @@ export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps
   const [attached, setAttached] = useState<string[]>([]);
   const [picking, setPicking] = useState(false);
   const box = useRef<HTMLTextAreaElement | null>(null);
+  /** Document intake (docx spec §6): a Word file dropped on the box goes to
+   * `matters/inbox/` — Home has no matter — and lands as an attach chip. */
+  const [dragDepth, setDragDepth] = useState(0);
+  const [intakeStatus, setIntakeStatus] = useState<IntakeStatus | null>(null);
+  const dragging = dragDepth > 0;
+
+  const onDrop = (event: React.DragEvent): void => {
+    event.preventDefault();
+    setDragDepth(0);
+    void intake(droppedFiles(event.dataTransfer), undefined, setIntakeStatus).then(up => {
+      if (up !== null) setAttached(current => (current.includes(up.path) ? current : [...current, up.path]));
+    });
+  };
+
+  /** "move to a matter" on the result line: the file leaves the inbox for
+   * the matter's folder, and the chip follows it. */
+  const moveTo = async (from: string, matterPath: string | null): Promise<void> => {
+    if (matterPath === null) return;
+    try {
+      const { path } = await moveFile(from, matterFolderOf(matterPath));
+      setAttached(current => current.map(p => (p === from ? path : p)));
+      const moved = addedLine({ path, size: 0 });
+      setIntakeStatus({ kind: 'done', up: { path, size: 0 }, text: `Moved ${moved.name} to ${moved.folder}` });
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) return;
+      setIntakeStatus({ kind: 'error', text: `Could not move the document: ${err instanceof Error ? err.message : String(err)}` });
+    }
+  };
 
   /**
    * The three reads settle INDEPENDENTLY. They answer different questions
@@ -172,7 +202,24 @@ export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps
         {subline === null ? null : <div className="v2-sub">{subline}</div>}
 
         <ProviderNotice health={health} />
-        <div className="v2-ask">
+        <div
+          className={dragging ? 'v2-ask v2-dragging' : 'v2-ask'}
+          onDragEnter={event => {
+            if (!carriesFiles(event.dataTransfer)) return;
+            event.preventDefault();
+            setDragDepth(d => d + 1);
+          }}
+          onDragOver={event => {
+            if (carriesFiles(event.dataTransfer)) event.preventDefault();
+          }}
+          onDragLeave={() => setDragDepth(d => Math.max(0, d - 1))}
+          onDrop={onDrop}
+        >
+          {dragging ? (
+            <div className="v2-drop" aria-hidden="true">
+              <em>Drop a Word document to add it to the matter</em>
+            </div>
+          ) : null}
           <textarea
             ref={box}
             aria-label="Ask counsel"
@@ -218,6 +265,17 @@ export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps
             </div>
           ) : null}
         </div>
+        {intakeStatus === null ? null : (
+          <p className={intakeStatus.kind === 'error' ? 'v2-intake v2-intake-error' : 'v2-intake'} role={intakeStatus.kind === 'error' ? 'alert' : 'status'}>
+            <span>{intakeStatus.text}</span>
+            {intakeStatus.kind === 'done' && intakeStatus.up.path.startsWith('matters/inbox/') ? (
+              <>
+                <span aria-hidden="true">·</span>
+                <MatterPicker current={null} label="move to a matter" onPick={path => void moveTo(intakeStatus.up.path, path)} />
+              </>
+            ) : null}
+          </p>
+        )}
 
         {docketError === null ? null : (
           <p className="v2-notice v2-notice-error v2-docket-error" role="alert">

--- a/runtime/ui/src/v2/intake.test.ts
+++ b/runtime/ui/src/v2/intake.test.ts
@@ -1,0 +1,80 @@
+import '../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { ApiError } from '../api/client';
+import { TOKEN_KEY } from '../api/token';
+import { addedLine, formatSize, intake, matterFolderOf, refusalFor, type IntakeStatus } from './intake';
+
+const realFetch = globalThis.fetch;
+
+beforeEach(() => sessionStorage.setItem(TOKEN_KEY, 'tok'));
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  sessionStorage.clear();
+});
+
+describe('intake helpers', () => {
+  test('a flat matter file gets a folder named after it; a folder matter keeps its folder', () => {
+    expect(matterFolderOf('matters/acme-nda.md')).toBe('matters/acme-nda');
+    expect(matterFolderOf('matters/acme/matter.md')).toBe('matters/acme');
+    expect(matterFolderOf('deals/2026/x.md', 'deals')).toBe('deals/2026');
+  });
+
+  test('sizes and the added line', () => {
+    expect(formatSize(900)).toBe('900 B');
+    expect(formatSize(41 * 1024)).toBe('41 KB');
+    expect(formatSize(2.5 * 1024 * 1024)).toBe('2.5 MB');
+    expect(addedLine({ path: 'matters/inbox/Acme-NDA-v3.docx', size: 41 * 1024 })).toEqual({
+      name: 'Acme-NDA-v3.docx',
+      folder: 'matters/inbox',
+      text: 'Added Acme-NDA-v3.docx to matters/inbox · 41 KB',
+    });
+  });
+
+  test('refusals are one sentence each', () => {
+    expect(refusalFor('Acme-NDA.pages', null)).toBe('Could not add Acme-NDA.pages: only Word documents (.docx) can be added for now. Export it from Pages as Word and drop it again.');
+    expect(refusalFor('scan.pdf', null)).toContain('only Word documents (.docx)');
+    expect(refusalFor('big.docx', new ApiError(413, null))).toBe('Could not add big.docx: it is larger than the 25 MB limit.');
+    expect(refusalFor('bad.docx', new ApiError(422, null))).toContain('refused');
+  });
+});
+
+describe('intake', () => {
+  test('uploads the first Word document with the dest, reporting busy then done', async () => {
+    const seen: string[] = [];
+    const sent: { dest: string | null; auth: string | undefined } = { dest: null, auth: undefined };
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push(String(input));
+      const form = init?.body as FormData;
+      sent.dest = (form.get('dest') as string | null) ?? null;
+      // Recorded, not asserted here: a throw inside the mock is swallowed by
+      // `intake` and would read as a refusal.
+      sent.auth = (init?.headers as Record<string, string>)['authorization'];
+      return new Response(JSON.stringify({ path: 'matters/acme/nda.docx', size: 10 }), { status: 201, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    const statuses: IntakeStatus[] = [];
+    const up = await intake([new File(['x'], 'notes.txt'), new File(['pk'], 'nda.docx')], 'matters/acme', s => statuses.push(s));
+    expect(up).toEqual({ path: 'matters/acme/nda.docx', size: 10 });
+    expect(seen).toEqual(['/vault/upload']);
+    expect(sent.dest).toBe('matters/acme');
+    expect(sent.auth?.startsWith('Bearer ')).toBe(true);
+    expect(statuses.map(s => s.kind)).toEqual(['busy', 'done']);
+    expect(statuses[1]!.text).toBe('Added nda.docx to matters/acme · 10 B');
+  });
+
+  test('a non-Word file is refused without a request; a server refusal becomes the sentence', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      return new Response(JSON.stringify({ error: 'too big' }), { status: 413, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    const statuses: IntakeStatus[] = [];
+    expect(await intake([new File(['x'], 'Acme.pages')], undefined, s => statuses.push(s))).toBeNull();
+    expect(calls).toBe(0);
+    expect(statuses[0]!.kind).toBe('error');
+    statuses.length = 0;
+    expect(await intake([new File(['x'], 'big.docx')], undefined, s => statuses.push(s))).toBeNull();
+    expect(statuses.map(s => s.kind)).toEqual(['busy', 'error']);
+    expect(statuses[1]!.text).toContain('25 MB');
+  });
+});

--- a/runtime/ui/src/v2/intake.ts
+++ b/runtime/ui/src/v2/intake.ts
@@ -1,0 +1,96 @@
+/**
+ * Document intake (docx spec §6): a Word file dropped on Home's ask box or
+ * the chat composer goes into the vault — the matter's folder when the
+ * thread is linked to one, `matters/inbox/` otherwise (§10) — and lands in
+ * the message as a path chip, like "＋ attach from vault" does. The pure
+ * parts live here so both surfaces say the same things the same way.
+ */
+import { ApiError, uploadFile, type Uploaded } from '../api/client';
+
+/** Where a matter's documents live. A matter that is its own folder
+ * (`matters/acme/matter.md`) keeps them beside it; a flat matter file
+ * (`matters/acme.md`) gets a folder named after it (`matters/acme/`). */
+export function matterFolderOf(matterPath: string, mattersDir = 'matters'): string {
+  const cut = matterPath.lastIndexOf('/');
+  const dir = cut === -1 ? '' : matterPath.slice(0, cut);
+  if (dir !== mattersDir && dir !== '') return dir;
+  const base = matterPath.slice(cut + 1).replace(/\.[^.]+$/, '');
+  return `${mattersDir}/${base}`;
+}
+
+export function inboxFolder(mattersDir = 'matters'): string {
+  return `${mattersDir}/inbox`;
+}
+
+export function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function isDocxName(name: string): boolean {
+  return /\.docx$/i.test(name);
+}
+
+/** The result line: "Added Acme-NDA.docx to matters/inbox · 41 KB". */
+export function addedLine(up: Uploaded): { name: string; folder: string; text: string } {
+  const name = up.path.slice(up.path.lastIndexOf('/') + 1);
+  const folder = up.path.slice(0, up.path.lastIndexOf('/'));
+  return { name, folder, text: `Added ${name} to ${folder} · ${formatSize(up.size)}` };
+}
+
+/** The one-sentence refusal for a file that cannot be added. */
+export function refusalFor(name: string, err: unknown): string {
+  if (!isDocxName(name)) {
+    const ext = name.includes('.') ? name.slice(name.lastIndexOf('.') + 1) : '';
+    const hint = ext === 'pages' ? ' Export it from Pages as Word and drop it again.' : ext === 'pdf' ? ' A PDF cannot be redlined; ask for the Word version.' : '';
+    return `Could not add ${name}: only Word documents (.docx) can be added for now.${hint}`;
+  }
+  if (err instanceof ApiError) {
+    if (err.status === 413) return `Could not add ${name}: it is larger than the 25 MB limit.`;
+    if (err.status === 422) return `Could not add ${name}: the file was refused — it carries a document type declaration a safe reader cannot accept.`;
+    if (err.status === 415) return `Could not add ${name}: it is not a Word document.`;
+    return `Could not add ${name}: ${err.message}`;
+  }
+  return `Could not add ${name}: ${err instanceof Error ? err.message : String(err)}`;
+}
+
+export type IntakeStatus = { kind: 'busy'; text: string } | { kind: 'done'; up: Uploaded; text: string } | { kind: 'error'; text: string };
+
+/** The files a drop carried, Word documents first (so a mixed drop adds
+ * the one that can be added and refuses the rest by name). */
+export function droppedFiles(transfer: DataTransfer | null): File[] {
+  if (transfer === null) return [];
+  return Array.from(transfer.files ?? []);
+}
+
+/** True when the drag carries files at all — a dragged text selection or
+ * a link must not light the drop zone. */
+export function carriesFiles(transfer: DataTransfer | null): boolean {
+  if (transfer === null) return false;
+  return Array.from(transfer.types ?? []).includes('Files');
+}
+
+/**
+ * Uploads one dropped file and reports each state through `onStatus`;
+ * resolves with the upload on success, `null` on refusal. One file per
+ * drop for now — the first Word document wins, the others are named.
+ */
+export async function intake(files: File[], dest: string | undefined, onStatus: (s: IntakeStatus) => void): Promise<Uploaded | null> {
+  const file = files.find(f => isDocxName(f.name)) ?? files[0];
+  if (file === undefined) return null;
+  if (!isDocxName(file.name)) {
+    onStatus({ kind: 'error', text: refusalFor(file.name, null) });
+    return null;
+  }
+  onStatus({ kind: 'busy', text: `Adding ${file.name}…` });
+  try {
+    const up = await uploadFile(file, dest);
+    onStatus({ kind: 'done', up, text: addedLine(up).text });
+    return up;
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 401) return null;
+    onStatus({ kind: 'error', text: refusalFor(file.name, err) });
+    return null;
+  }
+}


### PR DESCRIPTION
Stage 1 step 3 of docs/superpowers/specs/2026-09-01-docx-in-typescript-design.md (§5 upload, §6 intake, §10 decisions). Branched from `docx-read`, so **PR #45's commits show here until #45 merges**; the coordinator rebases onto main after that.

**Runtime**
- `VaultStore.writeBytes` (never overwrites — `wx`) and `rename` (link + unlink, never clobbers) on `FsVaultStore`.
- `POST /vault/upload` — multipart `file` + optional `dest`. `dest` must be the matters dir or a folder under it; omitted → `matters/inbox/`. Filename reduced to a safe basename; `nda.docx` → `nda-2.docx`, `nda-3.docx` on collision. `.docx` only (415), not a zip / not a Word document (415), any XML part with a DOCTYPE (422, refused before anything is stored), over 25 MB (413), missing field (400), no token (401). Returns `201 { path, size }`.
- `POST /vault/move` `{ from, to }` — a file from one matter folder or the inbox to another, both under `matters/`, no overwrite.
- `CONFIGURATION.md`: per-matter folders and the `matters/inbox/` convention.

**UI** (matches `docs/superpowers/specs/img-standalone/mock-intake.html` / `intake.png`)
- Drag-over: a dashed inset drawn inside the existing ask box / composer box with the italic serif line. A dragged text selection does not light it.
- Drop: busy line → upload → the mono attach chip in the message row → "Added <file> to <folder> · <size> · move to a matter" (the link is PR #42's `MatterPicker`; a pick moves the file and the chip follows). Refusals are one set-text line in the error colour, e.g. "Could not add Acme-NDA.pages: only Word documents (.docx) can be added for now. Export it from Pages as Word and drop it again."
- Chat: with an explicit matter link, drops go to that matter's folder and the composer shows `MATTER · <title> · dropped files go into this matter's folder`; the chip alone is a sendable message (rides as a backticked path, like Home's attach).
- Shared logic in `runtime/ui/src/v2/intake.ts` (folder derivation, size words, refusal sentences, the upload flow).

**Tests:** `bun run test` 710 pass · `bun run ui:test` 423 pass · typechecks clean · `bunx playwright test -c e2e/playwright.config.ts intake.spec.ts` 1 passed (drops the demo NDA through a real `serve --fake`, sees the chip and the result line, then reads the converted file). Screenshots of the three states on a throwaway serve match the mock.