### PR TITLE
runtime: stay signed in — per-install token + same-origin session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Runtime-owned setup, stage 1 (spec `docs/superpowers/specs/2026-09-01-runtime-ow
 - `bun runtime/src/cli.ts init` creates and seeds a Counsel OS vault the way `/counsel-os:setup` does (default `~/Documents/Counsel OS`), from flags or four questions; idempotent, adopts an existing vault, never overwrites a file.
 - `serve` no longer exits when no legal root exists: it starts in setup mode, serves the page, and offers `GET /setup/detect`, `GET /setup/providers`, and `POST /setup`; every other API route answers 409 until a vault is set up, then the same server switches to it in place. `/health` reports `setup`.
 - The web UI shows a setup-required page in setup mode (the first-run screen lands next).
+- **Stay signed in.** The runtime's bearer token is now per install, kept in `~/.counsel-os/token` (owner-only) across restarts (`serve --new-token` mints a fresh one and signs every browser out). The first visit through the printed `#token=` address sets an `HttpOnly`, `SameSite=Strict` cookie carrying the same secret, and the server accepts it only for requests the browser marks as same-origin (or typed into the address bar), so another local tool's page on a different port cannot ride on it. After that first visit, `http://127.0.0.1:7431` just opens — new tabs and restarts included. Settings › Runtime gains "Sign out of this browser" (`POST /session/clear`). The session-lost screen says so.
+
 
 Runtime-owned setup, stage 2 — content updates and doctor (spec §6–§7)
 

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -40,6 +40,7 @@ const { values, positionals } = parseArgs({
     fake: { type: 'boolean' },        // `serve`: register fake/fake as the default — no model is ever called
     'fake-script': { type: 'string' }, // `serve`: a JSON array of FakeScript steps for --fake
     open: { type: 'boolean' },        // `serve`: open the printed token URL in the browser
+    'new-token': { type: 'boolean' }, // `serve`: mint a fresh bearer (signs every browser out)
     dist: { type: 'string' },         // `serve`: the built UI to serve (default runtime/ui/dist)
     // `init` — the first-run answers as flags (spec 2026-09-01 §4); a
     // missing one is asked on stdin unless `--yes`.
@@ -62,7 +63,7 @@ const [cmd, ...rest] = positionals;
 
 function usage(): never {
   console.error('usage: bun runtime/src/cli.ts step --vault <dir> --provider <id> [--task <name>] [--schema <json>] [--session <id>] [--codex-home <dir>] [--cwd <dir>] [--step-timeout <ms>] "<prompt>"');
-  console.error('       bun runtime/src/cli.ts serve [--port <n>] [--vault <dir>] [--step-timeout <ms>] [--dist <dir>] [--open] [--fake [--fake-script <file.json>]]');
+  console.error('       bun runtime/src/cli.ts serve [--port <n>] [--vault <dir>] [--step-timeout <ms>] [--dist <dir>] [--open] [--new-token] [--fake [--fake-script <file.json>]]');
   console.error('         --dist <dir> is the built UI; everything in it is served WITHOUT a token, so it must not overlap the vault');
   console.error('       bun runtime/src/cli.ts init [--vault <dir>] [--name <n> --org <o> --role in-house|outside|solo --jurisdiction <j> --practice "<one line>"] [--default-provider <id>] [--no-git] [--yes]');
   console.error('         creates a Counsel OS vault (default ~/Documents/Counsel OS) and seeds it; asks for anything missing unless --yes');
@@ -191,6 +192,7 @@ if (cmd === 'serve') {
       ...(stepTimeoutMs === undefined ? {} : { stepTimeoutMs }),
       ...(values.dist ? { distDir: resolve(values.dist) } : {}),
       ...(values.open ? { open: true } : {}),
+      ...(values['new-token'] ? { newToken: true } : {}),
       ...(values.fake ? { fake: fakeScript(values['fake-script']) } : {}),
     });
   } catch (err) {

--- a/runtime/src/server/auth.test.ts
+++ b/runtime/src/server/auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { bearerToken, isAuthorized, tokensMatch } from './auth';
+import { authorize, bearerToken, CLEAR_SESSION_COOKIE, cookieAllowedForOrigin, isAuthorized, sessionCookie, sessionCookieHeader, tokensMatch, withSessionCookie } from './auth';
 
 const req = (headers: Record<string, string> = {}): Request =>
   new Request('http://127.0.0.1:7431/health', { headers });
@@ -33,5 +33,71 @@ describe('isAuthorized', () => {
     expect(isAuthorized(req({ authorization: 'Bearer secret' }), 'secret')).toBe(true);
     expect(isAuthorized(req({ authorization: 'Bearer nope' }), 'secret')).toBe(false);
     expect(isAuthorized(req(), 'secret')).toBe(false);
+  });
+});
+
+describe('sessionCookie', () => {
+  test('reads the session cookie out of a cookie header, ignoring the rest', () => {
+    expect(sessionCookie(req({ cookie: 'counsel_session=abc' }))).toBe('abc');
+    expect(sessionCookie(req({ cookie: 'other=1; counsel_session=abc; more=2' }))).toBe('abc');
+    expect(sessionCookie(req({ cookie: 'other=1' }))).toBeNull();
+    expect(sessionCookie(req({ cookie: 'counsel_session=' }))).toBeNull();
+    expect(sessionCookie(req())).toBeNull();
+  });
+});
+
+describe('cookieAllowedForOrigin', () => {
+  test('same-origin fetches and address-bar navigations may use the cookie', () => {
+    expect(cookieAllowedForOrigin(req({ 'sec-fetch-site': 'same-origin' }))).toBe(true);
+    expect(cookieAllowedForOrigin(req({ 'sec-fetch-site': 'none' }))).toBe(true);
+    // A non-browser client sends neither header.
+    expect(cookieAllowedForOrigin(req())).toBe(true);
+  });
+
+  test('another port on 127.0.0.1 is same-SITE, not same-origin — the gap SameSite=Strict leaves open', () => {
+    expect(cookieAllowedForOrigin(req({ 'sec-fetch-site': 'same-site' }))).toBe(false);
+    expect(cookieAllowedForOrigin(req({ 'sec-fetch-site': 'cross-site' }))).toBe(false);
+  });
+
+  test('an Origin header must be this server\'s own', () => {
+    expect(cookieAllowedForOrigin(req({ host: '127.0.0.1:7431', origin: 'http://127.0.0.1:7431' }))).toBe(true);
+    expect(cookieAllowedForOrigin(req({ host: '127.0.0.1:7431', origin: 'http://127.0.0.1:8080' }))).toBe(false);
+    expect(cookieAllowedForOrigin(req({ host: '127.0.0.1:7431', origin: 'null' }))).toBe(false);
+    expect(cookieAllowedForOrigin(req({ host: '127.0.0.1:7431', origin: 'http://localhost:7431' }))).toBe(false);
+  });
+});
+
+describe('authorize', () => {
+  test('a right bearer is "bearer"; a right cookie from this origin is "cookie"', () => {
+    expect(authorize(req({ authorization: 'Bearer secret' }), 'secret')).toBe('bearer');
+    expect(authorize(req({ cookie: 'counsel_session=secret', 'sec-fetch-site': 'same-origin' }), 'secret')).toBe('cookie');
+  });
+
+  test('a wrong cookie, or a right one from elsewhere, is nothing', () => {
+    expect(authorize(req({ cookie: 'counsel_session=nope' }), 'secret')).toBeNull();
+    expect(authorize(req({ cookie: 'counsel_session=secret', 'sec-fetch-site': 'same-site' }), 'secret')).toBeNull();
+    expect(authorize(req({ cookie: 'counsel_session=secret', 'sec-fetch-site': 'cross-site' }), 'secret')).toBeNull();
+  });
+
+  test('a wrong bearer is refused even beside a right cookie', () => {
+    expect(authorize(req({ authorization: 'Bearer nope', cookie: 'counsel_session=secret' }), 'secret')).toBeNull();
+    expect(isAuthorized(req({ authorization: 'Bearer nope', cookie: 'counsel_session=secret' }), 'secret')).toBe(false);
+  });
+});
+
+describe('the cookie itself', () => {
+  test('is HttpOnly, SameSite=Strict, a year long, for the whole origin, and never Secure (plain http on loopback)', () => {
+    const value = sessionCookieHeader('secret');
+    expect(value).toBe('counsel_session=secret; Path=/; Max-Age=31536000; HttpOnly; SameSite=Strict');
+    expect(value).not.toContain('Secure');
+    expect(CLEAR_SESSION_COOKIE).toBe('counsel_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict');
+  });
+
+  test('withSessionCookie keeps the response and adds the header', async () => {
+    const res = withSessionCookie(Response.json({ ok: true }, { status: 201, headers: { 'x-thing': '1' } }), 'secret');
+    expect(res.status).toBe(201);
+    expect(res.headers.get('x-thing')).toBe('1');
+    expect(res.headers.get('set-cookie')).toBe(sessionCookieHeader('secret'));
+    expect(await res.json()).toEqual({ ok: true });
   });
 });

--- a/runtime/src/server/auth.ts
+++ b/runtime/src/server/auth.ts
@@ -1,6 +1,58 @@
 import { createHash, timingSafeEqual } from 'node:crypto';
 
 /**
+ * How a request proves it may use the API.
+ *
+ * THE THREAT MODEL. The runtime listens on 127.0.0.1 only, so the attacker
+ * is not on the network: it is a web page in the same browser (any site
+ * the operator has open) or another local process. A page cannot read a
+ * loopback response without a credential it does not have — that is what
+ * the bearer token is for — and the token never travels in a URL that a
+ * server sees (the printed link carries it in the fragment).
+ *
+ * TWO CREDENTIALS, ONE SECRET. A request is accepted with either
+ *   1. `Authorization: Bearer <token>` — what the page sends after reading
+ *      the printed link once, and what the plugin adapter and tests send; or
+ *   2. the `counsel_session` cookie, whose VALUE IS the same token. The
+ *      server sets it on the first bearer-authenticated response, so the
+ *      browser remembers the sign-in across tabs and across restarts of the
+ *      runtime (the token itself is per install now, not per process).
+ *
+ * WHY A COOKIE IS SAFE HERE, AND WHY THAT IS NOT ENOUGH. The cookie is
+ * `HttpOnly` (no script can read it) and `SameSite=Strict` (the browser
+ * attaches it only to requests whose SITE is the cookie's). But "site" is
+ * the registrable domain or the IP — it IGNORES THE PORT. A page served by
+ * some other local tool on 127.0.0.1:8080 is same-SITE with this runtime,
+ * so a Strict cookie WOULD ride along on its cross-ORIGIN fetch. That is
+ * the one hole, and `cookieAllowedForOrigin` closes it: a cookie may
+ * authenticate a request only when the browser says the request came from
+ * this very origin (or from the address bar).
+ *
+ * WHAT BROWSERS SEND. Every current browser adds `Sec-Fetch-Site` to every
+ * request: `same-origin` (this page), `same-site` (another port or
+ * subdomain), `cross-site`, or `none` (the user typed or clicked a bookmark).
+ * Only the first and last may use the cookie. `Origin` is sent on every
+ * cross-origin request and on every non-GET; when present it must be this
+ * server's own `http://<host>` exactly — a null origin (a sandboxed frame)
+ * fails that test. A client that sends neither header is not a browser;
+ * to hold the cookie at all it already holds the secret, so it is accepted.
+ *
+ * NO `Secure` FLAG: the runtime speaks plain http on loopback (browsers
+ * treat 127.0.0.1 as a secure context, but a `Secure` cookie is not
+ * portable across them on http). The cookie never leaves the machine.
+ *
+ * ROTATION. `serve --new-token` mints a fresh secret; every cookie holding
+ * the old one is then a wrong token and gets a 401, which is the page's cue
+ * to show the session-lost screen. `POST /session/clear` drops the cookie
+ * from one browser without rotating.
+ */
+
+export const SESSION_COOKIE = 'counsel_session';
+
+/** A year: the sign-in should outlive a browser restart, not just a tab. */
+const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+/**
  * Pulls the bearer credential out of an `Authorization` header. Anything
  * else — no header, another scheme, an empty credential — is `null`, which
  * the caller treats exactly like a wrong token.
@@ -10,6 +62,20 @@ export function bearerToken(req: Request): string | null {
   if (!header) return null;
   const match = /^Bearer[ \t]+(\S+)$/i.exec(header.trim());
   return match ? match[1]! : null;
+}
+
+/** The session cookie's value, or `null` when the request carries none. */
+export function sessionCookie(req: Request): string | null {
+  const header = req.headers.get('cookie');
+  if (!header) return null;
+  for (const part of header.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    if (part.slice(0, eq).trim() !== SESSION_COOKIE) continue;
+    const value = part.slice(eq + 1).trim();
+    return value === '' ? null : value;
+  }
+  return null;
 }
 
 /**
@@ -23,8 +89,59 @@ export function tokensMatch(presented: string, expected: string): boolean {
   return timingSafeEqual(digest(presented), digest(expected));
 }
 
-/** True when the request carries the server's bearer token. */
-export function isAuthorized(req: Request, expected: string): boolean {
+/**
+ * Whether the browser vouches that this request came from this origin (or
+ * the address bar) — the condition under which a cookie may authenticate
+ * it. See the module comment for why `SameSite=Strict` alone is not that.
+ */
+export function cookieAllowedForOrigin(req: Request): boolean {
+  const site = req.headers.get('sec-fetch-site');
+  if (site !== null && site !== 'same-origin' && site !== 'none') return false;
+  const origin = req.headers.get('origin');
+  if (origin !== null) {
+    const host = req.headers.get('host');
+    if (host === null) return false;
+    if (origin.toLowerCase() !== `http://${host.toLowerCase()}`) return false;
+  }
+  return true;
+}
+
+export type AuthVia = 'bearer' | 'cookie';
+
+/**
+ * Which credential authorized the request, or `null`. The bearer is checked
+ * first: a request carrying a WRONG bearer and a right cookie is refused —
+ * a client that names a credential must be right about it.
+ */
+export function authorize(req: Request, expected: string): AuthVia | null {
   const presented = bearerToken(req);
-  return presented !== null && tokensMatch(presented, expected);
+  if (presented !== null) return tokensMatch(presented, expected) ? 'bearer' : null;
+  const cookie = sessionCookie(req);
+  if (cookie !== null && cookieAllowedForOrigin(req) && tokensMatch(cookie, expected)) return 'cookie';
+  return null;
+}
+
+/** True when the request carries the server's token, either way. */
+export function isAuthorized(req: Request, expected: string): boolean {
+  return authorize(req, expected) !== null;
+}
+
+/** The `Set-Cookie` value that signs this browser in. */
+export function sessionCookieHeader(token: string): string {
+  return `${SESSION_COOKIE}=${token}; Path=/; Max-Age=${SESSION_MAX_AGE_SECONDS}; HttpOnly; SameSite=Strict`;
+}
+
+/** The `Set-Cookie` value that signs this browser out. */
+export const CLEAR_SESSION_COOKIE = `${SESSION_COOKIE}=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict`;
+
+/**
+ * The same response with the sign-in cookie attached. A new `Response` is
+ * built rather than the headers mutated: `Response.json` hands back
+ * immutable headers, and a streaming body (the step's SSE) passes through
+ * untouched.
+ */
+export function withSessionCookie(res: Response, token: string): Response {
+  const headers = new Headers(res.headers);
+  headers.append('set-cookie', sessionCookieHeader(token));
+  return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1390,3 +1390,55 @@ describe('content updates and doctor (spec 2026-09-01 §6–§7)', () => {
     expect((await call(app, 'GET', '/doctor', { token: null })).status).toBe(401);
   });
 });
+
+describe('the session cookie', () => {
+  const cookie = (token: string): string => `counsel_session=${token}`;
+
+  test('a bearer-authenticated response signs the browser in; a cookie-authenticated one sets nothing new', async () => {
+    const app = appWithFake();
+    const first = await call(app, 'GET', '/health');
+    expect(first.status).toBe(200);
+    expect(first.headers.get('set-cookie')).toBe(`counsel_session=${TOKEN}; Path=/; Max-Age=31536000; HttpOnly; SameSite=Strict`);
+
+    const again = await app(new Request('http://127.0.0.1:7431/health', { headers: { cookie: cookie(TOKEN), 'sec-fetch-site': 'same-origin' } }));
+    expect(again.status).toBe(200);
+    expect(again.headers.get('set-cookie')).toBeNull();
+  });
+
+  test('a wrong cookie, or the right one from another site, is 401; a static path never gets a cookie', async () => {
+    const app = appWithFake();
+    const wrong = await app(new Request('http://127.0.0.1:7431/threads', { headers: { cookie: cookie('nope'), 'sec-fetch-site': 'same-origin' } }));
+    expect(wrong.status).toBe(401);
+    // Another local tool's page on 127.0.0.1:8080 — same-site, so a Strict
+    // cookie would ride along; the origin rule is what keeps it out.
+    const elsewhere = await app(new Request('http://127.0.0.1:7431/threads', { headers: { cookie: cookie(TOKEN), 'sec-fetch-site': 'same-site', origin: 'http://127.0.0.1:8080', host: '127.0.0.1:7431' } }));
+    expect(elsewhere.status).toBe(401);
+    const unauth = await call(app, 'GET', '/threads', { token: null });
+    expect(unauth.status).toBe(401);
+    expect(unauth.headers.get('set-cookie')).toBeNull();
+  });
+
+  test('a cookie is good for the whole API, the step stream included', async () => {
+    const app = appWithFake([{ text: 'hello there' }]);
+    const created = await app(new Request('http://127.0.0.1:7431/threads', { method: 'POST', headers: { cookie: cookie(TOKEN), 'sec-fetch-site': 'same-origin', 'content-type': 'application/json' }, body: '{}' }));
+    expect(created.status).toBe(201);
+    const { id } = (await created.json()) as { id: string };
+    const res = await app(new Request(`http://127.0.0.1:7431/threads/${id}/steps`, { method: 'POST', headers: { cookie: cookie(TOKEN), 'sec-fetch-site': 'same-origin', 'content-type': 'application/json' }, body: JSON.stringify({ message: 'hi' }) }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toBe('text/event-stream');
+    await res.text();
+  });
+
+  test('POST /session/clear signs this browser out and needs a credential itself', async () => {
+    const app = appWithFake();
+    const res = await app(new Request('http://127.0.0.1:7431/session/clear', { method: 'POST', headers: { cookie: cookie(TOKEN), 'sec-fetch-site': 'same-origin' } }));
+    expect(res.status).toBe(204);
+    expect(res.headers.get('set-cookie')).toBe('counsel_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict');
+    expect((await call(app, 'POST', '/session/clear', { token: null })).status).toBe(401);
+    // Signing out from a tab that still holds the bearer must not re-sign
+    // the browser in on the way out: one Set-Cookie, the clearing one.
+    const viaBearer = await call(app, 'POST', '/session/clear');
+    expect(viaBearer.status).toBe(204);
+    expect(viaBearer.headers.getSetCookie()).toEqual(['counsel_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict']);
+  });
+});

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -16,7 +16,7 @@ import { applyUpdates, contentStatus, UpdateError } from '../content/update';
 import { repoContentSource } from '../content/repo';
 import { runDoctor } from '../doctor/index';
 import { systemGit, type GitRunner } from '../setup/run';
-import { isAuthorized } from './auth';
+import { authorize, CLEAR_SESSION_COOKIE, withSessionCookie } from './auth';
 import {
   applySettings,
   effectiveDefault,
@@ -61,7 +61,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -815,13 +815,44 @@ export function createApp(deps: ServerDeps): App {
         return res ?? fail(404, `no route for ${req.method} ${url.pathname}`);
       }
 
-      if (!isAuthorized(req, deps.token)) return fail(401, 'unauthorized');
+      const via = authorize(req, deps.token);
+      if (via === null) return fail(401, 'unauthorized');
 
+      const res = await dispatch(req, url);
+      // A request that proved itself with the bearer — the page's first call
+      // after reading the printed link — signs this browser in: from here on
+      // the cookie carries the same secret, so a new tab or a restarted
+      // runtime needs no pasted address (auth.ts has the threat model). A
+      // cookie-authenticated request gets no new cookie: nothing changed.
+      // And a route that set a cookie of its own (`/session/clear`, which
+      // clears it) is left alone: appending the sign-in after the sign-out
+      // would make the browser keep the sign-in.
+      return via === 'bearer' && !res.headers.has('set-cookie') ? withSessionCookie(res, deps.token) : res;
+    } catch (err) {
+      if (err instanceof HttpError) return fail(err.status, err.message, err.extra);
+      // An unexpected failure is a bug, and its message can carry absolute
+      // paths and vault contents. The operator gets the detail on stderr;
+      // the client gets a status code.
+      console.error(`counsel-os server: ${req.method} ${req.url} failed:`, err);
+      return fail(500, 'internal error');
+    }
+  };
+
+  /** The authenticated API, one route per branch. Throws `HttpError` for a
+   * status the caller decided on; `app` above turns it into the response. */
+  async function dispatch(req: Request, url: URL): Promise<Response> {
+    {
       const segments = url.pathname.split('/').filter(s => s !== '');
       const [first, second, third] = segments;
       const { method } = req;
 
       if (segments.length === 1 && first === 'health' && method === 'GET') return health();
+
+      // Signs THIS browser out: the cookie is cleared, the token stands. The
+      // page forgets its own copy too (client.ts `signOut`).
+      if (segments.length === 2 && first === 'session' && second === 'clear' && method === 'POST') {
+        return new Response(null, { status: 204, headers: { 'set-cookie': CLEAR_SESSION_COOKIE } });
+      }
 
       if (segments.length === 1 && first === 'threads') {
         if (method === 'GET') return json(await deps.store.list(deps.tenant));
@@ -882,15 +913,8 @@ export function createApp(deps: ServerDeps): App {
       if (segments.length === 1 && first === 'doctor' && method === 'GET') return doctorRoute();
 
       return fail(404, `no route for ${method} ${url.pathname}`);
-    } catch (err) {
-      if (err instanceof HttpError) return fail(err.status, err.message, err.extra);
-      // An unexpected failure is a bug, and its message can carry absolute
-      // paths and vault contents. The operator gets the detail on stderr;
-      // the client gets a status code.
-      console.error(`counsel-os server: ${req.method} ${req.url} failed:`, err);
-      return fail(500, 'internal error');
     }
-  };
+  }
 }
 
 /** The path a proposal targets, for the conflict message. */

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -9,6 +9,7 @@ import {
   openUrl,
   runtimeFilePath,
   startServer,
+  tokenFilePath,
   type RunningServer,
   type RuntimeFile,
 } from './serve';
@@ -160,21 +161,55 @@ describe('startServer', () => {
     expect((JSON.parse(readFileSync(file, 'utf8')) as RuntimeFile).token).toBe(running.token);
   });
 
-  test('a fresh token per process', async () => {
+  test('a token per install: kept across restarts in one home, different across homes, rotated by newToken', async () => {
     const a = fixture();
     const b = fixture();
     const first = await startServer({ vault: a.vault, pluginRoot: a.pluginRoot, port: 0, env: a.env, registryFile: join(a.vault, 'none.yaml') });
-    const second = await startServer({ vault: b.vault, pluginRoot: b.pluginRoot, port: 0, env: b.env, registryFile: join(b.vault, 'none.yaml') });
+    const other = await startServer({ vault: b.vault, pluginRoot: b.pluginRoot, port: 0, env: b.env, registryFile: join(b.vault, 'none.yaml') });
     try {
-      expect(first.token).not.toBe(second.token);
-      expect(first.port).not.toBe(second.port);
-      // One server's token is no good at the other.
-      const crossed = await fetch(`${second.url}/health`, { headers: { authorization: `Bearer ${first.token}` } });
+      expect(first.token).not.toBe(other.token);
+      // One install's token is no good at the other.
+      const crossed = await fetch(`${other.url}/health`, { headers: { authorization: `Bearer ${first.token}` } });
       expect(crossed.status).toBe(401);
+      // The secret is on disk, owner-only, and outlives the handshake file.
+      const tokenFile = tokenFilePath(a.env);
+      expect(readFileSync(tokenFile, 'utf8').trim()).toBe(first.token);
+      expect(statSync(tokenFile).mode & 0o777).toBe(0o600);
     } finally {
       await first.stop();
-      await second.stop();
+      await other.stop();
     }
+    expect(existsSync(runtimeFilePath(a.env))).toBe(false);
+    expect(existsSync(tokenFilePath(a.env))).toBe(true);
+
+    // A restart in the same home serves the SAME token, so a browser that
+    // holds it (in its cookie) stays signed in.
+    const again = await startServer({ vault: a.vault, pluginRoot: a.pluginRoot, port: 0, env: a.env, registryFile: join(a.vault, 'none.yaml') });
+    try {
+      expect(again.token).toBe(first.token);
+    } finally {
+      await again.stop();
+    }
+
+    // `--new-token` rotates it, and the old one is dead.
+    const rotated = await startServer({ vault: a.vault, pluginRoot: a.pluginRoot, port: 0, env: a.env, registryFile: join(a.vault, 'none.yaml'), newToken: true });
+    try {
+      expect(rotated.token).not.toBe(first.token);
+      expect(readFileSync(tokenFilePath(a.env), 'utf8').trim()).toBe(rotated.token);
+      const stale = await fetch(`${rotated.url}/health`, { headers: { authorization: `Bearer ${first.token}` } });
+      expect(stale.status).toBe(401);
+    } finally {
+      await rotated.stop();
+    }
+  });
+
+  test('a token file holding something that is not a token is minted over', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    mkdirSync(counselHome(env), { recursive: true });
+    writeFileSync(tokenFilePath(env), 'not-a-token\n', 'utf8');
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+    expect(running.token).toMatch(/^[0-9a-f]{64}$/);
+    expect(readFileSync(tokenFilePath(env), 'utf8').trim()).toBe(running.token);
   });
 });
 

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -49,6 +49,9 @@ export interface StartServerOptions {
   open?: boolean;
   /** The built UI's `dist/`. Omitted → `defaultDistDir()`. */
   distDir?: string;
+  /** Mint a fresh bearer even when `runtime.json` holds one. Every browser
+   * signed in with the old one is signed out. */
+  newToken?: boolean;
   env?: NodeJS.ProcessEnv;
   /** The user's real home, for setup mode's probes. Omitted → `env.HOME`,
    * then `os.homedir()` — the same rule the root resolver applies. */
@@ -257,6 +260,43 @@ function runtimeFileOwner(path: string): number | null {
   }
 }
 
+/** The shape this runtime mints: `randomBytes(32).toString('hex')`. A file
+ * holding anything else is not trusted as a token — it is minted over. */
+const TOKEN_SHAPE = /^[0-9a-f]{64}$/;
+
+/** Where the install's secret lives: `<counselHome>/token`, 0600. Separate
+ * from `runtime.json`, which is a HANDSHAKE (port, pid, vault) and is
+ * removed when the server stops — the secret has to outlive that. */
+export function tokenFilePath(env: NodeJS.ProcessEnv = process.env): string {
+  return join(counselHome(env), 'token');
+}
+
+/**
+ * The token to serve with: the install's, when the token file holds one of
+ * the right shape and `fresh` is not asked for; else a new one, written
+ * there for next time.
+ *
+ * Per INSTALL, not per process (the earlier rule): the browser remembers
+ * the sign-in in a cookie whose value is the token (auth.ts), and a token
+ * that changed on every restart would sign every browser out on every
+ * restart — the "paste the address again" the founder objected to. The
+ * file is 0600 in a 0700 directory, like `runtime.json` always was, so
+ * keeping the secret exposes nothing that publishing it did not.
+ */
+function chooseToken(file: string, fresh: boolean): string {
+  if (!fresh) {
+    try {
+      const held = readFileSync(file, 'utf8').trim();
+      if (TOKEN_SHAPE.test(held)) return held;
+    } catch {
+      /* no file yet: mint */
+    }
+  }
+  const token = randomBytes(32).toString('hex');
+  writeFileAtomic(file, token + '\n', { mode: 0o600, dirMode: 0o700 });
+  return token;
+}
+
 export interface RuntimeStateOptions {
   vaultRoot: string;
   /** Overrides `<counselHome>/providers.yaml`. */
@@ -322,8 +362,8 @@ export function runtimeState(opts: RuntimeStateOptions): RuntimeHandle {
  * Starts the local runtime: resolve the vault, load the provider registry,
  * bind loopback, and publish `runtime.json` for the plugin adapter.
  *
- * The token is fresh per process — it lives only in that file (0600) and in
- * memory, so stopping the server ends every credential it issued.
+ * The token is per install: `runtime.json` (0600) keeps it across restarts
+ * so the browser's cookie stays good, and `newToken` rotates it.
  */
 export async function startServer(opts: StartServerOptions = {}): Promise<RunningServer> {
   const env = opts.env ?? process.env;
@@ -335,8 +375,8 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
   // `providers.yaml`, so the operator's real setup is untouched.
   const fake = opts.fake === undefined ? undefined : new FakeModelProvider(opts.fake);
   const registryFile = opts.registryFile ?? defaultRegistryFile(env);
-  const token = randomBytes(32).toString('hex');
   const file = runtimeFilePath(env);
+  const token = chooseToken(tokenFilePath(env), opts.newToken === true);
   const startedAt = new Date().toISOString();
 
   let vaultRoot: string | null = resolveVaultOrSetup(opts);

--- a/runtime/src/server/setup-routes.test.ts
+++ b/runtime/src/server/setup-routes.test.ts
@@ -121,6 +121,28 @@ describe('the setup app', () => {
   });
 });
 
+describe('the setup app, signed in by cookie', () => {
+  test('a bearer sets the sign-in cookie; the cookie then works for health, setup, and the 409s; sign-out clears it', async () => {
+    const { app: a } = app();
+    const first = await call(a, 'GET', '/health');
+    expect(first.status).toBe(200);
+    expect(first.headers.get('set-cookie')).toContain(`counsel_session=${TOKEN}; Path=/;`);
+    const cookie = { cookie: `counsel_session=${TOKEN}`, 'sec-fetch-site': 'same-origin' };
+    const health = await a(new Request('http://127.0.0.1:7431/health', { headers: cookie }));
+    expect(health.status).toBe(200);
+    expect(((await health.json()) as { setup?: boolean }).setup).toBe(true);
+    expect(health.headers.get('set-cookie')).toBeNull();
+    expect((await a(new Request('http://127.0.0.1:7431/setup/detect', { headers: cookie }))).status).toBe(200);
+    expect((await a(new Request('http://127.0.0.1:7431/threads', { headers: cookie }))).status).toBe(409);
+    // From another 127.0.0.1 port: same-site, not same-origin — refused.
+    const elsewhere = await a(new Request('http://127.0.0.1:7431/health', { headers: { cookie: `counsel_session=${TOKEN}`, 'sec-fetch-site': 'same-site' } }));
+    expect(elsewhere.status).toBe(401);
+    const out = await a(new Request('http://127.0.0.1:7431/session/clear', { method: 'POST', headers: cookie }));
+    expect(out.status).toBe(204);
+    expect(out.headers.get('set-cookie')).toContain('Max-Age=0');
+  });
+});
+
 describe('API_PREFIXES', () => {
   test('reserves setup, so the setup routes are never served as static', () => {
     expect(API_PREFIXES).toContain('setup');

--- a/runtime/src/server/setup-routes.ts
+++ b/runtime/src/server/setup-routes.ts
@@ -4,7 +4,7 @@ import { DEFAULT_STEP_TIMEOUT_MS } from '../loop/counsel-loop';
 import { detectLocations, probeProviders, type Location, type ProviderProbe } from '../setup/detect';
 import { SetupPlan } from '../setup/plan';
 import { runSetup, SetupError, type SetupResult } from '../setup/run';
-import { isAuthorized } from './auth';
+import { authorize, CLEAR_SESSION_COOKIE, withSessionCookie } from './auth';
 import { isApiPath, type App } from './routes';
 import { serveStatic } from './static';
 
@@ -97,13 +97,29 @@ export function createSetupApp(deps: SetupAppDeps): App {
         const page = staticHandler === null ? null : await staticHandler(req);
         return page ?? json({ error: `no route for ${req.method} ${url.pathname}` }, 404);
       }
-      if (!isAuthorized(req, deps.token)) return json({ error: 'unauthorized' }, 401);
+      // The same two credentials as the real app (auth.ts): the bearer signs
+      // the browser in with the cookie, so the first-run screen's own calls
+      // and the app that takes over after `POST /setup` share one sign-in.
+      const via = authorize(req, deps.token);
+      if (via === null) return json({ error: 'unauthorized' }, 401);
+      const res = await dispatch(req, url);
+      return via === 'bearer' && !res.headers.has('set-cookie') ? withSessionCookie(res, deps.token) : res;
+    } catch (err) {
+      console.error(`counsel-os server (setup mode): ${req.method} ${req.url} failed:`, err);
+      return json({ error: 'internal error' }, 500);
+    }
+  };
 
+  async function dispatch(req: Request, url: URL): Promise<Response> {
+    {
       const segments = url.pathname.split('/').filter(s => s !== '');
       const [first, second] = segments;
       const { method } = req;
 
       if (segments.length === 1 && first === 'health' && method === 'GET') return health();
+      if (segments.length === 2 && first === 'session' && second === 'clear' && method === 'POST') {
+        return new Response(null, { status: 204, headers: { 'set-cookie': CLEAR_SESSION_COOKIE } });
+      }
       if (first === 'setup') {
         if (segments.length === 2 && second === 'detect' && method === 'GET') return json({ locations: detect() });
         if (segments.length === 2 && second === 'providers' && method === 'GET') return json({ providers: await probe() });
@@ -112,9 +128,6 @@ export function createSetupApp(deps: SetupAppDeps): App {
       }
       // Everything else needs a vault this runtime does not have yet.
       return json(SETUP_REQUIRED, 409);
-    } catch (err) {
-      console.error(`counsel-os server (setup mode): ${req.method} ${req.url} failed:`, err);
-      return json({ error: 'internal error' }, 500);
     }
-  };
+  }
 }

--- a/runtime/ui/src/api/client.test.ts
+++ b/runtime/ui/src/api/client.test.ts
@@ -1,7 +1,7 @@
 import '../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { ApiError, fetchJson, fetchJsonWithHeaders, streamStep } from './client';
+import { ApiError, fetchJson, fetchJsonWithHeaders, signOut, streamStep } from './client';
 import { clearToken, readToken, TOKEN_KEY } from './token';
 import { onUnauthorized } from './unauthorized';
 import type { StreamEvent } from './types';
@@ -163,5 +163,57 @@ describe('fetchBlob', () => {
     const { fetchBlob } = await import('./client');
     responds(404, { error: 'no such file' });
     await expect(fetchBlob('/vault/download?path=none.docx')).rejects.toBeInstanceOf(ApiError);
+  });
+});
+
+describe('without a token in the tab', () => {
+  test('the request goes out with no Authorization header and nothing is reported — the cookie may carry it', async () => {
+    clearToken();
+    sessionStorage.clear();
+    let reported = 0;
+    const off = onUnauthorized(() => (reported += 1));
+    responds(200, { ok: true });
+    try {
+      expect(await fetchJson<{ ok: boolean }>('/health')).toEqual({ ok: true });
+      const headers = seen[0]!.init?.headers as Record<string, string>;
+      expect(headers['authorization']).toBeUndefined();
+      expect(reported).toBe(0);
+    } finally {
+      off();
+    }
+  });
+
+  test('a 401 still reports, so the app shows the session-lost screen', async () => {
+    clearToken();
+    sessionStorage.clear();
+    let reported = 0;
+    const off = onUnauthorized(() => (reported += 1));
+    responds(401, { error: 'unauthorized' });
+    try {
+      await expect(fetchJson('/health')).rejects.toBeInstanceOf(ApiError);
+      expect(reported).toBe(1);
+    } finally {
+      off();
+    }
+  });
+});
+
+describe('signOut', () => {
+  test('clears the cookie server-side, forgets the token, and reports unauthorized', async () => {
+    let reported = 0;
+    const off = onUnauthorized(() => (reported += 1));
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      seen.push({ url: String(input), init });
+      return new Response(null, { status: 204 });
+    }) as unknown as typeof fetch;
+    try {
+      await signOut();
+      expect(seen[0]!.url).toBe('/session/clear');
+      expect(seen[0]!.init?.method).toBe('POST');
+      expect(readToken()).toBeNull();
+      expect(reported).toBe(1);
+    } finally {
+      off();
+    }
   });
 });

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -7,7 +7,7 @@
  * app can show the spec §5 message instead of each caller inventing its own.
  */
 import { parseSseChunk } from './sse';
-import { clearToken, getToken, TokenMissingError } from './token';
+import { clearToken, readToken } from './token';
 import { reportUnauthorized } from './unauthorized';
 import type { StepBody, StreamEvent } from './types';
 
@@ -36,16 +36,30 @@ function errorMessage(status: number, body: unknown): string {
 }
 
 /**
- * The `Authorization` header, or a reported failure. A missing token is the
- * same user-visible state as a rejected one, so it is announced here rather
- * than surfacing as a bare exception from somewhere deep in a component.
+ * The `Authorization` header when this tab holds the token, else nothing:
+ * the browser may be carrying the sign-in cookie the runtime set on an
+ * earlier visit (same secret, `HttpOnly`, same-origin only — see
+ * `runtime/src/server/auth.ts`), and `fetch` attaches it by itself on a
+ * same-origin request. Whether either credential is good is the server's
+ * call; a 401 is what says neither was.
  */
 function authHeaders(): Record<string, string> {
+  const token = readToken();
+  return token === null || token === '' ? {} : { authorization: `Bearer ${token}` };
+}
+
+/**
+ * Signs THIS browser out: the runtime clears its cookie, the tab forgets
+ * its token, and the app shows the session-lost screen. The runtime's
+ * token stands — other browsers stay signed in; `serve --new-token` is the
+ * way to sign everyone out.
+ */
+export async function signOut(): Promise<void> {
   try {
-    return { authorization: `Bearer ${getToken()}` };
-  } catch (err) {
-    if (err instanceof TokenMissingError) reportUnauthorized();
-    throw err;
+    await request('/session/clear', { method: 'POST' });
+  } finally {
+    clearToken();
+    reportUnauthorized();
   }
 }
 

--- a/runtime/ui/src/settings/Health.tsx
+++ b/runtime/ui/src/settings/Health.tsx
@@ -1,3 +1,4 @@
+import { signOut } from '../api/client';
 import type { Health as HealthData, SettingsView } from '../api/types';
 
 export interface HealthProps {
@@ -66,6 +67,14 @@ export function Health({ health, effective, file }: HealthProps): JSX.Element {
           <dd>{effective.stepTimeoutMs} ms</dd>
         </div>
       </dl>
+
+      <p className="muted settings-signout">
+        This browser is signed in to the runtime and stays so across tabs and restarts.{' '}
+        <button type="button" className="v2-link" onClick={() => void signOut()}>
+          Sign out of this browser
+        </button>
+        {' '}— other browsers keep their sign-in; start the runtime with <code>--new-token</code> to sign everyone out.
+      </p>
 
       <h3 className="runin">Providers</h3>
       {effective.providers.length === 0 ? (

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -923,3 +923,6 @@ a { color: var(--accent); }
 .v2-doctor-detail { color: var(--fg-muted); font-size: 12.5px; white-space: pre-line; margin-top: 2px; }
 .v2-doctor-fix { color: var(--fg-faint); font: 12px var(--mono); margin-top: 2px; word-break: break-all; }
 .v2-doctor-verdict { margin-top: 8px; font: italic 500 13.5px/1.4 var(--serif); color: var(--fg); }
+
+/* The Runtime group's sign-out: one sentence, the action as a quiet link. */
+.settings-signout { margin: 10px 0 18px; font-size: 13px; }

--- a/runtime/ui/src/v2/SessionLost.test.tsx
+++ b/runtime/ui/src/v2/SessionLost.test.tsx
@@ -92,3 +92,15 @@ describe('SessionLost', () => {
     expect((screen.getByRole('button', { name: 'Open' }) as HTMLButtonElement).disabled).toBe(true);
   });
 });
+
+describe('SessionLost, already signed in by cookie', () => {
+  test('a 2xx probe means the browser holds the session: hand straight back, nothing to paste', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      if (String(input).startsWith('/health')) return new Response('{"vault":"/v"}', { status: 200, headers: { 'content-type': 'application/json' } });
+      throw new Error(`unexpected fetch: ${String(input)}`);
+    }) as unknown as typeof fetch;
+    let restored = 0;
+    render(<SessionLost onRestored={() => (restored += 1)} />);
+    await waitFor(() => expect(restored).toBe(1));
+  });
+});

--- a/runtime/ui/src/v2/SessionLost.tsx
+++ b/runtime/ui/src/v2/SessionLost.tsx
@@ -9,22 +9,25 @@ import { storeToken, tokenFromPaste } from '../api/token';
  */
 export const SERVE_COMMAND = 'bun runtime/src/cli.ts serve --vault <your vault> --open';
 
-/** What the probe found: the runtime answered (any status — a 401 is the
- * runtime saying "who are you", which is the whole question here), or
- * nothing is listening. `null` while the probe is in flight. */
-export type Probe = 'up' | 'down' | null;
+/** What the probe found: this browser is already signed in (the cookie
+ * worked — a 2xx), the runtime answered but wants a credential (a 401 is
+ * the runtime saying "who are you"), or nothing is listening. `null` while
+ * the probe is in flight. */
+export type Probe = 'in' | 'up' | 'down' | null;
 
 /**
  * Asks the runtime whether it is there, WITHOUT a token: the point is to
  * tell "your key is stale" from "nothing is running", and sending the
  * stale key would not change either answer while giving a log one more
- * copy of it. A plain `fetch`, not `client.ts` — that one reports 401s to
- * the app, and this screen is already the app's answer to one.
+ * copy of it. The browser still attaches its sign-in cookie, so a 2xx here
+ * means this screen is not needed at all. A plain `fetch`, not
+ * `client.ts` — that one reports 401s to the app, and this screen is
+ * already the app's answer to one.
  */
 export async function probeRuntime(): Promise<Probe> {
   try {
-    await fetch('/health', { cache: 'no-store' });
-    return 'up';
+    const res = await fetch('/health', { cache: 'no-store' });
+    return res.ok ? 'in' : 'up';
   } catch {
     return 'down';
   }
@@ -52,8 +55,14 @@ export function SessionLost({ onRestored }: SessionLostProps): JSX.Element {
 
   const check = useCallback(async (): Promise<void> => {
     setProbe(null);
-    setProbe(await probeRuntime());
-  }, []);
+    const found = await probeRuntime();
+    // The cookie let us in: nothing to paste — hand straight back.
+    if (found === 'in') {
+      onRestored();
+      return;
+    }
+    setProbe(found);
+  }, [onRestored]);
 
   useEffect(() => {
     void check();
@@ -91,8 +100,8 @@ export function SessionLost({ onRestored }: SessionLostProps): JSX.Element {
           {probe === null
             ? 'Checking whether counsel-os is running…'
             : probe === 'up'
-              ? 'The runtime is running, but this tab no longer has its key. Paste the address it printed to get back in.'
-              : 'counsel-os is not running. Start it, then paste the address it prints.'}
+              ? 'The runtime is running, but this browser is not signed in. Open the address counsel-os printed once; after that this page remembers you on this machine.'
+              : 'counsel-os is not running. Start it, then open the address it prints once; after that this page remembers you on this machine.'}
         </p>
 
         <section className="v2-lost-group rule-double">
@@ -105,7 +114,7 @@ export function SessionLost({ onRestored }: SessionLostProps): JSX.Element {
             </button>
           </div>
           <p className="muted">
-            It prints an address that starts with <code>http://127.0.0.1</code> and ends in <code>#token=…</code>. The browser it opens is already signed in; any other tab needs that address.
+            It prints an address that starts with <code>http://127.0.0.1</code> and ends in <code>#token=…</code>. Open it once in this browser and it stays signed in — new tabs and restarts included — until you sign out in Settings or start the runtime with <code>--new-token</code>.
           </p>
         </section>
 

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -1,7 +1,7 @@
 import { act, cleanup, fireEvent, render, screen, userEvent, waitFor } from '../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { TOKEN_KEY } from '../api/token';
+import { clearToken, TOKEN_KEY } from '../api/token';
 import { routeFromHash, vaultPathFromHash } from '../app';
 import type { Health, SettingsView, Thread, ThreadEvent, ThreadHeader } from '../api/types';
 import { Shell } from './Shell';
@@ -722,5 +722,51 @@ describe('Shell in setup mode (spec 2026-09-01 §4)', () => {
     await waitFor(() => expect(screen.queryByText('Set up counsel-os.')).toBeNull(), { timeout: 3000 });
     await waitFor(() => expect(fetched).toContain('GET /threads'));
     expect(document.querySelector('.v2-rail')).toBeTruthy();
+  });
+});
+
+describe('Shell, signed in by cookie', () => {
+  test('no token in the tab but the runtime answers 200 (the cookie): the app renders, no session-lost screen', async () => {
+    // The in-memory copy an earlier test's paste left behind, too.
+    clearToken();
+    sessionStorage.clear();
+    const auths: (string | undefined)[] = [];
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/threads') auths.push((init?.headers as Record<string, string> | undefined)?.['authorization']);
+      return base(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(screen.getAllByText('Acme NDA term').length).toBeGreaterThan(0));
+    expect(screen.queryByLabelText('Session lost')).toBeNull();
+    expect(document.querySelector('.v2-rail')).toBeTruthy();
+    // The list was fetched with NO bearer — the browser's cookie is the credential.
+    expect(auths).toEqual([undefined]);
+    expect(globalThis.location.hash).not.toContain('token');
+  });
+});
+
+describe('Shell, a printed link opened into the session-lost tab', () => {
+  test('the fragment token is taken on hashchange — no reload — and the app comes back', async () => {
+    clearToken();
+    sessionStorage.clear();
+    const hex = 'fedcba9876543210'.repeat(4);
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const auth = (init?.headers as Record<string, string> | undefined)?.['authorization'];
+      // No credential at all: the runtime says who-are-you.
+      if (auth === undefined) return new Response('{"error":"unauthorized"}', { status: 401 });
+      return base(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(screen.getByLabelText('Session lost')).toBeTruthy());
+
+    goTo(`#token=${hex}`);
+    await waitFor(() => expect(screen.getAllByText('Acme NDA term').length).toBeGreaterThan(0));
+    expect(screen.queryByLabelText('Session lost')).toBeNull();
+    expect(sessionStorage.getItem(TOKEN_KEY)).toBe(hex);
+    expect(globalThis.location.hash).not.toContain('token');
   });
 });

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
-import { readToken } from '../api/token';
+import { bootstrapToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
 import type { Health, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
@@ -44,7 +44,9 @@ function byRecent(a: ThreadHeader, b: ThreadHeader): number {
 export function Shell(): JSX.Element {
   const [route, setRoute] = useState<Route>(() => parseHash(globalThis.location.hash).route);
   const [vaultPath, setVaultPath] = useState<string | null>(() => vaultPathFromHash(globalThis.location.hash));
-  const [unauthorized, setUnauthorized] = useState(() => readToken() === null);
+  // Not "no token in this tab": the browser may hold the sign-in cookie
+  // from an earlier visit. The first request finds out; a 401 flips this.
+  const [unauthorized, setUnauthorized] = useState(false);
   const [health, setHealth] = useState<Health | null>(null);
   const [threads, setThreads] = useState<ThreadHeader[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
@@ -235,6 +237,11 @@ export function Shell(): JSX.Element {
 
   useEffect(() => {
     const onHashChange = (): void => {
+      // A printed `#token=…` link opened INTO a tab already showing the app
+      // (the session-lost page, say) is a same-document navigation: no
+      // reload, so `main.tsx`'s bootstrap never ran for it. Take the token
+      // here, the same way — stored, fragment rewritten — and let the app in.
+      if (bootstrapToken() !== null) setUnauthorized(false);
       const hash = globalThis.location.hash;
       const next = parseHash(hash).route;
       setRoute(next);

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { clearToken, TOKEN_KEY } from '../../api/token';
+import { onUnauthorized } from '../../api/unauthorized';
 import type { Health as HealthData, ProviderInfo, SettingsView } from '../../api/types';
 import { SettingsPage } from './SettingsPage';
 
@@ -239,5 +240,31 @@ describe('SettingsPage, the default provider field (cou-93 item 3)', () => {
     expect((screen.getByLabelText('Default provider') as HTMLInputElement).value).toBe('claude-sub/claude-opus-5');
     expect(screen.getByText(/Built-in default/)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'Make it the default' })).toBeNull();
+  });
+});
+
+describe('SettingsPage, signing out', () => {
+  test('Runtime has "Sign out of this browser": it POSTs /session/clear and the app hears unauthorized', async () => {
+    const calls: { url: string; method: string }[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({ url, method });
+      if (url === '/settings' && method === 'GET') return json(view);
+      if (url === '/session/clear' && method === 'POST') return new Response(null, { status: 204 });
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as unknown as typeof fetch;
+    let reported = 0;
+    const off = onUnauthorized(() => (reported += 1));
+    try {
+      render(<SettingsPage health={health} />);
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Sign out of this browser' })).toBeTruthy());
+      await userEvent.click(screen.getByRole('button', { name: 'Sign out of this browser' }));
+      await waitFor(() => expect(reported).toBe(1));
+      expect(calls.some(c => c.url === '/session/clear' && c.method === 'POST')).toBe(true);
+      expect(sessionStorage.getItem(TOKEN_KEY)).toBeNull();
+    } finally {
+      off();
+    }
   });
 });


### PR DESCRIPTION
Founder, 2026-09-01: "it sucks to have to paste an address with a token each time."

**Threat model**
1. The attacker is a web page in the same browser (any site the operator has open) or another local process; the runtime listens on loopback only.
2. A page cannot read a loopback response without a credential it does not have: the bearer, which never travels in a URL a server sees (fragment only) and is never logged.
3. The new cookie carries the same secret, `HttpOnly` + `SameSite=Strict`, so no script reads it and cross-site requests never carry it.
4. `SameSite=Strict` still sends the cookie on same-SITE requests, and "site" ignores the port: a page on `127.0.0.1:8080` could ride on it. So a cookie authenticates only when `Sec-Fetch-Site` is `same-origin` or `none` (address bar) and any `Origin` header equals the server's own `http://<host>`; a wrong bearer is refused even beside a right cookie.
5. `serve --new-token` rotates the secret and signs every browser out; `POST /session/clear` signs one browser out.

**What changed**
- `runtime/src/server/auth.ts`: `authorize` (bearer OR same-origin cookie), `cookieAllowedForOrigin`, `sessionCookieHeader` (`counsel_session=<token>; Path=/; Max-Age=31536000; HttpOnly; SameSite=Strict`), `withSessionCookie`, threat-model doc comment.
- `routes.ts`: `session` API prefix; bearer-authenticated responses set the cookie (unless the route set its own); `POST /session/clear` (204 + clearing cookie).
- `serve.ts`: the token is per install in `<counselHome>/token` (0600, atomic, outlives `runtime.json`); `newToken` option. `cli.ts`: `serve --new-token`.
- UI: `client.ts` sends the bearer only when the tab has one and otherwise relies on the cookie; `signOut()`; Shell no longer assumes "no token = no session" and takes a fragment token on hashchange too; the session-lost probe hands back on a 2xx and its copy explains the one-time sign-in; Settings › Runtime gains "Sign out of this browser".
- CHANGELOG (Unreleased).

**Tests**: `bun run test` 646 · `bun run ui:test` 412 · both typechecks clean. Verified in a real browser on a throwaway home: printed link → cookie-only reload → runtime restart keeps the token → foreign-origin cookie refused (401) → sign out → session-lost.