### PR TITLE
release: regenerate the content manifest as part of the version bump

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -148,6 +148,11 @@ p.write_text(text, encoding="utf-8")
 print(f"prepended CHANGELOG.md entry for {v}")
 PY
 
+# The shipped-content manifest records the version and per-file hashes
+# (runtime/src/content/manifest.ts); a release that bumps VERSION without
+# regenerating it fails the manifest test on the next checkout.
+bun scripts/gen_content_manifest.ts
+
 # Verify sync + content conventions before committing
 python3 scripts/lint_knowledge.py --check-versions
 


### PR DESCRIPTION
After v0.11.3 the generated content manifest (which records the version) was stale on main and failed its own test on every branch rebased onto it. release.sh now runs `bun scripts/gen_content_manifest.ts` right after bumping the manifests and before the lint, so the release commit carries a fresh manifest. `bash -n` clean.