### PR TITLE
ui: the reader's facts block is a ledger of label → value, not a right-aligned table

### DIFF
--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -544,10 +544,18 @@ a { color: var(--accent); }
 .v2-doc-meta { margin-left: auto; font: 12px var(--mono); color: var(--fg-faint); flex-shrink: 0; white-space: nowrap; }
 /* Two columns while each can hold ~280px, one column below that — and values
    wrap at words, never mid-word (`anywhere` split "Publishing" in three). */
-.v2-fm { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); column-gap: 40px; margin: 0 0 26px; border-bottom: 1px solid var(--border); padding-bottom: 16px; }
-.v2-fm-row { display: flex; align-items: baseline; font-size: 13px; color: var(--fg-faint); padding: 2px 0; min-width: 0; }
-.v2-fm-row dt { color: var(--fg-faint); white-space: nowrap; }
-.v2-fm-row dd { margin: 0; color: var(--fg); font-weight: 600; text-align: right; overflow-wrap: break-word; min-width: 0; }
+/* The facts block (founder, 2026-09-01: "still looks messy"). A ledger of
+   label → value pairs, not a right-aligned table: the label sits in a fixed
+   small-caps column and the value reads left-aligned beside it at regular
+   weight, so a value that is a sentence wraps under itself. The two columns
+   are independent flows (`columns`), so one tall value never opens a hole
+   beside it the way an aligned grid row did. Leaders are dropped here — they
+   only ever made sense for one-word values. */
+.v2-fm { columns: 300px 2; column-gap: 48px; margin: 0 0 26px; border-bottom: 1px solid var(--border); padding-bottom: 14px; }
+.v2-fm-row { display: grid; grid-template-columns: 8.5em minmax(0, 1fr); column-gap: 12px; align-items: baseline; font-size: 13px; padding: 3px 0; break-inside: avoid; }
+.v2-fm-row dt { font: 600 10.5px/1.8 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-faint); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.v2-fm-row .leader { display: none; }
+.v2-fm-row dd { margin: 0; color: var(--fg); font-weight: 400; line-height: 1.5; text-align: left; overflow-wrap: break-word; min-width: 0; }
 .v2-doc-md { font: 400 15.5px/1.65 var(--serif); color: var(--fg); max-width: 68ch; }
 .v2-doc-md h2 { font: 500 17px/1.3 var(--serif); margin: 30px 0 10px; padding-bottom: 6px; border-bottom: 1px solid var(--border); }
 .v2-doc-md h3 { font: 600 11px/1 var(--sans); letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-faint); margin: 22px 0 8px; }


### PR DESCRIPTION
Founder screenshot 2026-09-01 (IPOR matter): right-aligned bold multi-line values with leaders, and a grid that aligned rows across the two columns, read as a mess. Now: small-caps labels in a fixed 8.5em column, values left-aligned at regular weight wrapping under themselves, two independent column flows (one below ~300px per column), no leaders in this block. CSS only; vault UI tests pass (44); typecheck clean; verified by screenshot at 1440px and 900px.