### PR TITLE
runtime: content updates and doctor in the runtime (setup stage 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Runtime-owned setup, stage 1 (spec `docs/superpowers/specs/2026-09-01-runtime-ow
 - `serve` no longer exits when no legal root exists: it starts in setup mode, serves the page, and offers `GET /setup/detect`, `GET /setup/providers`, and `POST /setup`; every other API route answers 409 until a vault is set up, then the same server switches to it in place. `/health` reports `setup`.
 - The web UI shows a setup-required page in setup mode (the first-run screen lands next).
 
+Runtime-owned setup, stage 2 — content updates and doctor (spec §6–§7)
+
+- `bun runtime/src/cli.ts update-content`, `GET /content/status` and `POST /content/apply`, and a **Content** group in Settings: the shipped law and practice content compared with the vault by body hash and by what the vault last received. Law updates apply (never a file you changed — `managed-by: user`, `law_management: user`, or an edited copy); a practice seed that changed upstream shows its diff against the seed as received (`.counsel/received/`) for a merge by hand; missing files can be added. `auto_apply_law_updates: true` in `config.md` applies law updates at serve start.
+- `bun runtime/src/cli.ts doctor`, `GET /doctor`, and **Check the vault** under Settings › Runtime: the read-only vault checks of `/counsel-os:doctor` — config marker, structure and counts, law currency against the policy cadences, git, a standards ↔ library numeric divergence check (time units), and open matters behind a refreshed law area. No environment checks.
+
 ## [0.11.3] — 2026-09-01
 
 UI review batch — readable search, unified docket, session-lost screen, provider notice, conversation rename and matter link

--- a/docs/superpowers/plans/2026-09-01-content-update-doctor.md
+++ b/docs/superpowers/plans/2026-09-01-content-update-doctor.md
@@ -1,0 +1,128 @@
+# Content Updates and Doctor in the Runtime — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The runtime keeps a vault's shipped content current and checks the vault's health without the plugin: `counsel-os update-content`, `counsel-os doctor`, `GET /content/status`, `POST /content/apply`, `GET /doctor`, a Content group and a "Check the vault" action in Settings — porting the rules of `skills/update/SKILL.md` steps 4–7 and `skills/doctor/SKILL.md` steps 1, 2, 4B, 8, 10, 11 exactly, with the environment checks dropped.
+
+**Architecture:** `runtime/src/content/update.ts` classifies every shipped file against the vault by frontmatter-stripped body hash — the shipped hash, the vault hash, and the hash the vault last received (`.counsel/content-state.json`, written by `runSetup`) — and applies only what the rules allow (law `update-available`/`missing`; practice `missing`; never a user-modified file, never a practice file the user has). Practice diffs are drawn against a snapshot of the last received seed (`.counsel/received/…`, written from this PR on) or, when there is none, against the vault copy with that stated. `runtime/src/doctor/` runs pure checks over the vault root, the content source, the law policy, and an injected git runner, and returns findings. Routes and CLI are thin; the UI renders ledgers in set text.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict, `Bun.YAML` for frontmatter (as `overview.ts`), `node:crypto` hashing (`content/hash.ts`), a small in-repo line diff (no new dependency), React 18 + happy-dom tests for the UI.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-runtime-owned-setup-design.md` §6 (content updates), §7 (doctor), §10 steps 5–6.
+
+## Global Constraints
+
+- Law is plugin-managed by default; a file is user-owned when its frontmatter says `managed-by: user`, when `config.md` says `law_management: user`, or when its body differs from what the vault last received. **A user-owned file is never written.** Vault-only law areas are never touched.
+- Practice seeds are user-owned. Never seed-vs-vault diffed as "updated guidance"; never overwritten. A practice file the vault lacks may be added. `## Our Position` is never touched by any automatic step.
+- `auto_apply_law_updates: true` in `config.md` applies law `update-available` items at serve start, logs one line, and still never touches a user-owned file. Practice always needs a person.
+- Doctor is read-only. Findings are `{ check, severity: 'ok' | 'warn' | 'error', message, detail?, paths? }`. No environment checks (pandoc, python, browse, qmd). Doctor never runs `git add/commit/push`.
+- Every route that needs the token has its first segment in `API_PREFIXES` (`content`, `doctor`) and in `runtime/ui/vite.config.ts`'s proxy list.
+- Tests never touch the real `~/.counsel-os` or a real vault: temp `COUNSEL_OS_HOME`, temp vaults, an injected git runner.
+- Design language in the UI: set text, small-caps run-ins, dotted leaders, no pills, no modals.
+- Commit prefixes `runtime:` / `ui:` / `docs:`; no `Co-Authored-By`, no `Claude-Session` trailers.
+
+---
+
+## File structure
+
+```
+runtime/src/
+  vault/resolve-root.ts                 VaultConfig + autoApplyLawUpdates, lawManagement
+  setup/run.ts                          export readContentState, PLACEMENTS; practice snapshots
+  content/diff.ts (+ .test.ts)          unifiedDiff(a, b, labels) — line LCS, capped
+  content/update.ts (+ .test.ts)        contentStatus, applyUpdates, autoApplyLawUpdates
+  doctor/policy.ts                      LawPolicy loader (frontmatter-policy.json)
+  doctor/checks.ts (+ .test.ts)         the six checks, pure over a vault root
+  doctor/index.ts                       runDoctor → DoctorReport
+  server/routes.ts (+ .test.ts)         GET /content/status, POST /content/apply, GET /doctor
+  server/serve.ts (+ .test.ts)          auto-apply at start
+  cli.ts                                update-content, doctor
+runtime/ui/
+  vite.config.ts                        + /content, /doctor
+  src/api/types.ts                      ContentStatus, ContentItem, DoctorReport, DoctorFinding
+  src/v2/settings/ContentGroup.tsx (+ .test.tsx)
+  src/v2/settings/DoctorLedger.tsx (+ .test.tsx)
+  src/v2/settings/SettingsPage.tsx      mounts both
+  src/styles.css                        .v2-content-*, .v2-doctor-*
+skills/update/SKILL.md, skills/doctor/SKILL.md   one line each
+CHANGELOG.md                             Unreleased
+```
+
+---
+
+### Task 1: Config fields and content-state exports
+
+**Files:** `runtime/src/vault/resolve-root.ts`, `resolve-root.test.ts`, `runtime/src/setup/run.ts`, `run.test.ts`
+
+- [ ] Test: `readVaultConfig` returns `autoApplyLawUpdates: false`, `lawManagement: 'plugin'` by default; `true`/`'user'` when the lines are present (case as written; quoted values tolerated).
+- [ ] Add the two fields. Export `readContentState`, `writeContentState`, `PLACEMENTS`, `RECEIVED_DIR` (`.counsel/received`) from `run.ts`; `runSetup` writes a snapshot of each PRACTICE seed it places under `.counsel/received/<vault path>` (law is not snapshotted — its baseline is its hash).
+- [ ] Test: after `runSetup`, `.counsel/received/practice/standards/confidentiality.md` exists and equals the seed; law has no snapshot.
+- [ ] Commit `runtime: config flags for law updates; practice seed snapshots beside the content state`.
+
+### Task 2: Line diff
+
+**Files:** `runtime/src/content/diff.ts`, `diff.test.ts`
+
+- [ ] Test: identical → `''`; one changed line → a unified hunk with `-`/`+`; leading/trailing context of 3; inputs over 4000 lines → a one-line "diff too large" marker.
+- [ ] Implement LCS over lines (O(n·m) with the cap), `unifiedDiff(a, b, { from, to })`.
+- [ ] Commit `runtime: a small unified line diff for practice seed changes`.
+
+### Task 3: Content update classification
+
+**Files:** `runtime/src/content/update.ts`, `update.test.ts`
+
+- [ ] Types: `ContentItem { path (vault), shipped, group: 'law' | 'practice', status, reason?, diff?, baseline?: 'received' | 'vault' }`, `ContentStatus { shippedVersion, vaultVersion, items, counts }`.
+- [ ] `contentStatus(deps: { vaultRoot, content, shippedVersion, now? })`:
+  - law: per shipped file → `current` / `update-available` / `user-modified` (`reason: 'managed-by' | 'law-management' | 'edited' | 'no-baseline'`) / `missing`; vault law files not shipped → `vault-only`. `law_management: user` marks every law file user-modified (reason `law-management`) and no law is ever applicable.
+  - practice: shipped hash ≠ received hash → `upstream-changed` with `diff` (received snapshot vs shipped when the snapshot exists, else vault vs shipped, `baseline: 'vault'`); missing in vault → `missing`; else `current`. Cosmetic-only changes: a diff whose only changed lines are `content-version:` frontmatter lines is `current` with `reason: 'restamped'`.
+  - counts per status.
+- [ ] Tests: every classification; managed-by guard; law_management guard; practice never `update-available`; restamp filter; vault-only.
+- [ ] `applyUpdates(deps, paths)`: refuses (throws `UpdateError`) a path that is not law `update-available`/`missing` or practice `missing`; writes the shipped text; updates content-state hashes and practice snapshots; returns `{ applied, skipped }`. Idempotent (second call → nothing to do).
+- [ ] `autoApplyLawUpdates(deps)`: when `config.autoApplyLawUpdates`, applies every law `update-available`, returns the count (0 when off); never touches user-modified.
+- [ ] Tests for both.
+- [ ] Commit `runtime: content updates — classify shipped vs vault by hash, apply what the rules allow`.
+
+### Task 4: Routes, serve, CLI
+
+**Files:** `routes.ts`, `routes.test.ts`, `serve.ts`, `serve.test.ts`, `cli.ts`, `runtime/ui/vite.config.ts`
+
+- [ ] `GET /content/status` → `ContentStatus`; `POST /content/apply` `{ paths }` → `{ applied, skipped }`, 400 with the refusal; `API_PREFIXES` + `'content'`, `'doctor'`.
+- [ ] Tests: status on a seeded temp vault (one user-edited law file, one upstream change simulated by writing a different shipped file to the plugin root), apply happy path, apply refusal 400.
+- [ ] `serve.ts`: after `buildApp`, if `readVaultConfig(vault).autoApplyLawUpdates`, run `autoApplyLawUpdates` and log `counsel-os runtime: applied N law updates`. Test in `serve.test.ts`.
+- [ ] `cli.ts`: `update-content [--vault] [--yes] [--dry-run]` prints the ledger, applies law updates with `--yes` (else asks y/n), exits 0; `doctor [--vault]` prints the table, exit 0 (1 with any `error` finding). Vite proxy.
+- [ ] Commit `runtime: /content/status, /content/apply, auto-apply at serve start, update-content CLI`.
+
+### Task 5: Doctor
+
+**Files:** `runtime/src/doctor/policy.ts`, `checks.ts`, `checks.test.ts`, `index.ts`, `routes.ts`, `cli.ts`
+
+- [ ] `checks.ts`, each `(ctx) => Finding[]`:
+  - `root-config`: `config.md` has the marker and `legal_root:` equals the root (realpath both) → ok; marker but elsewhere → warn; missing → error.
+  - `structure`: law, practice/{standards,methods,library,reference}, matters (override), memory, entities (override), profile.md; counts of `*.md` minus `index.md`; law or standards missing/empty → error; others missing → warn; empty matters/entities → ok "empty (fresh install)".
+  - `law-currency`: per vault law file: `last-reviewed` + `review_cadence_months[area] ?? default` (calendar month add as the Python) vs now; stale/never → warn, split user-owned vs plugin-managed in the message; skip `FRONTMATTER.md`.
+  - `git`: injected runner; not a repo → warn; no remote → warn; ≥20 uncommitted → warn; else ok with the detail line.
+  - `consistency`: standards ↔ library numeric divergence (see decisions) → warn per divergence; ok with the pair count.
+  - `law-impact`: open matters (`stage: intake|working`) with `updated:` and law areas (frontmatter `law_areas`/`law-areas`, or a body line `**Law areas:** …`); area's newest `last-reviewed` after `updated` → warn listing them.
+- [ ] Tests on seeded temp vaults: a stale area, a user-managed stale file, a matter behind its area, a divergent pair, a clean vault.
+- [ ] `runDoctor(deps)` → `{ at, vault, findings, verdict }`; `GET /doctor`; `counsel-os doctor`.
+- [ ] Commit `runtime: doctor — the vault checks of /counsel-os:doctor, read-only`.
+
+### Task 6: Settings UI
+
+**Files:** `runtime/ui/src/api/types.ts`, `v2/settings/ContentGroup.tsx` (+ test), `DoctorLedger.tsx` (+ test), `SettingsPage.tsx`, `styles.css`
+
+- [ ] `ContentGroup`: purpose line; "Shipped X · vault received Y"; summary line "N law areas have updates · review" (or "Everything is current"); the list: rows `path ···· status` with `apply` on `update-available`/`missing`, "user-modified — left alone" text, practice `show diff` toggling a `<pre>`; "apply all updates" when any applicable; errors inline; re-reads status after apply.
+- [ ] `DoctorLedger`: "Check the vault" → `GET /doctor` → rows `check ···· severity` (set text: `ok` green, `warn` amber, `error` red) with message and paths; verdict line.
+- [ ] Mount: ContentGroup as its own `.v2-group` after Test; DoctorLedger inside the Runtime group under `Health`.
+- [ ] Tests with fetch mocks: status render, apply → POST body → re-read, show diff, doctor rows and verdict, error lines.
+- [ ] Commit `ui: Settings — the Content group and Check the vault`.
+
+### Task 7: Docs
+
+- [ ] `skills/update/SKILL.md`, `skills/doctor/SKILL.md`: one line each; `CHANGELOG.md` Unreleased; commit `docs: content updates and doctor in the runtime`.
+
+## Decisions recorded up front
+
+- The consistency check is mechanical where the skill is judgment: for each standard ↔ library pair (name map below), numbers with a unit (hours, days, months, years, %, ×) are collected from the standard's `## Our Position` block (`Our standard` + `We'll accept` lines) and from the library's `### Standard` and `### Minimum Acceptable` blocks; a Minimum Acceptable number for a unit that is stricter than every number the standard accepts, or looser than all of them, is reported as a *possible* divergence with both numbers. Law floors are not compared mechanically (no machine-readable floors exist); the finding says so.
+- Name map for pairs: same stem, plus `ai-data-use↔ai-and-data-use`, `assignment-change-of-control↔assignment-and-change-of-control`, `termination-renewal↔termination-and-renewal`, `service-levels↔sla-and-performance`, `indemnification`/`limitation-of-liability↔liability-and-indemnification`, `ip-ownership`/`confidentiality↔ip-and-confidentiality`, `compliance-certifications↔compliance-regulatory`.
+- Backups (doctor step 7) are out of this PR: the runtime has no backup command yet.

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -14,10 +14,14 @@ import { buildProviders } from './providers/index';
 import { DEFAULT_TENANT, isTerminal, type ModelProvider } from './core/types';
 import type { FakeScript } from './core/fake-provider';
 import { DEFAULT_STEP_TIMEOUT_MS, withStepTimeout } from './loop/counsel-loop';
+import { createInterface } from 'node:readline/promises';
 import { repoContentSource } from './content/repo';
+import { applyUpdates, contentStatus, renderContentStatus } from './content/update';
 import { counselHome } from './core/home';
+import { renderReport, runDoctor } from './doctor/index';
 import { runInit } from './setup/init';
 import { defaultPluginRoot, startServer } from './server/serve';
+import { resolveLegalRoot } from './vault/resolve-root';
 
 const { values, positionals } = parseArgs({
   args: Bun.argv.slice(2),
@@ -47,9 +51,10 @@ const { values, positionals } = parseArgs({
     'sample-matter': { type: 'boolean' },
     'no-git': { type: 'boolean' },
     'default-provider': { type: 'string' },
-    yes: { type: 'boolean' },              // `init`: never prompt; fail on a missing answer
+    yes: { type: 'boolean' },              // `init`: never prompt; `update-content`: apply without asking
     changes: { type: 'string' },      // `docx read`: all | accept | reject
     format: { type: 'string' },       // `docx extract|check`: json | markdown | text
+    'dry-run': { type: 'boolean' },        // `update-content`: report only
   },
 });
 
@@ -64,6 +69,10 @@ function usage(): never {
   console.error('       bun runtime/src/cli.ts docx read <file.docx> [--changes all|accept|reject]   (markdown to stdout)');
   console.error('       bun runtime/src/cli.ts docx extract <file.docx> [--format json|markdown]  (tracked changes + comments)');
   console.error('       bun runtime/src/cli.ts docx check <file.docx|.md|.txt> [--format json|text] (mechanical QA)');
+  console.error('       bun runtime/src/cli.ts update-content [--vault <dir>] [--yes] [--dry-run]');
+  console.error('         compares the shipped law and practice content with the vault; applies law updates (never a file you changed)');
+  console.error('       bun runtime/src/cli.ts doctor [--vault <dir>]');
+  console.error('         read-only vault health: root config, structure, law currency, git, standards/library consistency, matter law impact');
   process.exit(2);
 }
 
@@ -97,6 +106,23 @@ async function docxCommand(sub: string | undefined, file: string | undefined): P
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
+}
+
+
+/** The vault for `update-content` / `doctor`: `--vault`, else the resolved
+ * legal root — the same rule `serve` uses, minus setup mode: with no root
+ * there is nothing to update or check. */
+function vaultForMaintenance(): string {
+  if (values.vault) return resolve(values.vault);
+  const found = resolveLegalRoot({ env: process.env });
+  if (found.ok) return found.root;
+  if (found.code === 2) {
+    console.error('Multiple Counsel OS legal roots found. Pass --vault or set COUNSEL_OS_LEGAL_ROOT:');
+    for (const root of found.candidates) console.error(`  ${root}`);
+  } else {
+    console.error('No Counsel OS legal root found. Pass --vault <dir>, or run: bun runtime/src/cli.ts init');
+  }
+  process.exit(1);
 }
 
 /** A millisecond option: a bad one is the caller's mistake, and exits the
@@ -193,6 +219,32 @@ if (cmd === 'serve') {
   process.exit(code);
 } else if (cmd === 'docx') {
   await docxCommand(rest[0], rest[1]);
+} else if (cmd === 'update-content') {
+  const vaultRoot = vaultForMaintenance();
+  const deps = { vaultRoot, content: repoContentSource(defaultPluginRoot()) };
+  const status = contentStatus(deps);
+  console.log(renderContentStatus(status));
+  const pending = status.items.filter(i => i.applicable).map(i => i.path);
+  if (pending.length === 0 || values['dry-run']) process.exit(0);
+  let go = values.yes === true;
+  if (!go && process.stdin.isTTY === true) {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    const answer = (await rl.question(`Apply ${pending.length} update${pending.length === 1 ? '' : 's'}? [y/N] `)).trim().toLowerCase();
+    rl.close();
+    go = answer === 'y' || answer === 'yes';
+  }
+  if (!go) {
+    console.log('Nothing applied. Rerun with --yes to apply.');
+    process.exit(0);
+  }
+  const result = applyUpdates(deps, pending);
+  console.log(`Applied ${result.applied.length}: ${result.applied.join(', ')}`);
+  process.exit(0);
+} else if (cmd === 'doctor') {
+  const vaultRoot = vaultForMaintenance();
+  const report = runDoctor({ vaultRoot, pluginRoot: defaultPluginRoot() });
+  console.log(renderReport(report));
+  process.exit(report.verdict === 'broken' ? 1 : 0);
 } else {
   await step();
 }

--- a/runtime/src/content/diff.test.ts
+++ b/runtime/src/content/diff.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'bun:test';
+import { MAX_LINES, unifiedDiff } from './diff';
+
+const labels = { from: 'received', to: 'shipped' };
+
+describe('unifiedDiff', () => {
+  test('equal texts diff to nothing', () => {
+    expect(unifiedDiff('a\nb\n', 'a\nb\n', labels)).toBe('');
+  });
+
+  test('one changed line, with three lines of context and unified headers', () => {
+    const a = ['1', '2', '3', '4', '5', '6', '7', '8', '9'].join('\n') + '\n';
+    const b = ['1', '2', '3', '4', 'five', '6', '7', '8', '9'].join('\n') + '\n';
+    expect(unifiedDiff(a, b, labels)).toBe(
+      ['--- received', '+++ shipped', '@@ -2,7 +2,7 @@', ' 2', ' 3', ' 4', '-5', '+five', ' 6', ' 7', ' 8', ''].join('\n'),
+    );
+  });
+
+  test('two far-apart changes make two hunks; an addition at the end is its own hunk', () => {
+    const lines = Array.from({ length: 20 }, (_, i) => `line ${i + 1}`);
+    const a = lines.join('\n') + '\n';
+    const b = [...lines.map((l, i) => (i === 1 ? 'changed 2' : l)), 'line 21'].join('\n') + '\n';
+    const diff = unifiedDiff(a, b, labels);
+    expect(diff.match(/^@@/gm)).toHaveLength(2);
+    expect(diff).toContain('-line 2\n+changed 2');
+    expect(diff).toContain('+line 21');
+  });
+
+  test('a deletion of everything, and an addition from nothing', () => {
+    expect(unifiedDiff('x\n', '', labels)).toBe('--- received\n+++ shipped\n@@ -1,1 +0,0 @@\n-x\n');
+    expect(unifiedDiff('', 'x\n', labels)).toBe('--- received\n+++ shipped\n@@ -0,0 +1,1 @@\n+x\n');
+  });
+
+  test('a file past the cap is a marker, not a quadratic table', () => {
+    const big = Array.from({ length: MAX_LINES + 1 }, (_, i) => `l${i}`).join('\n');
+    expect(unifiedDiff(big, big + '\nmore', labels)).toContain('@@ diff too large');
+  });
+});

--- a/runtime/src/content/diff.ts
+++ b/runtime/src/content/diff.ts
@@ -1,0 +1,112 @@
+/**
+ * A small unified line diff, for showing a practice seed's upstream change
+ * beside what the vault received (spec 2026-09-01 §6). Line-level LCS is
+ * enough for markdown files of a few hundred lines; anything past `MAX_LINES`
+ * is answered with a one-line marker rather than a quadratic table.
+ */
+
+export const MAX_LINES = 4000;
+const CONTEXT = 3;
+
+export interface DiffLabels {
+  from: string;
+  to: string;
+}
+
+type Op = { kind: ' ' | '-' | '+'; text: string };
+
+function ops(a: string[], b: string[]): Op[] {
+  const n = a.length;
+  const m = b.length;
+  // lcs[i][j] = length of the LCS of a[i..] and b[j..].
+  const lcs: Uint32Array[] = [];
+  for (let i = 0; i <= n; i++) lcs.push(new Uint32Array(m + 1));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      lcs[i]![j] = a[i] === b[j] ? lcs[i + 1]![j + 1]! + 1 : Math.max(lcs[i + 1]![j]!, lcs[i]![j + 1]!);
+    }
+  }
+  const out: Op[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) {
+      out.push({ kind: ' ', text: a[i]! });
+      i++;
+      j++;
+    } else if (lcs[i + 1]![j]! >= lcs[i]![j + 1]!) {
+      out.push({ kind: '-', text: a[i]! });
+      i++;
+    } else {
+      out.push({ kind: '+', text: b[j]! });
+      j++;
+    }
+  }
+  while (i < n) out.push({ kind: '-', text: a[i++]! });
+  while (j < m) out.push({ kind: '+', text: b[j++]! });
+  return out;
+}
+
+function splitLines(text: string): string[] {
+  if (text === '') return [];
+  const lines = text.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/**
+ * `''` when the texts are equal. Otherwise a unified diff with `---`/`+++`
+ * headers, hunks with `@@ -a,b +c,d @@` ranges and three lines of context.
+ */
+export function unifiedDiff(from: string, to: string, labels: DiffLabels): string {
+  if (from === to) return '';
+  const a = splitLines(from);
+  const b = splitLines(to);
+  if (a.length > MAX_LINES || b.length > MAX_LINES) {
+    return `--- ${labels.from}\n+++ ${labels.to}\n@@ diff too large (${a.length} → ${b.length} lines) @@\n`;
+  }
+  const all = ops(a, b);
+  // Group changed ops into hunks with CONTEXT lines around them.
+  const changed = all.map(op => op.kind !== ' ');
+  const keep = new Array<boolean>(all.length).fill(false);
+  for (let k = 0; k < all.length; k++) {
+    if (!changed[k]) continue;
+    for (let c = Math.max(0, k - CONTEXT); c <= Math.min(all.length - 1, k + CONTEXT); c++) keep[c] = true;
+  }
+  const out: string[] = [`--- ${labels.from}`, `+++ ${labels.to}`];
+  let k = 0;
+  let aLine = 0; // 0-based position in a
+  let bLine = 0;
+  while (k < all.length) {
+    if (!keep[k]) {
+      if (all[k]!.kind !== '+') aLine++;
+      if (all[k]!.kind !== '-') bLine++;
+      k++;
+      continue;
+    }
+    // A hunk: from k while keep[] holds.
+    const start = k;
+    const aStart = aLine;
+    const bStart = bLine;
+    let aCount = 0;
+    let bCount = 0;
+    const body: string[] = [];
+    while (k < all.length && keep[k]) {
+      const op = all[k]!;
+      body.push(`${op.kind}${op.text}`);
+      if (op.kind !== '+') {
+        aCount++;
+        aLine++;
+      }
+      if (op.kind !== '-') {
+        bCount++;
+        bLine++;
+      }
+      k++;
+    }
+    void start;
+    out.push(`@@ -${aCount === 0 ? aStart : aStart + 1},${aCount} +${bCount === 0 ? bStart : bStart + 1},${bCount} @@`);
+    out.push(...body);
+  }
+  return out.join('\n') + '\n';
+}

--- a/runtime/src/content/update.test.ts
+++ b/runtime/src/content/update.test.ts
@@ -14,6 +14,7 @@ function fakeSource(files: Record<string, string>): ContentSource & { files: Rec
     files,
     list: prefix => Object.keys(files).filter(p => isShippedPath(p) && (p === prefix || p.startsWith(`${prefix}/`))).sort(),
     has: path => path in files,
+    readBytes: path => new TextEncoder().encode(files[path] ?? ''),
     read: path => {
       const text = files[path];
       if (text === undefined) throw new Error(`not shipped: ${path}`);

--- a/runtime/src/content/update.test.ts
+++ b/runtime/src/content/update.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runSetup } from '../setup/run';
+import { isShippedPath, type ContentSource } from './source';
+import { applyUpdates, autoApplyLawUpdates, contentStatus, UpdateError } from './update';
+
+/** An in-memory shipped tree, so a test can change "upstream" by mutating
+ * one entry. */
+function fakeSource(files: Record<string, string>): ContentSource & { files: Record<string, string> } {
+  return {
+    kind: 'repo',
+    files,
+    list: prefix => Object.keys(files).filter(p => isShippedPath(p) && (p === prefix || p.startsWith(`${prefix}/`))).sort(),
+    has: path => path in files,
+    read: path => {
+      const text = files[path];
+      if (text === undefined) throw new Error(`not shipped: ${path}`);
+      return text;
+    },
+  };
+}
+
+const GDPR = '---\ncounsel-os-type: law-area\ncontent-version: "2026-06-11"\nlast-reviewed: "2026-06-11"\n---\n# GDPR\n\nArticle 33: 72 hours.\n';
+const CCPA = '---\ncounsel-os-type: law-area\ncontent-version: "2026-06-11"\n---\n# CCPA\n\nBody.\n';
+const CONF = '---\ncounsel-os-type: practice\ncontent-version: "2026-06-11"\n---\n# Confidentiality — Position\n\n## Our Position\n**Our standard:** 3 years.\n\n## Market Standard\nTwo to five years.\n';
+const SHIPPED = {
+  'knowledge/law/data-privacy/gdpr.md': GDPR,
+  'knowledge/law/data-privacy/ccpa.md': CCPA,
+  'knowledge/practice-seed/standards/confidentiality.md': CONF,
+  'templates/memory/patterns.md': '# Patterns\n',
+};
+
+let vault: string;
+let home: string;
+let pluginRoot: string;
+let source: ReturnType<typeof fakeSource>;
+
+function plan() {
+  return { vault, identity: { name: 'A', organization: 'B', role: 'solo' as const, jurisdiction: 'MA' }, practice: 'x', sampleMatter: false, git: false };
+}
+
+function deps(over: Partial<{ vaultRoot: string }> = {}) {
+  return { vaultRoot: over.vaultRoot ?? vault, content: source, shippedVersion: '9.9.9', now: () => new Date('2026-09-01T12:00:00Z') };
+}
+
+function setConfig(extra: string): void {
+  writeFileSync(join(vault, 'config.md'), `counsel-os-config: true\nlegal_root: ${vault}\n${extra}`, 'utf8');
+}
+
+beforeEach(() => {
+  vault = mkdtempSync(join(tmpdir(), 'update-vault-'));
+  home = mkdtempSync(join(tmpdir(), 'update-home-'));
+  pluginRoot = mkdtempSync(join(tmpdir(), 'update-plugin-'));
+  source = fakeSource({ ...SHIPPED });
+  runSetup(plan() as never, { content: source, home, pluginRoot, git: null });
+});
+
+describe('contentStatus — law', () => {
+  test('a freshly seeded vault is current everywhere, with the version it received', () => {
+    const status = contentStatus(deps());
+    expect(status.vaultVersion).not.toBeNull();
+    expect(status.shippedVersion).toBe('9.9.9');
+    expect(status.counts['update-available']).toBe(0);
+    expect(status.counts['user-modified']).toBe(0);
+    expect(status.items.map(i => [i.path, i.status])).toEqual([
+      ['law/data-privacy/ccpa.md', 'current'],
+      ['law/data-privacy/gdpr.md', 'current'],
+      ['practice/standards/confidentiality.md', 'current'],
+    ]);
+  });
+
+  test('upstream changed, vault untouched → update-available, applicable', () => {
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR.replace('72 hours', '72 hours, without undue delay');
+    const item = contentStatus(deps()).items.find(i => i.path === 'law/data-privacy/gdpr.md')!;
+    expect(item.status).toBe('update-available');
+    expect(item.applicable).toBe(true);
+  });
+
+  test('a content-version restamp with the same body is still current', () => {
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR.replace('2026-06-11"\nlast', '2026-09-01"\nlast');
+    expect(contentStatus(deps()).items.find(i => i.path === 'law/data-privacy/gdpr.md')!.status).toBe('current');
+  });
+
+  test('the user edited the vault copy → user-modified (edited), never applicable, even when upstream also changed', () => {
+    writeFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), GDPR + '\nMy note.\n', 'utf8');
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + '\nUpstream note.\n';
+    const item = contentStatus(deps()).items.find(i => i.path === 'law/data-privacy/gdpr.md')!;
+    expect(item.status).toBe('user-modified');
+    expect(item.reason).toBe('edited');
+    expect(item.applicable).toBe(false);
+  });
+
+  test('managed-by: user is user-owned whatever the hashes say', () => {
+    writeFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), GDPR.replace('---\n# GDPR', 'managed-by: user\n---\n# GDPR'), 'utf8');
+    const item = contentStatus(deps()).items.find(i => i.path === 'law/data-privacy/gdpr.md')!;
+    expect(item.status).toBe('user-modified');
+    expect(item.reason).toBe('managed-by');
+  });
+
+  test('law_management: user marks every law file user-owned and offers no adds', () => {
+    setConfig('law_management: user\n');
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + 'x\n';
+    source.files['knowledge/law/employment/flsa.md'] = '# FLSA\n';
+    const status = contentStatus(deps());
+    expect(status.lawManagement).toBe('user');
+    for (const item of status.items.filter(i => i.group === 'law')) {
+      expect(item.status).toBe('user-modified');
+      expect(item.reason).toBe('law-management');
+      expect(item.applicable).toBe(false);
+    }
+  });
+
+  test('a shipped file the vault lacks is missing (an add); a vault-only file is vault-only', () => {
+    source.files['knowledge/law/employment/flsa.md'] = '---\ncounsel-os-type: law-area\n---\n# FLSA\n';
+    mkdirSync(join(vault, 'law', 'my-area'), { recursive: true });
+    writeFileSync(join(vault, 'law', 'my-area', 'notes.md'), '# Mine\n', 'utf8');
+    const status = contentStatus(deps());
+    expect(status.items.find(i => i.path === 'law/employment/flsa.md')).toMatchObject({ status: 'missing', applicable: true, area: 'employment' });
+    expect(status.items.find(i => i.path === 'law/my-area/notes.md')).toMatchObject({ status: 'vault-only', shipped: null, applicable: false });
+  });
+
+  test('no baseline (a vault set up before content-state) — a differing file is user-modified with no-baseline', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'update-bare-'));
+    mkdirSync(join(bare, 'law', 'data-privacy'), { recursive: true });
+    writeFileSync(join(bare, 'config.md'), `counsel-os-config: true\nlegal_root: ${bare}\n`, 'utf8');
+    writeFileSync(join(bare, 'law', 'data-privacy', 'gdpr.md'), GDPR + 'edited\n', 'utf8');
+    writeFileSync(join(bare, 'law', 'data-privacy', 'ccpa.md'), CCPA, 'utf8');
+    const status = contentStatus(deps({ vaultRoot: bare }));
+    expect(status.vaultVersion).toBeNull();
+    expect(status.items.find(i => i.path === 'law/data-privacy/gdpr.md')).toMatchObject({ status: 'user-modified', reason: 'no-baseline' });
+    expect(status.items.find(i => i.path === 'law/data-privacy/ccpa.md')!.status).toBe('current');
+  });
+});
+
+describe('contentStatus — practice', () => {
+  test('the user edited their standard and upstream did not move → current (never seed-vs-vault noise)', () => {
+    writeFileSync(join(vault, 'practice', 'standards', 'confidentiality.md'), CONF.replace('3 years', '5 years'), 'utf8');
+    expect(contentStatus(deps()).items.find(i => i.path === 'practice/standards/confidentiality.md')!.status).toBe('current');
+  });
+
+  test('upstream changed → upstream-changed, diffed against the RECEIVED snapshot, never applicable', () => {
+    writeFileSync(join(vault, 'practice', 'standards', 'confidentiality.md'), CONF.replace('3 years', '5 years'), 'utf8');
+    source.files['knowledge/practice-seed/standards/confidentiality.md'] = CONF.replace('Two to five years.', 'Two to five years; three is market.');
+    const item = contentStatus(deps()).items.find(i => i.path === 'practice/standards/confidentiality.md')!;
+    expect(item.status).toBe('upstream-changed');
+    expect(item.applicable).toBe(false);
+    expect(item.baseline).toBe('received');
+    // The diff shows the upstream change only — the user's "5 years" edit is
+    // not in it, because the baseline is what was received, not the vault.
+    expect(item.diff).toContain('+Two to five years; three is market.');
+    expect(item.diff).not.toContain('5 years');
+  });
+
+  test('a restamp (frontmatter only) is not an upstream change', () => {
+    source.files['knowledge/practice-seed/standards/confidentiality.md'] = CONF.replace('2026-06-11', '2026-09-01');
+    expect(contentStatus(deps()).items.find(i => i.path === 'practice/standards/confidentiality.md')!.status).toBe('current');
+  });
+
+  test('a missing practice file is offered as an add', () => {
+    source.files['knowledge/practice-seed/standards/notices.md'] = '# Notices\n';
+    expect(contentStatus(deps()).items.find(i => i.path === 'practice/standards/notices.md')).toMatchObject({ status: 'missing', applicable: true, group: 'practice' });
+  });
+
+  test('without a snapshot the diff falls back to the vault copy and says so', () => {
+    const bare = mkdtempSync(join(tmpdir(), 'update-bare-'));
+    mkdirSync(join(bare, 'practice', 'standards'), { recursive: true });
+    writeFileSync(join(bare, 'config.md'), `counsel-os-config: true\nlegal_root: ${bare}\n`, 'utf8');
+    writeFileSync(join(bare, 'practice', 'standards', 'confidentiality.md'), CONF.replace('3 years', '5 years'), 'utf8');
+    const item = contentStatus(deps({ vaultRoot: bare })).items.find(i => i.path === 'practice/standards/confidentiality.md')!;
+    expect(item.status).toBe('upstream-changed');
+    expect(item.baseline).toBe('vault');
+    expect(item.diff).toContain('(your copy)');
+  });
+});
+
+describe('applyUpdates', () => {
+  test('writes a law update and a missing file, records them as received, and is idempotent', () => {
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + 'Upstream.\n';
+    source.files['knowledge/practice-seed/standards/notices.md'] = '# Notices\n';
+    const first = applyUpdates(deps(), ['law/data-privacy/gdpr.md', 'practice/standards/notices.md']);
+    expect(first.applied).toEqual(['law/data-privacy/gdpr.md', 'practice/standards/notices.md']);
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(GDPR + 'Upstream.\n');
+    expect(existsSync(join(vault, '.counsel', 'received', 'practice', 'standards', 'notices.md'))).toBe(true);
+    const after = contentStatus(deps());
+    expect(after.items.find(i => i.path === 'law/data-privacy/gdpr.md')!.status).toBe('current');
+    expect(after.items.find(i => i.path === 'practice/standards/notices.md')!.status).toBe('current');
+    expect(after.vaultVersion).toBe('9.9.9');
+    expect(after.receivedAt).toBe('2026-09-01T12:00:00.000Z');
+    expect(() => applyUpdates(deps(), ['law/data-privacy/gdpr.md'])).toThrow(UpdateError);
+  });
+
+  test('refuses a user-modified file, a practice upstream change, and an unknown path — writing nothing', () => {
+    writeFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), GDPR + 'mine\n', 'utf8');
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + 'theirs\n';
+    source.files['knowledge/law/data-privacy/ccpa.md'] = CCPA + 'new\n';
+    source.files['knowledge/practice-seed/standards/confidentiality.md'] = CONF + 'more\n';
+    for (const bad of ['law/data-privacy/gdpr.md', 'practice/standards/confidentiality.md', 'law/nope.md']) {
+      expect(() => applyUpdates(deps(), ['law/data-privacy/ccpa.md', bad])).toThrow(UpdateError);
+    }
+    // The good path in the same call was not written either.
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'ccpa.md'), 'utf8')).toBe(CCPA);
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(GDPR + 'mine\n');
+  });
+});
+
+describe('autoApplyLawUpdates', () => {
+  test('off by default: nothing is written', () => {
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + 'Upstream.\n';
+    expect(autoApplyLawUpdates(deps()).applied).toEqual([]);
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(GDPR);
+  });
+
+  test('on: applies law update-available only — never a user-modified file, never practice', () => {
+    setConfig('auto_apply_law_updates: true\n');
+    source.files['knowledge/law/data-privacy/gdpr.md'] = GDPR + 'Upstream.\n';
+    source.files['knowledge/law/data-privacy/ccpa.md'] = CCPA + 'Upstream.\n';
+    writeFileSync(join(vault, 'law', 'data-privacy', 'ccpa.md'), CCPA + 'mine\n', 'utf8');
+    source.files['knowledge/practice-seed/standards/confidentiality.md'] = CONF + 'more\n';
+    const result = autoApplyLawUpdates(deps());
+    expect(result.applied).toEqual(['law/data-privacy/gdpr.md']);
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'ccpa.md'), 'utf8')).toBe(CCPA + 'mine\n');
+    expect(readFileSync(join(vault, 'practice', 'standards', 'confidentiality.md'), 'utf8')).toBe(CONF);
+    // Idempotent: a second start applies nothing.
+    expect(autoApplyLawUpdates(deps()).applied).toEqual([]);
+  });
+});

--- a/runtime/src/content/update.ts
+++ b/runtime/src/content/update.ts
@@ -1,0 +1,309 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  PLACEMENTS,
+  readContentState,
+  readReceivedSnapshot,
+  writeContentState,
+  writeReceivedSnapshot,
+  type ContentGroup,
+  type ContentState,
+} from '../setup/run';
+import { parseFrontmatter } from '../vault/overview';
+import { readVaultConfig, type VaultConfig } from '../vault/resolve-root';
+import { unifiedDiff } from './diff';
+import { bodyHash } from './hash';
+import { MANIFEST } from './manifest';
+import type { ContentSource } from './source';
+
+/**
+ * Content updates in the runtime (spec 2026-09-01 §6) — the rules of
+ * `skills/update/SKILL.md` steps 4–7, mechanically:
+ *
+ * LAW is plugin-managed by default. Each shipped law file is compared to the
+ * vault copy by frontmatter-stripped body hash, against BOTH the shipped
+ * hash and the hash the vault last received (`.counsel/content-state.json`).
+ * Vault == received and shipped differs → `update-available`. Vault differs
+ * from received (or `managed-by: user`, or `law_management: user`) →
+ * `user-modified`, reported and never written. Absent → `missing` (new law
+ * content, offered as an add). Vault law files nothing ships → `vault-only`,
+ * never touched.
+ *
+ * PRACTICE is user-owned and diverges by design. It is never diffed
+ * seed-vs-vault as "updated guidance" and never overwritten. An upstream
+ * change is detected against the RECEIVED seed (its hash, and the snapshot
+ * under `.counsel/received/` for the diff); the user merges by hand. A
+ * practice file the vault lacks is offered as an add.
+ */
+
+export type ItemStatus = 'current' | 'update-available' | 'user-modified' | 'vault-only' | 'missing' | 'upstream-changed';
+export type ItemReason = 'managed-by' | 'law-management' | 'edited' | 'no-baseline';
+
+export interface ContentItem {
+  /** Vault-relative path (`law/data-privacy/gdpr.md`). */
+  path: string;
+  /** The shipped path it comes from, or `null` for a vault-only file. */
+  shipped: string | null;
+  group: 'law' | 'practice';
+  /** The law area (first segment under `law/`) or the practice group. */
+  area: string;
+  status: ItemStatus;
+  reason?: ItemReason;
+  /** `upstream-changed` only: the unified diff to merge by hand. */
+  diff?: string;
+  /** What the diff was drawn against: the received snapshot, or — when a
+   * vault predates snapshots — the vault copy itself (then the diff may show
+   * the user's own edits too, and says so). */
+  baseline?: 'received' | 'vault';
+  /** True when `applyUpdates` may write this item. */
+  applicable: boolean;
+}
+
+export interface ContentStatus {
+  shippedVersion: string;
+  /** The version the vault last received (content-state), or `null` for a
+   * vault set up before the runtime kept one. */
+  vaultVersion: string | null;
+  receivedAt: string | null;
+  lawManagement: VaultConfig['lawManagement'];
+  autoApplyLawUpdates: boolean;
+  items: ContentItem[];
+  counts: Record<ItemStatus, number>;
+}
+
+export interface UpdateDeps {
+  vaultRoot: string;
+  content: ContentSource;
+  /** Default: the generated manifest's version. */
+  shippedVersion?: string;
+  now?: () => Date;
+}
+
+export class UpdateError extends Error {
+  constructor(
+    message: string,
+    public readonly paths: string[],
+  ) {
+    super(message);
+    this.name = 'UpdateError';
+  }
+}
+
+const NOT_LAW_CONTENT = new Set(['FRONTMATTER.md']);
+
+function readIfFile(path: string): string | null {
+  try {
+    if (!statSync(path).isFile()) return null;
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function isUserManaged(text: string): boolean {
+  const { frontmatter } = parseFrontmatter(text);
+  return (frontmatter['managed-by'] ?? frontmatter['managed_by'] ?? '').trim().toLowerCase() === 'user';
+}
+
+/** Every `*.md` under `dir`, vault-relative, sorted; empty when absent. */
+function walkMd(root: string, rel: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(join(root, rel)).sort();
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.')) continue;
+    const path = `${rel}/${name}`;
+    let isDir = false;
+    try {
+      isDir = statSync(join(root, path)).isDirectory();
+    } catch {
+      continue;
+    }
+    if (isDir) out.push(...walkMd(root, path));
+    else if (name.endsWith('.md')) out.push(path);
+  }
+  return out;
+}
+
+function groupOf(group: ContentGroup): 'law' | 'practice' {
+  return group === 'law' ? 'law' : 'practice';
+}
+
+function areaOf(vaultPath: string, group: ContentGroup): string {
+  if (group === 'law') return vaultPath.split('/')[1] ?? '';
+  return group;
+}
+
+export function contentStatus(deps: UpdateDeps): ContentStatus {
+  const cfg = readVaultConfig(deps.vaultRoot);
+  const state = readContentState(deps.vaultRoot);
+  const received = state?.files ?? {};
+  const items: ContentItem[] = [];
+  const shippedVaultPaths = new Set<string>();
+
+  for (const placement of PLACEMENTS) {
+    const group = groupOf(placement.group);
+    for (const shipped of deps.content.list(placement.from)) {
+      const rel = `${placement.to}/${shipped.slice(placement.from.length + 1)}`;
+      shippedVaultPaths.add(rel);
+      const area = areaOf(rel, placement.group);
+      const shippedText = deps.content.read(shipped);
+      const shippedHash = bodyHash(shippedText);
+      const vaultText = readIfFile(join(deps.vaultRoot, rel));
+      const lastHash = received[rel]?.hash;
+      const base = { path: rel, shipped, group, area };
+
+      if (group === 'law') {
+        if (cfg.lawManagement === 'user') {
+          items.push({ ...base, status: 'user-modified', reason: 'law-management', applicable: false });
+          continue;
+        }
+        if (vaultText === null) {
+          items.push({ ...base, status: 'missing', applicable: true });
+          continue;
+        }
+        if (isUserManaged(vaultText)) {
+          items.push({ ...base, status: 'user-modified', reason: 'managed-by', applicable: false });
+          continue;
+        }
+        const vaultHash = bodyHash(vaultText);
+        if (vaultHash === shippedHash) {
+          items.push({ ...base, status: 'current', applicable: false });
+        } else if (lastHash !== undefined && vaultHash === lastHash) {
+          items.push({ ...base, status: 'update-available', applicable: true });
+        } else {
+          items.push({ ...base, status: 'user-modified', reason: lastHash === undefined ? 'no-baseline' : 'edited', applicable: false });
+        }
+        continue;
+      }
+
+      // Practice.
+      if (vaultText === null) {
+        items.push({ ...base, status: 'missing', applicable: true });
+        continue;
+      }
+      if (lastHash === undefined) {
+        // No record of what was received: the only honest comparison is the
+        // vault copy, framed as such.
+        if (bodyHash(vaultText) === shippedHash) items.push({ ...base, status: 'current', applicable: false });
+        else {
+          items.push({
+            ...base,
+            status: 'upstream-changed',
+            baseline: 'vault',
+            diff: unifiedDiff(vaultText, shippedText, { from: `${rel} (your copy)`, to: `${shipped} (shipped)` }),
+            applicable: false,
+          });
+        }
+        continue;
+      }
+      if (shippedHash === lastHash) {
+        items.push({ ...base, status: 'current', applicable: false });
+        continue;
+      }
+      const snapshot = readReceivedSnapshot(deps.vaultRoot, rel);
+      items.push({
+        ...base,
+        status: 'upstream-changed',
+        baseline: snapshot === null ? 'vault' : 'received',
+        diff: unifiedDiff(snapshot ?? vaultText, shippedText, {
+          from: snapshot === null ? `${rel} (your copy)` : `${rel} (as received)`,
+          to: `${shipped} (shipped)`,
+        }),
+        applicable: false,
+      });
+    }
+  }
+
+  // Vault-only law: the user's own areas and files. Never touched.
+  if (cfg.lawManagement !== 'user') {
+    for (const rel of walkMd(deps.vaultRoot, 'law')) {
+      const name = rel.slice(rel.lastIndexOf('/') + 1);
+      if (NOT_LAW_CONTENT.has(name) || shippedVaultPaths.has(rel)) continue;
+      items.push({ path: rel, shipped: null, group: 'law', area: areaOf(rel, 'law'), status: 'vault-only', applicable: false });
+    }
+  }
+
+  items.sort((a, b) => a.path.localeCompare(b.path));
+  const counts: Record<ItemStatus, number> = { current: 0, 'update-available': 0, 'user-modified': 0, 'vault-only': 0, missing: 0, 'upstream-changed': 0 };
+  for (const item of items) counts[item.status] += 1;
+
+  return {
+    shippedVersion: deps.shippedVersion ?? MANIFEST.version,
+    vaultVersion: state?.version ?? null,
+    receivedAt: state?.receivedAt ?? null,
+    lawManagement: cfg.lawManagement,
+    autoApplyLawUpdates: cfg.autoApplyLawUpdates,
+    items,
+    counts,
+  };
+}
+
+export interface ApplyResult {
+  applied: string[];
+  /** Paths that were applicable when asked but had nothing to write (a
+   * second click, a race with auto-apply). */
+  skipped: string[];
+}
+
+/**
+ * Writes the chosen items — and only items the rules allow. One refused
+ * path refuses the whole call before anything is written, so a client that
+ * asked for a user-modified file learns it rather than getting a partial
+ * apply it did not ask for.
+ */
+export function applyUpdates(deps: UpdateDeps, paths: string[]): ApplyResult {
+  const status = contentStatus(deps);
+  const byPath = new Map(status.items.map(item => [item.path, item]));
+  const refused = paths.filter(p => !(byPath.get(p)?.applicable ?? false));
+  if (refused.length > 0) {
+    throw new UpdateError(`not applicable: ${refused.join(', ')} — only law updates and missing files can be applied; user-modified and practice files are yours`, refused);
+  }
+  const now = deps.now ?? (() => new Date());
+  const state: ContentState = readContentState(deps.vaultRoot) ?? { version: status.shippedVersion, receivedAt: now().toISOString(), files: {} };
+  const applied: string[] = [];
+  const skipped: string[] = [];
+  for (const path of [...new Set(paths)]) {
+    const item = byPath.get(path)!;
+    if (item.shipped === null) {
+      skipped.push(path);
+      continue;
+    }
+    const text = deps.content.read(item.shipped);
+    const target = join(deps.vaultRoot, path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, text, 'utf8');
+    state.files[path] = { hash: bodyHash(text), from: item.shipped };
+    if (item.group === 'practice') writeReceivedSnapshot(deps.vaultRoot, path, text);
+    applied.push(path);
+  }
+  state.version = status.shippedVersion;
+  state.receivedAt = now().toISOString();
+  writeContentState(deps.vaultRoot, state);
+  return { applied, skipped };
+}
+
+/**
+ * `auto_apply_law_updates: true`: every law `update-available` item, at
+ * serve start, with no one asked. Returns what it wrote (empty when the
+ * flag is off or nothing was pending). User-modified files are never in
+ * the applicable set, so they are never touched here either.
+ */
+export function autoApplyLawUpdates(deps: UpdateDeps): ApplyResult {
+  const status = contentStatus(deps);
+  if (!status.autoApplyLawUpdates) return { applied: [], skipped: [] };
+  const pending = status.items.filter(item => item.group === 'law' && item.status === 'update-available').map(item => item.path);
+  if (pending.length === 0) return { applied: [], skipped: [] };
+  return applyUpdates(deps, pending);
+}
+
+/** A vault that predates the runtime's content state has no baseline; the
+ * status says so per item. This helper answers the one question a caller
+ * asks before offering updates at all. */
+export function hasContentState(vaultRoot: string): boolean {
+  return existsSync(join(vaultRoot, '.counsel', 'content-state.json'));
+}

--- a/runtime/src/content/update.ts
+++ b/runtime/src/content/update.ts
@@ -307,3 +307,30 @@ export function autoApplyLawUpdates(deps: UpdateDeps): ApplyResult {
 export function hasContentState(vaultRoot: string): boolean {
   return existsSync(join(vaultRoot, '.counsel', 'content-state.json'));
 }
+
+const STATUS_WORDS: Record<ItemStatus, string> = {
+  current: 'current',
+  'update-available': 'update available',
+  'user-modified': 'yours — left alone',
+  'vault-only': 'yours — not shipped',
+  missing: 'new — can be added',
+  'upstream-changed': 'changed upstream — merge by hand',
+};
+
+/** The status as the CLI prints it: the ledger, then what applies. */
+export function renderContentStatus(status: ContentStatus): string {
+  const lines = [
+    `Shipped ${status.shippedVersion} · vault received ${status.vaultVersion ?? 'unknown (no content state; a vault set up before the runtime kept one)'}`,
+    status.lawManagement === 'user' ? 'law_management: user — law is yours; the runtime never syncs it' : '',
+    '',
+  ].filter(l => l !== undefined);
+  const interesting = status.items.filter(i => i.status !== 'current');
+  if (interesting.length === 0) lines.push('Everything is current.');
+  for (const item of interesting) {
+    lines.push(`${item.path.padEnd(52)} ${STATUS_WORDS[item.status]}${item.reason !== undefined ? ` (${item.reason})` : ''}`);
+    if (item.diff !== undefined) lines.push(...item.diff.split('\n').map(l => `    ${l}`));
+  }
+  const applicable = status.items.filter(i => i.applicable).length;
+  lines.push('', `${status.counts.current} current · ${status.counts['update-available']} updates · ${status.counts.missing} new · ${status.counts['user-modified']} yours · ${status.counts['upstream-changed']} to merge by hand · ${applicable} applicable`);
+  return lines.filter(l => l !== '' || true).join('\n') + '\n';
+}

--- a/runtime/src/doctor/checks.test.ts
+++ b/runtime/src/doctor/checks.test.ts
@@ -1,0 +1,219 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { GitRunner } from '../setup/run';
+import type { VaultConfig } from '../vault/resolve-root';
+import {
+  acceptBand,
+  addMonths,
+  checkConsistency,
+  checkGit,
+  checkLawCurrency,
+  checkLawImpact,
+  checkRootConfig,
+  checkStructure,
+  divergences,
+  libraryBlocks,
+  unitNumbers,
+  type DoctorContext,
+} from './checks';
+import { renderReport, runDoctor, verdictOf } from './index';
+import { parseLawPolicy } from './policy';
+
+const POLICY = parseLawPolicy(JSON.stringify({ review_cadence_months: { default: 12, 'data-privacy': 6, employment: 6, corporate: 18 } }));
+const NOW = new Date('2026-09-01T12:00:00Z');
+const CFG: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
+
+let vault: string;
+
+function writeTo(root: string, rel: string, text: string): void {
+  const full = join(root, rel);
+  mkdirSync(join(full, '..'), { recursive: true });
+  writeFileSync(full, text, 'utf8');
+}
+
+function write(rel: string, text: string): void {
+  writeTo(vault, rel, text);
+}
+
+function law(area: string, name: string, lastReviewed: string | null, extra = ''): void {
+  write(`law/${area}/${name}.md`, `---\ncounsel-os-type: law-area\n${lastReviewed === null ? '' : `last-reviewed: "${lastReviewed}"\n`}${extra}---\n# ${name}\n`);
+}
+
+function ctx(over: Partial<DoctorContext> = {}): DoctorContext {
+  return { vaultRoot: vault, cfg: CFG, policy: POLICY, now: NOW, git: null, ...over };
+}
+
+/** A complete, healthy vault. */
+function seedHealthy(): void {
+  write('config.md', `counsel-os-config: true\nlegal_root: ${vault}\n`);
+  law('data-privacy', 'gdpr', '2026-06-11');
+  law('employment', 'flsa', '2026-06-11');
+  write('practice/standards/index.md', '# index\n');
+  write('practice/standards/confidentiality.md', '---\ncounsel-os-type: practice\n---\n# Confidentiality — Position\n\n## Our Position\n**Our standard:** 3 years.\n**We\'ll accept:** 2 years to 5 years.\n\n## Market Standard\nx\n');
+  write('practice/library/ip-and-confidentiality.md', '---\ncounsel-os-type: practice\n---\n# Library\n\n## Term\n\n### Standard\n> three (3) years\n\n### Minimum Acceptable\n> two (2) years\n');
+  write('practice/methods/m.md', '# m\n');
+  write('practice/reference/_index.md', '# r\n');
+  write('practice/profile.md', '# profile\n');
+  write('memory/patterns.md', '# p\n');
+  mkdirSync(join(vault, 'matters'), { recursive: true });
+  mkdirSync(join(vault, 'entities'), { recursive: true });
+}
+
+beforeEach(() => {
+  vault = mkdtempSync(join(tmpdir(), 'doctor-'));
+});
+
+describe('root-config', () => {
+  test('marked config pointing at itself is ok', () => {
+    seedHealthy();
+    expect(checkRootConfig(ctx()).severity).toBe('ok');
+  });
+  test('no config is an error; a copied config is a warning', () => {
+    expect(checkRootConfig(ctx()).severity).toBe('error');
+    write('config.md', 'counsel-os-config: true\nlegal_root: /somewhere/else\n');
+    const f = checkRootConfig(ctx());
+    expect(f.severity).toBe('warn');
+    expect(f.message).toContain('/somewhere/else');
+  });
+});
+
+describe('structure', () => {
+  test('a complete vault is ok with counts, index.md excluded, empty matters/entities said plainly', () => {
+    seedHealthy();
+    const f = checkStructure(ctx());
+    expect(f.severity).toBe('ok');
+    expect(f.message).toContain('standards 1');
+    expect(f.message).toContain('matters empty');
+    expect(f.message).toContain('law 2');
+  });
+  test('missing law is an error; missing memory is a warning; overrides are honoured', () => {
+    seedHealthy();
+    const noLaw = ctx({ cfg: { ...CFG, mattersPath: 'deals' } });
+    write('deals/x.md', '# x\n');
+    const f1 = checkStructure(noLaw);
+    expect(f1.severity).toBe('ok');
+    expect(f1.message).toContain('matters@deals 1');
+    const bare = mkdtempSync(join(tmpdir(), 'doctor-bare-'));
+    writeTo(bare, 'practice/standards/a.md', '# a\n');
+    const f2 = checkStructure({ ...ctx(), vaultRoot: bare });
+    expect(f2.severity).toBe('error');
+    expect(f2.message).toContain('law');
+  });
+});
+
+describe('law-currency', () => {
+  test('addMonths clamps to the month length like the Python', () => {
+    expect(addMonths(new Date(Date.UTC(2026, 0, 31)), 1).toISOString().slice(0, 10)).toBe('2026-02-28');
+    expect(addMonths(new Date(Date.UTC(2026, 5, 11)), 6).toISOString().slice(0, 10)).toBe('2026-12-11');
+    expect(addMonths(new Date(Date.UTC(2026, 10, 30)), 3).toISOString().slice(0, 10)).toBe('2027-02-28');
+  });
+  test('current when within the area cadence; stale and never-attested split by ownership', () => {
+    seedHealthy();
+    expect(checkLawCurrency(ctx()).severity).toBe('ok');
+    law('data-privacy', 'ccpa', '2026-02-01'); // 6-month cadence → stale by Sep 1
+    law('corporate', 'delaware', '2025-01-01', 'managed-by: user\n'); // user-owned, 18 months → stale
+    law('my-area', 'notes', null); // custom area → user-owned, never attested
+    const f = checkLawCurrency(ctx());
+    expect(f.severity).toBe('warn');
+    expect(f.message).toContain('2 stale');
+    expect(f.message).toContain('1 never attested');
+    expect(f.detail).toContain('2 user-owned');
+    expect(f.detail).toContain('1 plugin-managed');
+    expect(f.paths).toContain('law/data-privacy/ccpa.md');
+    expect(f.fix).toContain('update-content');
+  });
+  test('law_management: user makes every file user-owned', () => {
+    seedHealthy();
+    law('data-privacy', 'ccpa', '2026-02-01');
+    const f = checkLawCurrency(ctx({ cfg: { ...CFG, lawManagement: 'user' } }));
+    expect(f.detail).toContain('1 user-owned');
+    expect(f.fix).toBe('/counsel-os:law-refresh');
+  });
+});
+
+describe('git', () => {
+  function fakeGit(answers: Record<string, { ok: boolean; out: string }>): GitRunner {
+    return args => answers[args.join(' ')] ?? { ok: false, out: '' };
+  }
+  test('no git binary, not a repo, no remote, too many uncommitted, healthy', () => {
+    seedHealthy();
+    expect(checkGit(ctx({ git: null })).message).toContain('not installed');
+    expect(checkGit(ctx({ git: fakeGit({}) })).message).toContain('not a git repository');
+    const base = { 'rev-parse --is-inside-work-tree': { ok: true, out: 'true\n' }, 'log -1 --format=%ci %h': { ok: true, out: '2026-08-30 abc123\n' } };
+    const noRemote = checkGit(ctx({ git: fakeGit({ ...base, 'status --porcelain': { ok: true, out: '' }, remote: { ok: true, out: '' } }) }));
+    expect(noRemote.severity).toBe('warn');
+    expect(noRemote.detail).toContain('PRIVATE');
+    const dirty = checkGit(ctx({ git: fakeGit({ ...base, 'status --porcelain': { ok: true, out: Array(25).fill(' M x').join('\n') }, remote: { ok: true, out: 'origin\n' } }) }));
+    expect(dirty.severity).toBe('warn');
+    expect(dirty.message).toContain('25 uncommitted');
+    const fine = checkGit(ctx({ git: fakeGit({ ...base, 'status --porcelain': { ok: true, out: ' M a\n' }, remote: { ok: true, out: 'origin\n' } }) }));
+    expect(fine.severity).toBe('ok');
+    expect(fine.message).toBe('repo · remote origin · 1 uncommitted · last commit 2026-08-30 abc123');
+  });
+});
+
+describe('consistency', () => {
+  test('numbers with units are read from the accept band and the Minimum Acceptable blocks', () => {
+    const standard = '## Our Position\n**Our standard:** Breach notification within 72 hours.\n**We\'ll accept:** 72-96 hours, 14 days notice.\n**We won\'t accept:** 200 hours.\n\n## Market\n1 hour.\n';
+    expect(acceptBand(standard)).not.toContain('200 hours');
+    expect([...unitNumbers(acceptBand(standard)).entries()]).toEqual([
+      ['hours', [72, 96]],
+      ['days', [14]],
+    ]);
+    const library = '## Breach\n\n### Standard\n> seventy-two (72) hours\n\n### Minimum Acceptable\n> one hundred twenty (120) hours\n\n## Notice\n\n### Minimum Acceptable\n> ten (10) days\n';
+    expect(unitNumbers(libraryBlocks(library, 'Minimum Acceptable')).get('hours')).toEqual([120]);
+    const found = divergences('data-protection', standard, library, 's', 'l');
+    expect(found.map(d => [d.unit, d.library])).toEqual([
+      ['hours', 120],
+      ['days', 10],
+    ]);
+  });
+  test('a matching pair is ok; a divergent minimum is a warning with both numbers', () => {
+    seedHealthy();
+    const ok = checkConsistency(ctx());
+    expect(ok.severity).toBe('ok');
+    expect(ok.message).toContain('1 standard/library pairs');
+    write('practice/library/ip-and-confidentiality.md', '# Library\n\n## Term\n\n### Standard\n> three (3) years\n\n### Minimum Acceptable\n> one (1) year\n');
+    const warn = checkConsistency(ctx());
+    expect(warn.severity).toBe('warn');
+    expect(warn.detail).toContain('confidentiality: standard accepts 2–5 years, library Minimum Acceptable says 1 years');
+    expect(warn.detail).toContain('law floors are not compared mechanically');
+  });
+});
+
+describe('law-impact', () => {
+  test('an open matter updated before its law area was reviewed is behind; closed and current matters are not', () => {
+    seedHealthy();
+    law('data-privacy', 'gdpr', '2026-08-15');
+    write('matters/2026-06-acme.md', '---\ncounsel-os-type: matter\nstage: working\nupdated: 2026-07-01\nlaw_areas: [data-privacy]\n---\n# Acme — DPA\n');
+    write('matters/2026-05-beta.md', '---\nstage: working\nupdated: 2026-08-20\n---\n# Beta\n\n- **Law areas:** data-privacy, employment\n');
+    write('matters/2026-04-closed.md', '---\nstage: closed\nupdated: 2026-01-01\nlaw_areas: [data-privacy]\n---\n# Old\n');
+    write('matters/folder/matter.md', '---\nstage: intake\nupdated: 2026-07-01\n---\n# Folder\n\n- **Law areas:** law/data-privacy\n');
+    const f = checkLawImpact(ctx());
+    expect(f.severity).toBe('warn');
+    expect(f.paths).toEqual(['matters/2026-06-acme.md', 'matters/folder/matter.md']);
+    expect(f.detail).toContain('Acme — DPA (updated 2026-07-01) — law/data-privacy refreshed 2026-08-15');
+  });
+  test('no open matters, or none behind, is ok', () => {
+    seedHealthy();
+    expect(checkLawImpact(ctx()).message).toBe('no open matters');
+    write('matters/x.md', '---\nstage: working\nupdated: 2026-08-30\nlaw_areas: [data-privacy]\n---\n# X\n');
+    expect(checkLawImpact(ctx()).severity).toBe('ok');
+  });
+});
+
+describe('runDoctor + verdict', () => {
+  test('a healthy vault is healthy; one warning names the check; an error is broken', () => {
+    seedHealthy();
+    const report = runDoctor({ vaultRoot: vault, pluginRoot: '/nowhere', policy: POLICY, git: null, now: () => NOW });
+    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact']);
+    // git: null is the one warning on this seeded vault.
+    expect(report.verdict).toBe('warnings');
+    expect(report.summary).toContain('git');
+    expect(renderReport(report)).toContain('Verdict:');
+    expect(verdictOf([{ check: 'x', severity: 'error', message: 'no config.md', fix: 'init' }]).summary).toBe('broken: no config.md — init');
+    expect(verdictOf([{ check: 'x', severity: 'ok', message: 'fine' }]).verdict).toBe('healthy');
+  });
+});

--- a/runtime/src/doctor/checks.ts
+++ b/runtime/src/doctor/checks.ts
@@ -283,16 +283,17 @@ const LIBRARY_FOR: Record<string, string> = {
   'compliance-certifications': 'compliance-regulatory',
 };
 
-const UNIT_RE = /(\d+(?:\.\d+)?)\)?\s*(hours?|hrs?|days?|months?|years?|%|percent|x\b|×)/gi;
+/** Time units only. Percentages and multipliers name different things in
+ * the same file (an uptime, a credit, a cap), and comparing them across a
+ * standard and a library produced divergences that were not. */
+const UNIT_RE = /(\d+(?:\.\d+)?)\)?\s*(hours?|hrs?|days?|months?|years?)\b/gi;
 
 function normalizeUnit(raw: string): string {
   const u = raw.toLowerCase();
   if (u.startsWith('hour') || u.startsWith('hr')) return 'hours';
   if (u.startsWith('day')) return 'days';
   if (u.startsWith('month')) return 'months';
-  if (u.startsWith('year')) return 'years';
-  if (u === '%' || u === 'percent') return '%';
-  return 'x';
+  return 'years';
 }
 
 /** `{ unit → numbers }` mentioned in `text`. */

--- a/runtime/src/doctor/checks.ts
+++ b/runtime/src/doctor/checks.ts
@@ -1,0 +1,495 @@
+import { existsSync, readdirSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import type { GitRunner } from '../setup/run';
+import { parseFrontmatter, splitFrontmatterBlock } from '../vault/overview';
+import type { VaultConfig } from '../vault/resolve-root';
+import { cadenceFor, type LawPolicy } from './policy';
+
+/**
+ * The vault checks of `skills/doctor/SKILL.md` (steps 1, 2, 4B, 8, 10, 11),
+ * as pure functions over a vault root (spec 2026-09-01 §7). Read-only by
+ * construction: nothing here takes a writer. The environment checks the
+ * skill also runs (pandoc, python, the browse binary, qmd) are not ported —
+ * the runtime is the environment now.
+ */
+
+export type Severity = 'ok' | 'warn' | 'error';
+
+export interface Finding {
+  check: string;
+  severity: Severity;
+  /** One line. */
+  message: string;
+  /** More lines, when the message needs them. */
+  detail?: string;
+  paths?: string[];
+  /** The one-line fix the skill would print. */
+  fix?: string;
+}
+
+export interface DoctorContext {
+  vaultRoot: string;
+  cfg: VaultConfig;
+  policy: LawPolicy;
+  now: Date;
+  /** `null` when git is not on PATH. */
+  git: GitRunner | null;
+}
+
+function realOrLexical(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return resolve(p);
+  }
+}
+
+function readText(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+function isDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Every `*.md` under `dir` (recursive), vault-relative, sorted. */
+function walkMd(root: string, rel: string): string[] {
+  const out: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(join(root, rel)).sort();
+  } catch {
+    return out;
+  }
+  for (const name of entries) {
+    if (name.startsWith('.')) continue;
+    const path = `${rel}/${name}`;
+    if (isDir(join(root, path))) out.push(...walkMd(root, path));
+    else if (name.endsWith('.md')) out.push(path);
+  }
+  return out;
+}
+
+// ── 1. Legal root and config ────────────────────────────────────────────
+
+export function checkRootConfig(ctx: DoctorContext): Finding {
+  const check = 'root-config';
+  const text = readText(join(ctx.vaultRoot, 'config.md'));
+  if (text === null) {
+    return { check, severity: 'error', message: 'no config.md — this folder is not a Counsel OS root', fix: 'bun runtime/src/cli.ts init --vault <this folder>' };
+  }
+  const lines = text.split('\n');
+  const marked = lines.some(l => l.trim() === 'counsel-os-config: true');
+  const rootLine = lines.find(l => l.startsWith('legal_root:'));
+  if (!marked || rootLine === undefined) {
+    return { check, severity: 'error', message: 'config.md is not a marked Counsel OS config (needs `counsel-os-config: true` and `legal_root:`)', fix: 'bun runtime/src/cli.ts init --vault <this folder>' };
+  }
+  const declared = rootLine.slice('legal_root:'.length).trim().replace(/^["']|["']$/g, '');
+  if (realOrLexical(declared) !== realOrLexical(ctx.vaultRoot)) {
+    return {
+      check,
+      severity: 'warn',
+      message: `config.md says legal_root: ${declared}, but this vault is ${ctx.vaultRoot} (a copied config)`,
+      fix: 'edit config.md so legal_root matches its own directory',
+    };
+  }
+  return { check, severity: 'ok', message: `${ctx.vaultRoot} — marked config` };
+}
+
+// ── 2. Vault structure ──────────────────────────────────────────────────
+
+function countMd(root: string, rel: string): number {
+  return walkMd(root, rel).filter(p => !p.endsWith('/index.md')).length;
+}
+
+export function checkStructure(ctx: DoctorContext): Finding {
+  const check = 'structure';
+  const dirs: Array<{ rel: string; label: string; core: boolean; emptyOk: boolean }> = [
+    { rel: 'law', label: 'law', core: true, emptyOk: false },
+    { rel: 'practice/standards', label: 'standards', core: true, emptyOk: false },
+    { rel: 'practice/methods', label: 'methods', core: false, emptyOk: false },
+    { rel: 'practice/library', label: 'library', core: false, emptyOk: false },
+    { rel: 'practice/reference', label: 'reference', core: false, emptyOk: true },
+    { rel: ctx.cfg.mattersPath, label: ctx.cfg.mattersPath === 'matters' ? 'matters' : `matters@${ctx.cfg.mattersPath}`, core: false, emptyOk: true },
+    { rel: 'memory', label: 'memory', core: false, emptyOk: true },
+    { rel: ctx.cfg.entitiesPath, label: ctx.cfg.entitiesPath === 'entities' ? 'entities' : `entities@${ctx.cfg.entitiesPath}`, core: false, emptyOk: true },
+  ];
+  const parts: string[] = [];
+  const missing: string[] = [];
+  const emptyCore: string[] = [];
+  const paths: string[] = [];
+  for (const d of dirs) {
+    if (!isDir(join(ctx.vaultRoot, d.rel))) {
+      missing.push(d.rel);
+      paths.push(d.rel);
+      parts.push(`${d.label} MISSING`);
+      continue;
+    }
+    const n = countMd(ctx.vaultRoot, d.rel);
+    if (n === 0 && d.core) emptyCore.push(d.rel);
+    parts.push(n === 0 && d.emptyOk ? `${d.label} empty` : `${d.label} ${n}`);
+  }
+  const profile = existsSync(join(ctx.vaultRoot, 'practice', 'profile.md'));
+  if (!profile) {
+    missing.push('practice/profile.md');
+    paths.push('practice/profile.md');
+  }
+  const detail = parts.join(' · ') + (profile ? '' : ' · profile.md MISSING');
+  const coreMissing = missing.filter(m => m === 'law' || m === 'practice/standards');
+  if (coreMissing.length > 0 || emptyCore.length > 0) {
+    return { check, severity: 'error', message: `core content missing: ${[...coreMissing, ...emptyCore].join(', ')}`, detail, paths, fix: 'bun runtime/src/cli.ts init --vault <this folder> (re-seeding is safe; it never overwrites)' };
+  }
+  if (missing.length > 0) {
+    return { check, severity: 'warn', message: `missing: ${missing.join(', ')}`, detail, paths, fix: 'bun runtime/src/cli.ts init --vault <this folder>, or set matters_path / entities_path in config.md if they live elsewhere' };
+  }
+  return { check, severity: 'ok', message: detail };
+}
+
+// ── 4B. Law currency ────────────────────────────────────────────────────
+
+/** The Python's `add_months`: the same day `months` later, clamped to the
+ * target month's length. */
+export function addMonths(value: Date, months: number): Date {
+  const y = value.getUTCFullYear();
+  const m0 = value.getUTCMonth() + months;
+  const year = y + Math.floor(m0 / 12);
+  const month = ((m0 % 12) + 12) % 12;
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+  return new Date(Date.UTC(year, month, Math.min(value.getUTCDate(), lastDay)));
+}
+
+export function parseIsoDate(raw: string | undefined): Date | null {
+  if (raw === undefined) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(raw.trim().replace(/^["']|["']$/g, ''));
+  if (m === null) return null;
+  const d = new Date(Date.UTC(Number(m[1]), Number(m[2]) - 1, Number(m[3])));
+  return Number.isNaN(d.getTime()) ? null : d;
+}
+
+function utcDay(d: Date): Date {
+  return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()));
+}
+
+interface LawFile {
+  path: string;
+  area: string;
+  lastReviewed: Date | null;
+  userOwned: boolean;
+}
+
+function lawFiles(ctx: DoctorContext): LawFile[] {
+  const out: LawFile[] = [];
+  for (const path of walkMd(ctx.vaultRoot, 'law')) {
+    if (path.endsWith('/FRONTMATTER.md')) continue;
+    const text = readText(join(ctx.vaultRoot, path));
+    if (text === null) continue;
+    const { frontmatter } = parseFrontmatter(text);
+    const segments = path.split('/');
+    // `law/<area>/file.md` or a consolidated `law/<area>.md`.
+    const area = segments.length >= 3 ? segments[1]! : segments[1]!.replace(/\.md$/, '');
+    const managedByUser = (frontmatter['managed-by'] ?? '').trim().toLowerCase() === 'user';
+    out.push({
+      path,
+      area,
+      lastReviewed: parseIsoDate(frontmatter['last-reviewed']),
+      userOwned: managedByUser || ctx.cfg.lawManagement === 'user' || !ctx.policy.areas.has(area),
+    });
+  }
+  return out;
+}
+
+export function checkLawCurrency(ctx: DoctorContext): Finding {
+  const check = 'law-currency';
+  const files = lawFiles(ctx);
+  if (files.length === 0) return { check, severity: 'warn', message: 'no law content in the vault', fix: 'bun runtime/src/cli.ts init --vault <this folder>' };
+  const today = utcDay(ctx.now);
+  const areas = new Set(files.map(f => f.area));
+  let current = 0;
+  const staleUser: string[] = [];
+  const stalePlugin: string[] = [];
+  const neverUser: string[] = [];
+  const neverPlugin: string[] = [];
+  for (const f of files) {
+    if (f.lastReviewed === null) {
+      (f.userOwned ? neverUser : neverPlugin).push(f.path);
+      continue;
+    }
+    const staleAfter = addMonths(f.lastReviewed, cadenceFor(ctx.policy, f.area));
+    if (today.getTime() > staleAfter.getTime()) (f.userOwned ? staleUser : stalePlugin).push(f.path);
+    else current++;
+  }
+  const stale = staleUser.length + stalePlugin.length;
+  const never = neverUser.length + neverPlugin.length;
+  const summary = `${areas.size} areas · ${current} attested current · ${stale} stale · ${never} never attested`;
+  if (stale === 0 && never === 0) return { check, severity: 'ok', message: summary };
+  const bits: string[] = [];
+  if (staleUser.length + neverUser.length > 0) bits.push(`${staleUser.length + neverUser.length} user-owned — refresh them (the plugin's /counsel-os:law-refresh)`);
+  if (stalePlugin.length + neverPlugin.length > 0) bits.push(`${stalePlugin.length + neverPlugin.length} plugin-managed — refreshed upstream; apply content updates`);
+  return {
+    check,
+    severity: 'warn',
+    message: summary,
+    detail: bits.join('; '),
+    paths: [...staleUser, ...stalePlugin, ...neverUser, ...neverPlugin],
+    fix: stalePlugin.length + neverPlugin.length > 0 ? 'bun runtime/src/cli.ts update-content' : '/counsel-os:law-refresh',
+  };
+}
+
+// ── 8. Vault git ────────────────────────────────────────────────────────
+
+export function checkGit(ctx: DoctorContext): Finding {
+  const check = 'git';
+  if (ctx.git === null) return { check, severity: 'warn', message: 'git is not installed — the vault has no version control', fix: 'install git, then: git -C <vault> init' };
+  const inside = ctx.git(['rev-parse', '--is-inside-work-tree'], ctx.vaultRoot);
+  if (!inside.ok || inside.out.trim() !== 'true') {
+    return { check, severity: 'warn', message: 'not a git repository — no history of your vault', fix: `git -C ${ctx.vaultRoot} init` };
+  }
+  const status = ctx.git(['status', '--porcelain'], ctx.vaultRoot);
+  const uncommitted = status.ok ? status.out.split('\n').filter(l => l.trim() !== '').length : 0;
+  const remotes = ctx.git(['remote'], ctx.vaultRoot);
+  const remote = remotes.ok ? remotes.out.split('\n').map(l => l.trim()).filter(l => l !== '')[0] : undefined;
+  const last = ctx.git(['log', '-1', '--format=%ci %h'], ctx.vaultRoot);
+  const lastCommit = last.ok ? last.out.trim() : '';
+  const detail = `repo · ${remote === undefined ? 'no remote' : `remote ${remote}`} · ${uncommitted} uncommitted${lastCommit === '' ? '' : ` · last commit ${lastCommit}`}`;
+  if (remote === undefined) {
+    return { check, severity: 'warn', message: detail, detail: 'no remote — local-only history; a legal vault belongs in a PRIVATE repository', fix: 'gh repo create <name> --private && git -C <vault> remote add origin <url>' };
+  }
+  if (uncommitted >= 20) {
+    return { check, severity: 'warn', message: detail, fix: `git -C <vault> add law/ practice/ ${ctx.cfg.mattersPath}/ memory/ ${ctx.cfg.entitiesPath}/ && git -C <vault> commit -m "Vault checkpoint"` };
+  }
+  return { check, severity: 'ok', message: detail };
+}
+
+// ── 10. Vault consistency (standards ↔ library) ─────────────────────────
+
+/** Standards whose library file is not the same stem. */
+const LIBRARY_FOR: Record<string, string> = {
+  'ai-data-use': 'ai-and-data-use',
+  'assignment-change-of-control': 'assignment-and-change-of-control',
+  'termination-renewal': 'termination-and-renewal',
+  'service-levels': 'sla-and-performance',
+  indemnification: 'liability-and-indemnification',
+  'limitation-of-liability': 'liability-and-indemnification',
+  'ip-ownership': 'ip-and-confidentiality',
+  confidentiality: 'ip-and-confidentiality',
+  'compliance-certifications': 'compliance-regulatory',
+};
+
+const UNIT_RE = /(\d+(?:\.\d+)?)\)?\s*(hours?|hrs?|days?|months?|years?|%|percent|x\b|×)/gi;
+
+function normalizeUnit(raw: string): string {
+  const u = raw.toLowerCase();
+  if (u.startsWith('hour') || u.startsWith('hr')) return 'hours';
+  if (u.startsWith('day')) return 'days';
+  if (u.startsWith('month')) return 'months';
+  if (u.startsWith('year')) return 'years';
+  if (u === '%' || u === 'percent') return '%';
+  return 'x';
+}
+
+/** `{ unit → numbers }` mentioned in `text`. */
+export function unitNumbers(text: string): Map<string, number[]> {
+  const out = new Map<string, number[]>();
+  for (const m of text.matchAll(UNIT_RE)) {
+    const unit = normalizeUnit(m[2]!);
+    const list = out.get(unit) ?? [];
+    list.push(Number(m[1]));
+    out.set(unit, list);
+  }
+  return out;
+}
+
+/** The `## Our Position` block's `Our standard` and `We'll accept` lines. */
+export function acceptBand(standard: string): string {
+  const block = sectionOf(standard, /^## Our Position\s*$/m, /^## /m);
+  return block
+    .split('\n')
+    .filter(l => /^\*\*(Our standard|We'll accept)/i.test(l.trim()))
+    .join('\n');
+}
+
+/** The text of every `### <heading>` block named `heading` under any `##`. */
+export function libraryBlocks(library: string, heading: string): string {
+  const out: string[] = [];
+  const lines = library.split('\n');
+  let inBlock = false;
+  for (const line of lines) {
+    if (/^###\s/.test(line)) {
+      inBlock = line.replace(/^###\s+/, '').trim().toLowerCase().startsWith(heading.toLowerCase());
+      continue;
+    }
+    if (/^##\s/.test(line)) {
+      inBlock = false;
+      continue;
+    }
+    if (inBlock) out.push(line);
+  }
+  return out.join('\n');
+}
+
+function sectionOf(text: string, start: RegExp, end: RegExp): string {
+  const s = start.exec(text);
+  if (s === null) return '';
+  const rest = text.slice(s.index + s[0].length);
+  const e = end.exec(rest);
+  return e === null ? rest : rest.slice(0, e.index);
+}
+
+export interface Divergence {
+  topic: string;
+  unit: string;
+  standardMin: number;
+  standardMax: number;
+  library: number;
+  standardPath: string;
+  libraryPath: string;
+}
+
+/** A library Minimum Acceptable number outside everything the standard's
+ * accept band names for the same unit — a POSSIBLE divergence, reported
+ * with both numbers for a person to judge (the skill's Step 10 is
+ * judgment; this is the mechanical part of it). */
+export function divergences(topic: string, standard: string, library: string, standardPath: string, libraryPath: string): Divergence[] {
+  const band = unitNumbers(acceptBand(standard));
+  const minimum = unitNumbers(libraryBlocks(library, 'Minimum Acceptable'));
+  const out: Divergence[] = [];
+  for (const [unit, libNumbers] of minimum) {
+    const accepted = band.get(unit);
+    if (accepted === undefined || accepted.length === 0) continue;
+    const lo = Math.min(...accepted);
+    const hi = Math.max(...accepted);
+    for (const n of libNumbers) {
+      if (n < lo || n > hi) out.push({ topic, unit, standardMin: lo, standardMax: hi, library: n, standardPath, libraryPath });
+    }
+  }
+  return out;
+}
+
+export function checkConsistency(ctx: DoctorContext): Finding {
+  const check = 'consistency';
+  const standardsDir = join(ctx.vaultRoot, 'practice', 'standards');
+  const libraryDir = join(ctx.vaultRoot, 'practice', 'library');
+  if (!isDir(standardsDir) || !isDir(libraryDir)) return { check, severity: 'ok', message: 'no standards/library pair to compare' };
+  let pairs = 0;
+  const found: Divergence[] = [];
+  for (const name of readdirSync(standardsDir).sort()) {
+    if (!name.endsWith('.md') || name === 'index.md') continue;
+    const topic = name.replace(/\.md$/, '');
+    const libName = `${LIBRARY_FOR[topic] ?? topic}.md`;
+    const standard = readText(join(standardsDir, name));
+    const library = readText(join(libraryDir, libName));
+    if (standard === null || library === null) continue;
+    pairs++;
+    found.push(...divergences(topic, standard, library, `practice/standards/${name}`, `practice/library/${libName}`));
+  }
+  const floors = 'law floors are not compared mechanically — ask counsel to check a standard against its law area';
+  if (found.length === 0) return { check, severity: 'ok', message: `${pairs} standard/library pairs checked, no numeric divergence`, detail: floors };
+  const lines = found.map(d => `${d.topic}: standard accepts ${d.standardMin === d.standardMax ? d.standardMin : `${d.standardMin}–${d.standardMax}`} ${d.unit}, library Minimum Acceptable says ${d.library} ${d.unit} — align or document`);
+  return {
+    check,
+    severity: 'warn',
+    message: `${found.length} possible divergence${found.length === 1 ? '' : 's'} across ${pairs} standard/library pairs`,
+    detail: [...lines, floors].join('\n'),
+    paths: [...new Set(found.flatMap(d => [d.standardPath, d.libraryPath]))],
+    fix: 'align the numbers, or note the deliberate split in the file',
+  };
+}
+
+// ── 11. Matter-aware law impact ─────────────────────────────────────────
+
+interface OpenMatter {
+  path: string;
+  title: string;
+  updated: Date | null;
+  areas: string[];
+}
+
+function lawAreasOf(raw: string, body: string): string[] {
+  const areas: string[] = [];
+  const push = (s: string): void => {
+    for (const part of s.split(/[,;]/)) {
+      const a = part.trim().replace(/^law\//, '').replace(/\/$/, '').toLowerCase();
+      if (a !== '' && a !== 'none' && !a.startsWith('none ')) areas.push(a);
+    }
+  };
+  // Frontmatter: `law_areas:` / `law-areas:` as a list or a string.
+  const { block } = splitFrontmatterBlock(raw);
+  if (block !== null) {
+    try {
+      const parsed = Bun.YAML.parse(block) as Record<string, unknown> | null;
+      const value = parsed?.['law_areas'] ?? parsed?.['law-areas'] ?? parsed?.['law areas'];
+      if (Array.isArray(value)) for (const v of value) push(String(v));
+      else if (typeof value === 'string') push(value);
+    } catch {
+      /* odd frontmatter: fall through to the body line */
+    }
+  }
+  // Body: `- **Law areas:** data-privacy, employment` (the remember primitive's line).
+  const m = /\*\*Law areas:\*\*\s*(.+)/i.exec(body);
+  if (m !== null) push(m[1]!);
+  return [...new Set(areas)];
+}
+
+function openMatters(ctx: DoctorContext): OpenMatter[] {
+  const dir = join(ctx.vaultRoot, ctx.cfg.mattersPath);
+  if (!isDir(dir)) return [];
+  const files: string[] = [];
+  for (const name of readdirSync(dir).sort()) {
+    if (name.startsWith('.')) continue;
+    const full = join(dir, name);
+    if (name.endsWith('.md') && !isDir(full)) files.push(`${ctx.cfg.mattersPath}/${name}`);
+    else if (isDir(full) && existsSync(join(full, 'matter.md'))) files.push(`${ctx.cfg.mattersPath}/${name}/matter.md`);
+  }
+  const out: OpenMatter[] = [];
+  for (const path of files) {
+    const text = readText(join(ctx.vaultRoot, path));
+    if (text === null) continue;
+    const { frontmatter, body } = parseFrontmatter(text);
+    const stage = (frontmatter['stage'] ?? '').trim().toLowerCase();
+    if (stage !== 'intake' && stage !== 'working') continue;
+    const h1 = /^#\s+(.+)$/m.exec(body);
+    out.push({ path, title: frontmatter['title']?.trim() || h1?.[1]?.trim() || path, updated: parseIsoDate(frontmatter['updated']), areas: lawAreasOf(text, body) });
+  }
+  return out;
+}
+
+export function checkLawImpact(ctx: DoctorContext): Finding {
+  const check = 'law-impact';
+  const matters = openMatters(ctx);
+  if (matters.length === 0) return { check, severity: 'ok', message: 'no open matters' };
+  const newestByArea = new Map<string, Date>();
+  for (const f of lawFiles(ctx)) {
+    if (f.lastReviewed === null) continue;
+    const prev = newestByArea.get(f.area);
+    if (prev === undefined || f.lastReviewed.getTime() > prev.getTime()) newestByArea.set(f.area, f.lastReviewed);
+  }
+  const behind: Array<{ matter: OpenMatter; area: string; reviewed: Date }> = [];
+  for (const matter of matters) {
+    if (matter.updated === null) continue;
+    for (const area of matter.areas) {
+      const reviewed = newestByArea.get(area);
+      if (reviewed !== undefined && reviewed.getTime() > matter.updated.getTime()) behind.push({ matter, area, reviewed });
+    }
+  }
+  if (behind.length === 0) return { check, severity: 'ok', message: `${matters.length} open matter${matters.length === 1 ? '' : 's'} — none behind a refreshed law area` };
+  const iso = (d: Date): string => d.toISOString().slice(0, 10);
+  const affected = new Set(behind.map(b => b.matter.path));
+  return {
+    check,
+    severity: 'warn',
+    message: `${affected.size} open matter${affected.size === 1 ? '' : 's'} behind refreshed law areas`,
+    detail: behind.map(b => `${b.matter.title} (updated ${iso(b.matter.updated!)}) — law/${b.area} refreshed ${iso(b.reviewed)}: review the area's recent changes before the next action`).join('\n'),
+    paths: [...affected],
+    fix: 'review the listed areas before the next action on each matter',
+  };
+}
+
+export const ALL_CHECKS: ReadonlyArray<(ctx: DoctorContext) => Finding> = [checkRootConfig, checkStructure, checkLawCurrency, checkGit, checkConsistency, checkLawImpact];

--- a/runtime/src/doctor/index.ts
+++ b/runtime/src/doctor/index.ts
@@ -1,0 +1,61 @@
+import { systemGit, type GitRunner } from '../setup/run';
+import { readVaultConfig } from '../vault/resolve-root';
+import { ALL_CHECKS, type DoctorContext, type Finding, type Severity } from './checks';
+import { loadLawPolicy, type LawPolicy } from './policy';
+
+export type { Finding, Severity } from './checks';
+
+export type Verdict = 'healthy' | 'warnings' | 'broken';
+
+export interface DoctorReport {
+  at: string;
+  vault: string;
+  findings: Finding[];
+  verdict: Verdict;
+  /** The verdict in words, the way the skill's table ends. */
+  summary: string;
+}
+
+export interface DoctorDeps {
+  vaultRoot: string;
+  pluginRoot: string;
+  policy?: LawPolicy;
+  /** Default: real git, or `null` when there is none. */
+  git?: GitRunner | null;
+  now?: () => Date;
+}
+
+export function verdictOf(findings: Finding[]): { verdict: Verdict; summary: string } {
+  const errors = findings.filter(f => f.severity === 'error');
+  const warns = findings.filter(f => f.severity === 'warn');
+  if (errors.length > 0) return { verdict: 'broken', summary: `broken: ${errors[0]!.message} — ${errors[0]!.fix ?? 'fix it before doing legal work'}` };
+  if (warns.length > 0) return { verdict: 'warnings', summary: `${warns.length} warning${warns.length === 1 ? '' : 's'} — ${warns[0]!.check} first` };
+  return { verdict: 'healthy', summary: 'healthy' };
+}
+
+/** Runs every check. Read-only. */
+export function runDoctor(deps: DoctorDeps): DoctorReport {
+  const now = deps.now?.() ?? new Date();
+  const ctx: DoctorContext = {
+    vaultRoot: deps.vaultRoot,
+    cfg: readVaultConfig(deps.vaultRoot),
+    policy: deps.policy ?? loadLawPolicy(deps.pluginRoot),
+    now,
+    git: deps.git === undefined ? systemGit() : deps.git,
+  };
+  const findings = ALL_CHECKS.map(check => check(ctx));
+  return { at: now.toISOString(), vault: deps.vaultRoot, findings, ...verdictOf(findings) };
+}
+
+/** The report as the skill's table, for the CLI. */
+export function renderReport(report: DoctorReport): string {
+  const mark: Record<Severity, string> = { ok: 'ok   ', warn: 'warn ', error: 'error' };
+  const lines = [`Counsel OS vault health — ${report.at.slice(0, 10)} — ${report.vault}`, ''];
+  for (const f of report.findings) {
+    lines.push(`${mark[f.severity]}  ${f.check.padEnd(14)} ${f.message}`);
+    if (f.detail !== undefined) for (const d of f.detail.split('\n')) lines.push(`${' '.repeat(22)}${d}`);
+    if (f.fix !== undefined && f.severity !== 'ok') lines.push(`${' '.repeat(22)}fix: ${f.fix}`);
+  }
+  lines.push('', `Verdict: ${report.summary}`);
+  return lines.join('\n') + '\n';
+}

--- a/runtime/src/doctor/policy.ts
+++ b/runtime/src/doctor/policy.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * The law frontmatter policy (`knowledge/law/frontmatter-policy.json`): the
+ * per-area review cadence the doctor's currency check measures against. The
+ * file is maintainer documentation, not shipped content, so it is read from
+ * the plugin root directly; a runtime without it (a future embedded build
+ * that forgot it) falls back to the policy's own default of twelve months.
+ */
+export interface LawPolicy {
+  reviewCadenceMonths: Record<string, number>;
+  /** The areas the policy names — the shipped areas. A vault area outside
+   * this set is a custom, user-owned area. */
+  areas: ReadonlySet<string>;
+}
+
+export const DEFAULT_CADENCE_MONTHS = 12;
+
+export function parseLawPolicy(text: string): LawPolicy {
+  const raw = JSON.parse(text) as { review_cadence_months?: Record<string, unknown> };
+  const reviewCadenceMonths: Record<string, number> = {};
+  for (const [area, months] of Object.entries(raw.review_cadence_months ?? {})) {
+    if (typeof months === 'number' && Number.isFinite(months) && months > 0) reviewCadenceMonths[area] = months;
+  }
+  const areas = new Set(Object.keys(reviewCadenceMonths).filter(a => a !== 'default'));
+  return { reviewCadenceMonths, areas };
+}
+
+export function loadLawPolicy(pluginRoot: string): LawPolicy {
+  try {
+    return parseLawPolicy(readFileSync(join(pluginRoot, 'knowledge', 'law', 'frontmatter-policy.json'), 'utf8'));
+  } catch {
+    return { reviewCadenceMonths: { default: DEFAULT_CADENCE_MONTHS }, areas: new Set() };
+  }
+}
+
+export function cadenceFor(policy: LawPolicy, area: string): number {
+  return policy.reviewCadenceMonths[area] ?? policy.reviewCadenceMonths['default'] ?? DEFAULT_CADENCE_MONTHS;
+}

--- a/runtime/src/loop/prompt.test.ts
+++ b/runtime/src/loop/prompt.test.ts
@@ -8,7 +8,7 @@ import { readPrimitiveTool } from './primitives';
 import { runToolDef } from '../core/fake-provider';
 import type { VaultConfig } from '../vault/resolve-root';
 
-const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
 
 const allTools: AvailableTools = {
   available: [
@@ -177,7 +177,7 @@ describe('assembleSystemPrompt', () => {
       vaultRoot,
       platform: 'macos',
       tools: { available: ['vault_read', 'vault_write'], unavailable: [] },
-      cfg: { entitiesPath: 'clients', mattersPath: 'cases' },
+      cfg: { entitiesPath: 'clients', mattersPath: 'cases', autoApplyLawUpdates: false, lawManagement: 'plugin' },
     });
 
     expect(prompt).toContain('cases/');
@@ -211,7 +211,7 @@ describe('HOST_PREAMBLE', () => {
   });
 
   test('translates {legal_root}/x/y.md paths and states matters/entities live at the configured dirs', () => {
-    const preamble = HOST_PREAMBLE(allTools, 'macos', { entitiesPath: 'clients', mattersPath: 'cases' });
+    const preamble = HOST_PREAMBLE(allTools, 'macos', { entitiesPath: 'clients', mattersPath: 'cases', autoApplyLawUpdates: false, lawManagement: 'plugin' });
     expect(preamble).toContain('{legal_root}/x/y.md');
     expect(preamble.toLowerCase()).toContain('drop');
     expect(preamble).toContain('cases/');

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -1303,5 +1303,90 @@ describe('POST /vault/upload and /vault/move (docx intake, stage 1 step 3)', () 
     expect((await call(app, 'POST', '/vault/move', { body: { from: 'matters/acme/nda.docx', to: 'practice' } })).status).toBe(400);
     expect((await call(app, 'POST', '/vault/move', { body: { from: 'matters/inbox/none.docx', to: 'matters/acme' } })).status).toBe(404);
     expect((await call(app, 'POST', '/vault/move', { body: { from: '' } })).status).toBe(400);
+  });
+});
+
+describe('content updates and doctor (spec 2026-09-01 §6–§7)', () => {
+  const LAW = '---\ncounsel-os-type: law-area\nlast-reviewed: "2026-06-11"\n---\n# GDPR\n\n72 hours.\n';
+
+  /** A plugin root that ships one law file and one standard, and a vault
+   * seeded from it by hand with the content state `runSetup` would write. */
+  function seed(): { shippedGdpr: string } {
+    const shippedGdpr = join(pluginRoot, 'knowledge', 'law', 'data-privacy', 'gdpr.md');
+    mkdirSync(join(pluginRoot, 'knowledge', 'law', 'data-privacy'), { recursive: true });
+    writeFileSync(shippedGdpr, LAW, 'utf8');
+    mkdirSync(join(pluginRoot, 'knowledge', 'practice-seed', 'standards'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'knowledge', 'practice-seed', 'standards', 'confidentiality.md'), '# Conf\n\n## Our Position\n**Our standard:** 3 years.\n', 'utf8');
+    mkdirSync(join(vaultRoot, 'law', 'data-privacy'), { recursive: true });
+    writeFileSync(join(vaultRoot, 'law', 'data-privacy', 'gdpr.md'), LAW, 'utf8');
+    mkdirSync(join(vaultRoot, 'practice', 'standards'), { recursive: true });
+    writeFileSync(join(vaultRoot, 'practice', 'standards', 'confidentiality.md'), '# Conf\n\n## Our Position\n**Our standard:** 5 years.\n', 'utf8');
+    writeFileSync(join(vaultRoot, 'config.md'), `counsel-os-config: true\nlegal_root: ${vaultRoot}\n`, 'utf8');
+    mkdirSync(join(vaultRoot, '.counsel'), { recursive: true });
+    const hash = (text: string): string => createHash('sha256').update(text.replace(/^---[ \t]*\n[\s\S]*?\n---[ \t]*\n/, ''), 'utf8').digest('hex');
+    writeFileSync(
+      join(vaultRoot, '.counsel', 'content-state.json'),
+      JSON.stringify({ version: '0.0.1', receivedAt: '2026-08-01T00:00:00.000Z', files: { 'law/data-privacy/gdpr.md': { hash: hash(LAW), from: 'knowledge/law/data-privacy/gdpr.md' }, 'practice/standards/confidentiality.md': { hash: hash('# Conf\n\n## Our Position\n**Our standard:** 3 years.\n'), from: 'knowledge/practice-seed/standards/confidentiality.md' } } }),
+      'utf8',
+    );
+    return { shippedGdpr };
+  }
+
+  test('GET /content/status classifies; an upstream law change is update-available, the edited standard is current', async () => {
+    const { shippedGdpr } = seed();
+    const app = appWithFake();
+    let res = await call(app, 'GET', '/content/status');
+    expect(res.status).toBe(200);
+    let status = (await res.json()) as { items: Array<{ path: string; status: string }>; vaultVersion: string; counts: Record<string, number> };
+    expect(status.vaultVersion).toBe('0.0.1');
+    expect(status.items.map(i => [i.path, i.status])).toEqual([
+      ['law/data-privacy/gdpr.md', 'current'],
+      ['practice/standards/confidentiality.md', 'current'],
+    ]);
+
+    writeFileSync(shippedGdpr, LAW + 'Upstream note.\n', 'utf8');
+    res = await call(app, 'GET', '/content/status');
+    status = (await res.json()) as typeof status;
+    expect(status.items[0]).toMatchObject({ path: 'law/data-privacy/gdpr.md', status: 'update-available' });
+    expect(status.counts['update-available']).toBe(1);
+  });
+
+  test('POST /content/apply writes an applicable path and refuses everything else with a 400', async () => {
+    const { shippedGdpr } = seed();
+    writeFileSync(shippedGdpr, LAW + 'Upstream note.\n', 'utf8');
+    const app = appWithFake();
+    const bad = await call(app, 'POST', '/content/apply', { body: { paths: ['practice/standards/confidentiality.md'] } });
+    expect(bad.status).toBe(400);
+    expect(((await bad.json()) as { paths: string[] }).paths).toEqual(['practice/standards/confidentiality.md']);
+    expect((await call(app, 'POST', '/content/apply', { body: { paths: [] } })).status).toBe(400);
+
+    const ok = await call(app, 'POST', '/content/apply', { body: { paths: ['law/data-privacy/gdpr.md'] } });
+    expect(ok.status).toBe(200);
+    expect(((await ok.json()) as { applied: string[] }).applied).toEqual(['law/data-privacy/gdpr.md']);
+    expect(readFileSync(join(vaultRoot, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(LAW + 'Upstream note.\n');
+    const after = (await (await call(app, 'GET', '/content/status')).json()) as { items: Array<{ status: string }> };
+    expect(after.items[0]!.status).toBe('current');
+  });
+
+  test('GET /doctor runs the vault checks read-only and reports a verdict', async () => {
+    seed();
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { git: null });
+    const res = await call(app, 'GET', '/doctor');
+    expect(res.status).toBe(200);
+    const report = (await res.json()) as { findings: Array<{ check: string; severity: string }>; verdict: string; vault: string };
+    expect(report.vault).toBe(vaultRoot);
+    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact']);
+    expect(report.findings[0]!.severity).toBe('ok');
+    expect(report.findings.find(f => f.check === 'git')!.severity).toBe('warn');
+    expect(['warnings', 'broken']).toContain(report.verdict);
+    // Nothing was written.
+    expect(readFileSync(join(vaultRoot, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(LAW);
+  });
+
+  test('both prefixes need the token', async () => {
+    seed();
+    const app = appWithFake();
+    expect((await call(app, 'GET', '/content/status', { token: null })).status).toBe(401);
+    expect((await call(app, 'GET', '/doctor', { token: null })).status).toBe(401);
   });
 });

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -12,6 +12,10 @@ import { vaultDocket } from '../vault/docket';
 import { normalizeVaultPath } from '../vault/knowledge-paths';
 import { vaultOverview } from '../vault/overview';
 import { readVaultConfig } from '../vault/resolve-root';
+import { applyUpdates, contentStatus, UpdateError } from '../content/update';
+import { repoContentSource } from '../content/repo';
+import { runDoctor } from '../doctor/index';
+import { systemGit, type GitRunner } from '../setup/run';
 import { isAuthorized } from './auth';
 import {
   applySettings,
@@ -44,6 +48,9 @@ export interface ServerDeps extends Omit<CounselLoopDeps, 'providers' | 'router'
   /** The built UI's `dist/` (spec §4.2). Omitted → no static serving at all,
    * and a non-API path is the 404 it has always been. */
   distDir?: string;
+  /** The doctor's git runner (spec 2026-09-01 §7). Default: real git when
+   * on PATH; `null` reports "git is not installed". */
+  git?: GitRunner | null;
 }
 
 export type App = (req: Request) => Promise<Response>;
@@ -54,7 +61,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -713,6 +720,28 @@ export function createApp(deps: ServerDeps): App {
   /** The deadline docket (roadmap §1, in the runtime): every dated
    * obligation the matter files carry, classified against today. Same
    * matter discovery as the overview, read-only. */
+  /**
+   * Content updates (spec 2026-09-01 §6): what the vault has against what
+   * ships, and the apply that writes only what the rules allow. The content
+   * source is the loop's (`deps.content`) or the repo's over `pluginRoot`.
+   */
+  const updateDeps = () => ({ vaultRoot: deps.vaultRoot, content: deps.content ?? repoContentSource(deps.pluginRoot) });
+  const contentStatusRoute = (): Response => json(contentStatus(updateDeps()));
+  const ContentApplyBody = z.object({ paths: z.array(z.string().min(1)).min(1) });
+  const contentApplyRoute = async (req: Request): Promise<Response> => {
+    const input = await body(req, ContentApplyBody);
+    try {
+      return json(applyUpdates(updateDeps(), input.paths));
+    } catch (err) {
+      if (err instanceof UpdateError) return fail(400, err.message, { paths: err.paths });
+      throw err;
+    }
+  };
+
+  /** The doctor (spec 2026-09-01 §7): read-only vault checks. */
+  const doctorRoute = (): Response =>
+    json(runDoctor({ vaultRoot: deps.vaultRoot, pluginRoot: deps.pluginRoot, git: deps.git === undefined ? systemGit() : deps.git }));
+
   const docketRoute = async (): Promise<Response> =>
     json(await vaultDocket(deps.vault, deps.tenant, readVaultConfig(deps.vaultRoot)));
 
@@ -844,6 +873,13 @@ export function createApp(deps: ServerDeps): App {
       }
 
       if (segments.length === 1 && first === 'docket' && method === 'GET') return await docketRoute();
+
+      if (segments.length === 2 && first === 'content') {
+        if (second === 'status' && method === 'GET') return contentStatusRoute();
+        if (second === 'apply' && method === 'POST') return await contentApplyRoute(req);
+      }
+
+      if (segments.length === 1 && first === 'doctor' && method === 'GET') return doctorRoute();
 
       return fail(404, `no route for ${method} ${url.pathname}`);
     } catch (err) {

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -399,3 +399,27 @@ describe('startServer in setup mode (spec 2026-09-01 §4)', () => {
     expect(await health.json()).toMatchObject({ setup: false, vault });
   });
 });
+
+describe('auto_apply_law_updates at serve start (spec 2026-09-01 §6)', () => {
+  test('applies a pending law update when the flag is on, and nothing when it is off', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    const law = '---\ncounsel-os-type: law-area\n---\n# GDPR\n\nold\n';
+    mkdirSync(join(pluginRoot, 'knowledge', 'law', 'data-privacy'), { recursive: true });
+    writeFileSync(join(pluginRoot, 'knowledge', 'law', 'data-privacy', 'gdpr.md'), law + 'new\n', 'utf8');
+    mkdirSync(join(vault, 'law', 'data-privacy'), { recursive: true });
+    writeFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), law, 'utf8');
+    mkdirSync(join(vault, '.counsel'), { recursive: true });
+    const { createHash } = await import('node:crypto');
+    const hash = createHash('sha256').update('# GDPR\n\nold\n', 'utf8').digest('hex');
+    writeFileSync(join(vault, '.counsel', 'content-state.json'), JSON.stringify({ version: '0.0.1', receivedAt: 'x', files: { 'law/data-privacy/gdpr.md': { hash, from: 'knowledge/law/data-privacy/gdpr.md' } } }), 'utf8');
+
+    writeFileSync(join(vault, 'config.md'), `counsel-os-config: true\nlegal_root: ${vault}\n`, 'utf8');
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(law);
+    await running.stop();
+
+    writeFileSync(join(vault, 'config.md'), `counsel-os-config: true\nlegal_root: ${vault}\nauto_apply_law_updates: true\n`, 'utf8');
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+    expect(readFileSync(join(vault, 'law', 'data-privacy', 'gdpr.md'), 'utf8')).toBe(law + 'new\n');
+  });
+});

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -3,6 +3,7 @@ import { readFileSync, realpathSync, rmSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, resolve, sep } from 'node:path';
 import { repoContentSource } from '../content/repo';
+import { autoApplyLawUpdates } from '../content/update';
 import { writeFileAtomic } from '../core/atomic-write';
 import { counselHome } from '../core/home';
 import { FakeModelProvider, type FakeScript } from '../core/fake-provider';
@@ -358,6 +359,15 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
     // default is the real `$HOME`, which would ignore `COUNSEL_OS_HOME` and
     // drop a copy of `auth.json` somewhere the operator never pointed at.
     store = new ThreadStore(vault, { codexHomeRoot: codexHomeRoot(env) });
+    // `auto_apply_law_updates: true` (spec 2026-09-01 §6): law updates the
+    // vault has not modified are applied at start, and said so once. A
+    // failure here is logged, never fatal — the vault serves as it is.
+    try {
+      const auto = autoApplyLawUpdates({ vaultRoot: vault, content });
+      if (auto.applied.length > 0) console.log(`counsel-os runtime: applied ${auto.applied.length} law update${auto.applied.length === 1 ? '' : 's'} (auto_apply_law_updates)`);
+    } catch (err) {
+      console.error(`counsel-os runtime: auto-apply of law updates failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
     return createApp({
       token,
       tenant: DEFAULT_TENANT,

--- a/runtime/src/setup/run.test.ts
+++ b/runtime/src/setup/run.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { repoContentSource } from '../content/repo';
 import { SetupPlan } from './plan';
-import { CONTENT_STATE, runSetup, SetupError, systemGit, type ContentState, type GitRunner } from './run';
+import { CONTENT_STATE, RECEIVED_DIR, readReceivedSnapshot, runSetup, SetupError, systemGit, type ContentState, type GitRunner } from './run';
 
 const REPO = resolve(import.meta.dir, '../../..');
 const content = repoContentSource(REPO);
@@ -264,5 +264,27 @@ describe('the sample matter (spec §4)', () => {
     const again = runSetup(plan(vault), { content, home, pluginRoot: REPO });
     expect(again.groups.sample).toEqual({ written: 2, skipped: 1 });
     expect(readFileSync(join(vault, 'matters', 'sample-mutual-nda', 'matter.md'), 'utf8')).toBe('# Mine\n');
+  });
+});
+
+describe('runSetup practice snapshots (content updates, spec §6)', () => {
+  test('each placed practice seed is copied under .counsel/received; law is not', () => {
+    const { home, vault } = fixture();
+    runSetup(plan(vault), { content, home, pluginRoot: REPO, git: null });
+    const snap = readReceivedSnapshot(vault, 'practice/standards/confidentiality.md');
+    expect(snap).toBe(content.read('knowledge/practice-seed/standards/confidentiality.md'));
+    expect(snap).toBe(readFileSync(join(vault, 'practice', 'standards', 'confidentiality.md'), 'utf8'));
+    expect(existsSync(join(vault, RECEIVED_DIR, 'law'))).toBe(false);
+    expect(readReceivedSnapshot(vault, 'law/data-privacy/gdpr.md')).toBeNull();
+  });
+
+  test('a rerun leaves an existing snapshot and file alone', () => {
+    const { home, vault } = fixture();
+    runSetup(plan(vault), { content, home, pluginRoot: REPO, git: null });
+    const target = join(vault, 'practice', 'standards', 'confidentiality.md');
+    writeFileSync(target, '# mine\n', 'utf8');
+    runSetup(plan(vault), { content, home, pluginRoot: REPO, git: null });
+    expect(readFileSync(target, 'utf8')).toBe('# mine\n');
+    expect(readReceivedSnapshot(vault, 'practice/standards/confidentiality.md')).toBe(content.read('knowledge/practice-seed/standards/confidentiality.md'));
   });
 });

--- a/runtime/src/setup/run.ts
+++ b/runtime/src/setup/run.ts
@@ -91,10 +91,20 @@ export interface ContentState {
 
 export const CONTENT_STATE = join('.counsel', 'content-state.json');
 
+/** `.counsel/received/<vault path>`: a copy of each PRACTICE seed as the
+ * vault received it. The update step (spec §6) diffs a new seed against
+ * this, never against the user's edited copy — the only way to show what
+ * changed upstream once the practice file has diverged by design. Law is
+ * not snapshotted: its baseline is the received hash alone, because a
+ * plugin-managed law file that still matches it is simply replaced. */
+export const RECEIVED_DIR = join('.counsel', 'received');
+
+export type ContentGroup = 'law' | 'standards' | 'methods' | 'library' | 'reference';
+
 /** The 26 law areas plus the practice seed: shipped path prefix → vault
  * path prefix. Shipped paths never carry `..` (the source refuses them), so
  * the rewrite is a prefix swap. */
-const PLACEMENTS: ReadonlyArray<{ group: keyof SetupResult['groups']; from: string; to: string }> = [
+export const PLACEMENTS: ReadonlyArray<{ group: ContentGroup; from: string; to: string }> = [
   { group: 'law', from: 'knowledge/law', to: 'law' },
   { group: 'standards', from: 'knowledge/practice-seed/standards', to: 'practice/standards' },
   { group: 'methods', from: 'knowledge/practice-seed/methods', to: 'practice/methods' },
@@ -163,9 +173,29 @@ function checkVault(vault: string, pluginRoot: string): { adopted: boolean } {
   return { adopted };
 }
 
-function readContentState(vault: string): ContentState | null {
+export function readContentState(vault: string): ContentState | null {
   try {
     return JSON.parse(readFileSync(join(vault, CONTENT_STATE), 'utf8')) as ContentState;
+  } catch {
+    return null;
+  }
+}
+
+export function writeContentState(vault: string, state: ContentState): void {
+  mkdirSync(join(vault, '.counsel'), { recursive: true });
+  writeFileSync(join(vault, CONTENT_STATE), JSON.stringify(state, null, 2) + '\n', 'utf8');
+}
+
+/** The practice seed as received, for the update step's diffs. */
+export function writeReceivedSnapshot(vault: string, rel: string, text: string): void {
+  const target = join(vault, RECEIVED_DIR, rel);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, text, 'utf8');
+}
+
+export function readReceivedSnapshot(vault: string, rel: string): string | null {
+  try {
+    return readFileSync(join(vault, RECEIVED_DIR, rel), 'utf8');
   } catch {
     return null;
   }
@@ -213,11 +243,17 @@ export function runSetup(plan: SetupPlan, deps: SetupDeps): SetupResult {
   mkdirSync(deps.home, { recursive: true, mode: 0o700 });
   writeFileAtomic(join(deps.home, 'legal-root'), vault, { mode: 0o600, dirMode: 0o700 });
 
-  // 3. Law areas and the practice seed, path for path.
+  // 3. Law areas and the practice seed, path for path. A practice seed that
+  //    is placed is also snapshotted, so a later upstream change can be
+  //    shown against what the vault received rather than against the
+  //    user's own edits.
   for (const { group, from, to } of PLACEMENTS) {
     for (const shipped of deps.content.list(from)) {
       const rel = `${to}/${shipped.slice(from.length + 1)}`;
-      place(group, rel, deps.content.read(shipped), shipped);
+      const text = deps.content.read(shipped);
+      const before = groups[group].written;
+      place(group, rel, text, shipped);
+      if (group !== 'law' && groups[group].written > before) writeReceivedSnapshot(vault, rel, text);
     }
   }
 
@@ -270,8 +306,7 @@ export function runSetup(plan: SetupPlan, deps: SetupDeps): SetupResult {
     receivedAt: now().toISOString(),
     files: { ...(previous?.files ?? {}), ...received },
   };
-  mkdirSync(join(vault, '.counsel'), { recursive: true });
-  writeFileSync(join(vault, CONTENT_STATE), JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeContentState(vault, state);
 
   // 10. The default provider, only when asked for; the file is otherwise
   //    left exactly as it is (a fresh install has none, and that is fine).

--- a/runtime/src/vault/knowledge-paths.test.ts
+++ b/runtime/src/vault/knowledge-paths.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { isKnowledgePath, normalizeVaultPath } from './knowledge-paths';
 import type { VaultConfig } from './resolve-root';
 
-const defaults: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+const defaults: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
 
 describe('normalizeVaultPath', () => {
   test('strips a leading ./', () => {
@@ -65,11 +65,11 @@ describe('isKnowledgePath', () => {
   });
 
   test('an overridden entities_path is honored as a knowledge path', () => {
-    expect(isKnowledgePath('clients/acme.md', { entitiesPath: 'clients', mattersPath: 'matters' })).toBe(true);
+    expect(isKnowledgePath('clients/acme.md', { entitiesPath: 'clients', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' })).toBe(true);
   });
 
   test('the default entities/ path is not a knowledge path once overridden away', () => {
-    expect(isKnowledgePath('entities/acme.md', { entitiesPath: 'clients', mattersPath: 'matters' })).toBe(false);
+    expect(isKnowledgePath('entities/acme.md', { entitiesPath: 'clients', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' })).toBe(false);
   });
 
   test('an unrelated top-level path is not a knowledge path', () => {
@@ -96,7 +96,7 @@ describe('isKnowledgePath — case', () => {
   test('a knowledge path spelled with capitals is still a knowledge path', () => {
     // On APFS `Practice/standards/x.md` IS `practice/standards/x.md`, so a
     // case-sensitive prefix test would be a way around the `remember` gate.
-    const cfg = { entitiesPath: 'entities', mattersPath: 'matters' };
+    const cfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
     expect(isKnowledgePath('Practice/standards/x.md', cfg)).toBe(true);
     expect(isKnowledgePath('MEMORY/notes.md', cfg)).toBe(true);
     expect(isKnowledgePath('Entities/acme.md', cfg)).toBe(true);

--- a/runtime/src/vault/overview.test.ts
+++ b/runtime/src/vault/overview.test.ts
@@ -166,7 +166,7 @@ describe('folder matters (spec 2026-09-01 §4)', () => {
     writeFileSync(join(root, 'matters', 'sample-mutual-nda', 'sample-mutual-nda.md'), '# NDA\n');
     writeFileSync(join(root, 'matters', 'sample-mutual-nda', 'drafts', 'matter.md'), '# too deep\n');
     mkdirSync(join(root, 'matters', 'empty-folder'));
-    const overview = await vaultOverview(new FsVaultStore(root), 'default', { entitiesPath: 'entities', mattersPath: 'matters' });
+    const overview = await vaultOverview(new FsVaultStore(root), 'default', { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' });
     expect(overview.matters.map(m => [m.path, m.title]).sort()).toEqual([
       ['matters/flat.md', 'Flat'],
       ['matters/sample-mutual-nda/matter.md', 'Acme — Mutual NDA (sample)'],

--- a/runtime/src/vault/overview.test.ts
+++ b/runtime/src/vault/overview.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { FsVaultStore } from './fs-store';
 import { MAX_MATTERS, MAX_MATTER_BYTES, parseFrontmatter, prettifyName, titleOf, vaultOverview } from './overview';
 
-const CFG = { entitiesPath: 'entities', mattersPath: 'matters' };
+const CFG = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' as const };
 
 let root: string;
 let store: FsVaultStore;

--- a/runtime/src/vault/resolve-root.test.ts
+++ b/runtime/src/vault/resolve-root.test.ts
@@ -144,7 +144,7 @@ describe('readVaultConfig', () => {
   test('defaults to entities/ and matters/ when config.md has no overrides', () => {
     const root = tmpDir('root-');
     markRoot(root);
-    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' });
   });
 
   test('honors entities_path and matters_path overrides in config.md', () => {
@@ -155,7 +155,7 @@ describe('readVaultConfig', () => {
       `counsel-os-config: true\nlegal_root: ${root}\nentities_path: clients\nmatters_path: deals\n`,
       'utf8',
     );
-    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'clients', mattersPath: 'deals' });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'clients', mattersPath: 'deals', autoApplyLawUpdates: false, lawManagement: 'plugin' });
   });
 
   test('ignores commented-out override lines', () => {
@@ -166,13 +166,13 @@ describe('readVaultConfig', () => {
       `counsel-os-config: true\nlegal_root: ${root}\n# entities_path: entities\n# matters_path: matters\n`,
       'utf8',
     );
-    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' });
   });
 
   test('defaults when config.md is missing entirely', () => {
     const root = tmpDir('root-');
     mkdirSync(root, { recursive: true });
-    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters' });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' });
   });
 
   test('trims a trailing slash from entities_path and matters_path', () => {
@@ -183,6 +183,26 @@ describe('readVaultConfig', () => {
       `counsel-os-config: true\nlegal_root: ${root}\nentities_path: entities/\nmatters_path: cases/\n`,
       'utf8',
     );
-    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'cases' });
+    expect(readVaultConfig(root)).toEqual({ entitiesPath: 'entities', mattersPath: 'cases', autoApplyLawUpdates: false, lawManagement: 'plugin' });
+  });
+});
+
+describe('readVaultConfig law flags', () => {
+  test('auto_apply_law_updates and law_management, quoted or bare, any case', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: /x\nauto_apply_law_updates: "TRUE"\nlaw_management: user\n', 'utf8');
+    const cfg = readVaultConfig(root);
+    expect(cfg.autoApplyLawUpdates).toBe(true);
+    expect(cfg.lawManagement).toBe('user');
+  });
+
+  test('anything but true / user is the default', () => {
+    const root = tmpDir('root-');
+    mkdirSync(root, { recursive: true });
+    writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: /x\nauto_apply_law_updates: yes\nlaw_management: plugin\n', 'utf8');
+    const cfg = readVaultConfig(root);
+    expect(cfg.autoApplyLawUpdates).toBe(false);
+    expect(cfg.lawManagement).toBe('plugin');
   });
 });

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -22,6 +22,13 @@ export type ResolveRootResult = { ok: true; root: string } | { ok: false; code: 
 export interface VaultConfig {
   entitiesPath: string;
   mattersPath: string;
+  /** `auto_apply_law_updates: true` — law `update-available` items are
+   * applied at serve start without a person (spec 2026-09-01 §6). Never
+   * touches a user-owned file. */
+  autoApplyLawUpdates: boolean;
+  /** `law_management: user` — the user owns ALL law content; the runtime
+   * never syncs it (the plugin's `law-refresh` maintains it). */
+  lawManagement: 'plugin' | 'user';
 }
 
 const CWD_WALK_MAX_DEPTH = 3;
@@ -221,8 +228,11 @@ export function readVaultConfig(root: string): VaultConfig {
     return undefined;
   };
 
+  const flag = (raw: string | undefined): string => (raw ?? '').trim().replace(/^["']|["']$/g, '').toLowerCase();
   return {
     entitiesPath: findOverride('entities_path') || 'entities',
     mattersPath: findOverride('matters_path') || 'matters',
+    autoApplyLawUpdates: flag(findOverride('auto_apply_law_updates')) === 'true',
+    lawManagement: flag(findOverride('law_management')) === 'user' ? 'user' : 'plugin',
   };
 }

--- a/runtime/src/vault/vault-tools.test.ts
+++ b/runtime/src/vault/vault-tools.test.ts
@@ -9,7 +9,7 @@ import { runToolDef } from '../core/fake-provider';
 import type { VaultConfig } from './resolve-root';
 import type { Hit } from '../core/types';
 
-const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters' };
+const defaultCfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
 
 describe('vault tools', () => {
   test('exposes four tools and round-trips through runToolDef', async () => {
@@ -90,7 +90,7 @@ describe('guardedVaultTools', () => {
 
   test('vault_write description states the gate and names the real knowledge-system dirs', () => {
     const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
-    const tools = guardedVaultTools(store, { entitiesPath: 'clients', mattersPath: 'deals' });
+    const tools = guardedVaultTools(store, { entitiesPath: 'clients', mattersPath: 'deals', autoApplyLawUpdates: false, lawManagement: 'plugin' });
     const write = tools.find(t => t.name === 'vault_write')!;
     expect(write.description).toMatch(/propose_update/);
     expect(write.description).toContain('practice/');

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -354,6 +354,7 @@ export interface SetupResponse {
     git: 'initialized' | 'present' | 'skipped' | 'unavailable' | 'failed';
     warnings: string[];
   };
+}
 
 /** `GET /content/status` (spec 2026-09-01 §6). COPIED from
  * `runtime/src/content/update.ts`; a change there is a change here. */

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -354,4 +354,55 @@ export interface SetupResponse {
     git: 'initialized' | 'present' | 'skipped' | 'unavailable' | 'failed';
     warnings: string[];
   };
+
+/** `GET /content/status` (spec 2026-09-01 §6). COPIED from
+ * `runtime/src/content/update.ts`; a change there is a change here. */
+export type ContentItemStatus = 'current' | 'update-available' | 'user-modified' | 'vault-only' | 'missing' | 'upstream-changed';
+
+export interface ContentItem {
+  path: string;
+  shipped: string | null;
+  group: 'law' | 'practice';
+  area: string;
+  status: ContentItemStatus;
+  reason?: 'managed-by' | 'law-management' | 'edited' | 'no-baseline';
+  diff?: string;
+  baseline?: 'received' | 'vault';
+  applicable: boolean;
+}
+
+export interface ContentStatus {
+  shippedVersion: string;
+  vaultVersion: string | null;
+  receivedAt: string | null;
+  lawManagement: 'plugin' | 'user';
+  autoApplyLawUpdates: boolean;
+  items: ContentItem[];
+  counts: Record<ContentItemStatus, number>;
+}
+
+/** `POST /content/apply` — 200. */
+export interface ContentApplyResult {
+  applied: string[];
+  skipped: string[];
+}
+
+/** `GET /doctor` (spec 2026-09-01 §7). COPIED from `runtime/src/doctor/`. */
+export type DoctorSeverity = 'ok' | 'warn' | 'error';
+
+export interface DoctorFinding {
+  check: string;
+  severity: DoctorSeverity;
+  message: string;
+  detail?: string;
+  paths?: string[];
+  fix?: string;
+}
+
+export interface DoctorReport {
+  at: string;
+  vault: string;
+  findings: DoctorFinding[];
+  verdict: 'healthy' | 'warnings' | 'broken';
+  summary: string;
 }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -885,3 +885,33 @@ a { color: var(--accent); }
 .v2-prose h1, .v2-prose h2 { font: 500 17px/1.3 var(--serif); margin: 22px 0 8px; padding-bottom: 4px; border-bottom: 1px solid var(--border); }
 .v2-prose h3 { font: 600 11px/1 var(--sans); letter-spacing: 0.12em; text-transform: uppercase; color: var(--fg-faint); margin: 18px 0 6px; }
 .v2-prose strong, .v2-doc-md strong { font-weight: 600; }
+
+/* The setup-required page shares the session-lost page's layout (spec
+   2026-09-01 §4); it only needs its own hook for the coming first-run screen. */
+.v2-setup-required .v2-lost-acts { margin-top: 6px; }
+
+/* ── Settings: Content group + Check the vault (spec 2026-09-01 §6–§7) ── */
+
+/* A ledger row: path in mono, dotted leader, the status set as text. */
+.v2-content-row, .v2-doctor-row { display: flex; align-items: baseline; gap: 10px; padding: 5px 0; border-bottom: 1px solid var(--border); font-size: 13px; }
+.v2-content-row:last-child, .v2-doctor-row:last-child { border-bottom: none; }
+.v2-content-path { font: 12.5px var(--mono); color: var(--fg); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-content-state { font: italic 500 13px/1 var(--serif); color: var(--fg-muted); flex-shrink: 0; }
+.v2-content-state-update { color: var(--accent); }
+.v2-content-state-new { color: var(--ok); }
+.v2-content-state-merge { color: var(--warn); }
+.v2-content-acts { display: flex; gap: 10px; flex-shrink: 0; }
+.v2-content-diff { margin: 4px 0 8px; padding: 8px 10px; background: var(--bg-sunken); border: 1px solid var(--border); border-radius: var(--radius); font: 12px/1.5 var(--mono); white-space: pre; overflow-x: auto; max-height: 24rem; }
+.v2-content-summary { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; margin: 0 0 8px; }
+.v2-content-line { color: var(--fg-muted); font-size: 13px; }
+.v2-content-line b { font-weight: 600; color: var(--fg); }
+.v2-doctor-check { font: 600 10.5px/1 var(--sans); letter-spacing: 0.09em; text-transform: uppercase; color: var(--fg-faint); width: 9rem; flex-shrink: 0; }
+.v2-doctor-severity { font: italic 500 13px/1 var(--serif); width: 3.2rem; flex-shrink: 0; }
+.v2-doctor-ok { color: var(--ok); }
+.v2-doctor-warn { color: var(--warn); }
+.v2-doctor-error { color: var(--error); }
+.v2-doctor-body { min-width: 0; flex: 1; }
+.v2-doctor-message { color: var(--fg); }
+.v2-doctor-detail { color: var(--fg-muted); font-size: 12.5px; white-space: pre-line; margin-top: 2px; }
+.v2-doctor-fix { color: var(--fg-faint); font: 12px var(--mono); margin-top: 2px; word-break: break-all; }
+.v2-doctor-verdict { margin-top: 8px; font: italic 500 13.5px/1.4 var(--serif); color: var(--fg); }

--- a/runtime/ui/src/v2/settings/ContentGroup.test.tsx
+++ b/runtime/ui/src/v2/settings/ContentGroup.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../../api/token';
+import type { ContentItem, ContentStatus } from '../../api/types';
+import { ContentGroup, stateOf, summaryOf } from './ContentGroup';
+
+const realFetch = globalThis.fetch;
+
+function item(over: Partial<ContentItem> & { path: string; status: ContentItem['status'] }): ContentItem {
+  return { shipped: `knowledge/${over.path}`, group: over.path.startsWith('law/') ? 'law' : 'practice', area: 'x', applicable: false, ...over };
+}
+
+function status(items: ContentItem[]): ContentStatus {
+  const counts = { current: 0, 'update-available': 0, 'user-modified': 0, 'vault-only': 0, missing: 0, 'upstream-changed': 0 };
+  for (const i of items) counts[i.status] += 1;
+  return { shippedVersion: '0.12.0', vaultVersion: '0.11.3', receivedAt: '2026-09-01T00:00:00.000Z', lawManagement: 'plugin', autoApplyLawUpdates: false, items, counts };
+}
+
+let current: ContentStatus;
+let posts: unknown[];
+let failApply = false;
+
+function json(body: unknown, statusCode = 200): Response {
+  return new Response(JSON.stringify(body), { status: statusCode, headers: { 'content-type': 'application/json' } });
+}
+
+beforeEach(() => {
+  posts = [];
+  failApply = false;
+  sessionStorage.setItem(TOKEN_KEY, 'test-token');
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === '/content/status') return json(current);
+    if (url === '/content/apply' && init?.method === 'POST') {
+      const body = JSON.parse(String(init.body)) as { paths: string[] };
+      posts.push(body);
+      if (failApply) return json({ error: 'not applicable: practice/standards/x.md — only law updates and missing files can be applied', paths: body.paths }, 400);
+      // The apply makes the paths current.
+      current = status(current.items.map(i => (body.paths.includes(i.path) ? { ...i, status: 'current', applicable: false } : i)));
+      return json({ applied: body.paths, skipped: [] });
+    }
+    throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+describe('ContentGroup', () => {
+  test('everything current: versions and one quiet line, no list', async () => {
+    current = status([item({ path: 'law/data-privacy/gdpr.md', status: 'current' })]);
+    render(<ContentGroup />);
+    await waitFor(() => expect(screen.getByText('Everything is current.')).toBeTruthy());
+    expect(screen.getByText(/Shipped/).textContent).toContain('0.12.0');
+    expect(screen.queryByRole('button', { name: 'review' })).toBeNull();
+    expect(screen.queryByRole('button', { name: /apply all/ })).toBeNull();
+  });
+
+  test('updates: the summary, review opens the ledger, apply posts the path and the row goes current', async () => {
+    current = status([
+      item({ path: 'law/data-privacy/gdpr.md', status: 'update-available', applicable: true }),
+      item({ path: 'law/employment/flsa.md', status: 'missing', applicable: true }),
+      item({ path: 'law/corporate/x.md', status: 'user-modified', reason: 'edited' }),
+      item({ path: 'law/mine/notes.md', status: 'vault-only', shipped: null }),
+    ]);
+    render(<ContentGroup />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toBe('1 law file has updates · 1 new file can be added'));
+    await userEvent.click(screen.getByRole('button', { name: 'review' }));
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(4);
+    expect(rows[0]!.textContent).toContain('update available');
+    expect(rows[1]!.textContent).toContain('new — can be added');
+    expect(rows[2]!.textContent).toContain('yours — edited, left alone');
+    expect(rows[3]!.textContent).toContain('yours — not shipped');
+    // Only the applicable rows carry an action — and it reads add/apply by kind.
+    expect(screen.getAllByRole('button', { name: /^(apply|add)$/ })).toHaveLength(2);
+
+    await userEvent.click(screen.getByRole('button', { name: 'apply' }));
+    await waitFor(() => expect(posts).toEqual([{ paths: ['law/data-privacy/gdpr.md'] }]));
+    await waitFor(() => expect(screen.getByRole('status').textContent).toBe('1 new file can be added'));
+    expect(screen.getByText('Applied 1 file.')).toBeTruthy();
+  });
+
+  test('apply all posts every applicable path at once', async () => {
+    current = status([
+      item({ path: 'law/a/1.md', status: 'update-available', applicable: true }),
+      item({ path: 'law/a/2.md', status: 'update-available', applicable: true }),
+      item({ path: 'practice/standards/x.md', status: 'upstream-changed', diff: '--- a\n+++ b\n@@ -1,1 +1,1 @@\n-old\n+new\n' }),
+    ]);
+    render(<ContentGroup />);
+    await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'apply all updates (2)' })));
+    await waitFor(() => expect(posts).toEqual([{ paths: ['law/a/1.md', 'law/a/2.md'] }]));
+  });
+
+  test('a practice seed that changed upstream offers its diff inline and nothing else', async () => {
+    current = status([item({ path: 'practice/standards/x.md', status: 'upstream-changed', baseline: 'received', diff: '--- a\n+++ b\n@@ -1,1 +1,1 @@\n-old\n+new\n' })]);
+    render(<ContentGroup />);
+    await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'review' })));
+    expect(screen.getByText('changed upstream — merge by hand')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /^(apply|add)$/ })).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'show diff' }));
+    expect(document.querySelector('.v2-content-diff')?.textContent).toContain('+new');
+    await userEvent.click(screen.getByRole('button', { name: 'hide diff' }));
+    expect(document.querySelector('.v2-content-diff')).toBeNull();
+  });
+
+  test('a refused apply shows the server sentence inline', async () => {
+    current = status([item({ path: 'law/a/1.md', status: 'update-available', applicable: true })]);
+    failApply = true;
+    render(<ContentGroup />);
+    await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'apply all updates (1)' })));
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('not applicable'));
+  });
+});
+
+describe('stateOf / summaryOf', () => {
+  test('words per status', () => {
+    expect(stateOf(item({ path: 'p', status: 'user-modified', reason: 'managed-by' })).word).toContain('managed-by: user');
+    expect(stateOf(item({ path: 'p', status: 'user-modified', reason: 'no-baseline' })).word).toContain('no record');
+    expect(stateOf(item({ path: 'p', status: 'upstream-changed', baseline: 'vault' })).word).toContain('your copy');
+    expect(summaryOf(status([item({ path: 'p', status: 'upstream-changed' }), item({ path: 'q', status: 'upstream-changed' })]))).toBe('2 practice seeds changed upstream');
+  });
+});

--- a/runtime/ui/src/v2/settings/ContentGroup.tsx
+++ b/runtime/ui/src/v2/settings/ContentGroup.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState } from 'react';
+import { ApiError, fetchJson } from '../../api/client';
+import type { ContentApplyResult, ContentItem, ContentStatus } from '../../api/types';
+
+/**
+ * Settings › Content (spec 2026-09-01 §6): what the vault received against
+ * what this runtime ships. Law updates apply from here; a file the user
+ * changed is named and left alone; a practice seed that moved upstream
+ * shows its diff for a merge by hand. Set text and ledger rows, no pills.
+ */
+
+function detail(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The status word a row shows, and the tone it is set in. */
+export function stateOf(item: ContentItem): { word: string; tone: 'update' | 'new' | 'merge' | 'quiet' } {
+  switch (item.status) {
+    case 'update-available':
+      return { word: 'update available', tone: 'update' };
+    case 'missing':
+      return { word: 'new — can be added', tone: 'new' };
+    case 'upstream-changed':
+      return { word: item.baseline === 'vault' ? 'changed — compare with your copy' : 'changed upstream — merge by hand', tone: 'merge' };
+    case 'user-modified':
+      return {
+        word:
+          item.reason === 'managed-by'
+            ? 'yours (managed-by: user) — left alone'
+            : item.reason === 'law-management'
+              ? 'yours (law_management: user) — left alone'
+              : item.reason === 'no-baseline'
+                ? 'differs from shipped — no record of what you received, left alone'
+                : 'yours — edited, left alone',
+        tone: 'quiet',
+      };
+    case 'vault-only':
+      return { word: 'yours — not shipped', tone: 'quiet' };
+    default:
+      return { word: 'current', tone: 'quiet' };
+  }
+}
+
+/** The one-line summary under the versions. */
+export function summaryOf(status: ContentStatus): string {
+  const updates = status.counts['update-available'];
+  const adds = status.counts.missing;
+  const merges = status.counts['upstream-changed'];
+  const parts: string[] = [];
+  if (updates > 0) parts.push(`${updates} law file${updates === 1 ? '' : 's'} ${updates === 1 ? 'has' : 'have'} updates`);
+  if (adds > 0) parts.push(`${adds} new file${adds === 1 ? '' : 's'} can be added`);
+  if (merges > 0) parts.push(`${merges} practice seed${merges === 1 ? '' : 's'} changed upstream`);
+  return parts.length === 0 ? 'Everything is current.' : parts.join(' · ');
+}
+
+export function ContentGroup(): JSX.Element {
+  const [status, setStatus] = useState<ContentStatus | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [shown, setShown] = useState<ReadonlySet<string>>(new Set());
+  const [note, setNote] = useState<string | null>(null);
+
+  const load = async (): Promise<void> => {
+    try {
+      setStatus(await fetchJson<ContentStatus>('/content/status'));
+      setError(null);
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) return;
+      setError(detail(err));
+    }
+  };
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const apply = async (paths: string[], label: string): Promise<void> => {
+    setBusy(label);
+    setNote(null);
+    setError(null);
+    try {
+      const result = await fetchJson<ContentApplyResult>('/content/apply', { method: 'POST', body: JSON.stringify({ paths }) });
+      setNote(`Applied ${result.applied.length} file${result.applied.length === 1 ? '' : 's'}.`);
+      await load();
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) return;
+      setError(detail(err));
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const toggleDiff = (path: string): void => {
+    setShown(prev => {
+      const next = new Set(prev);
+      if (next.has(path)) next.delete(path);
+      else next.add(path);
+      return next;
+    });
+  };
+
+  const interesting = status === null ? [] : status.items.filter(item => item.status !== 'current');
+  const applicable = status === null ? [] : status.items.filter(item => item.applicable).map(item => item.path);
+
+  return (
+    <section className="v2-group" aria-label="Content">
+      <h2>Content</h2>
+      <p className="muted">
+        The law areas and practice seed this runtime ships, against what your vault has. Law is kept current for you unless you changed a file; your practice files are never overwritten — an upstream change shows its diff for you to merge.
+      </p>
+      {error !== null ? (
+        <p className="v2-notice v2-notice-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {status === null && error === null ? (
+        <p className="muted">Loading…</p>
+      ) : status === null ? null : (
+        <>
+          <div className="v2-content-summary">
+            <span className="v2-content-line">
+              Shipped <b>{status.shippedVersion}</b> · vault received <b>{status.vaultVersion ?? 'unknown'}</b>
+              {status.lawManagement === 'user' ? ' · law_management: user — law is yours' : ''}
+              {status.autoApplyLawUpdates ? ' · law updates apply at start' : ''}
+            </span>
+          </div>
+          <div className="v2-content-summary">
+            <span className="v2-content-line" role="status">
+              {summaryOf(status)}
+            </span>
+            {interesting.length === 0 ? null : (
+              <button type="button" className="v2-link" aria-expanded={open} onClick={() => setOpen(o => !o)}>
+                {open ? 'hide' : 'review'}
+              </button>
+            )}
+            {applicable.length > 0 ? (
+              <button type="button" className="v2-link" disabled={busy !== null} onClick={() => void apply(applicable, 'all')}>
+                {busy === 'all' ? 'applying…' : `apply all updates (${applicable.length})`}
+              </button>
+            ) : null}
+          </div>
+          {note === null ? null : (
+            <p className="v2-notice v2-notice-ok" role="note">
+              {note}
+            </p>
+          )}
+          {open && interesting.length > 0 ? (
+            <div role="list" aria-label="Content changes">
+              {interesting.map(item => {
+                const state = stateOf(item);
+                return (
+                  <div key={item.path} role="listitem">
+                    <div className="v2-content-row">
+                      <span className="v2-content-path" title={item.shipped ?? item.path}>
+                        {item.path}
+                      </span>
+                      <span className="leader" aria-hidden="true" />
+                      <span className={`v2-content-state v2-content-state-${state.tone}`}>{state.word}</span>
+                      <span className="v2-content-acts">
+                        {item.applicable ? (
+                          <button type="button" className="v2-link" disabled={busy !== null} onClick={() => void apply([item.path], item.path)}>
+                            {busy === item.path ? 'applying…' : item.status === 'missing' ? 'add' : 'apply'}
+                          </button>
+                        ) : null}
+                        {item.diff !== undefined ? (
+                          <button type="button" className="v2-link" aria-expanded={shown.has(item.path)} onClick={() => toggleDiff(item.path)}>
+                            {shown.has(item.path) ? 'hide diff' : 'show diff'}
+                          </button>
+                        ) : null}
+                      </span>
+                    </div>
+                    {item.diff !== undefined && shown.has(item.path) ? <pre className="v2-content-diff">{item.diff}</pre> : null}
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </>
+      )}
+    </section>
+  );
+}

--- a/runtime/ui/src/v2/settings/DoctorLedger.test.tsx
+++ b/runtime/ui/src/v2/settings/DoctorLedger.test.tsx
@@ -1,0 +1,73 @@
+import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../../api/token';
+import type { DoctorReport } from '../../api/types';
+import { DoctorLedger } from './DoctorLedger';
+
+const realFetch = globalThis.fetch;
+
+const report: DoctorReport = {
+  at: '2026-09-01T12:00:00.000Z',
+  vault: '/tmp/vault',
+  verdict: 'warnings',
+  summary: '2 warnings — git first',
+  findings: [
+    { check: 'root-config', severity: 'ok', message: '/tmp/vault — marked config' },
+    { check: 'git', severity: 'warn', message: 'not a git repository — no history of your vault', fix: 'git -C /tmp/vault init' },
+    { check: 'consistency', severity: 'warn', message: '1 possible divergence across 21 standard/library pairs', detail: 'non-solicitation: standard accepts 12–18 months, library Minimum Acceptable says 6 months — align or document\nlaw floors are not compared mechanically', paths: ['practice/standards/non-solicitation.md'] },
+  ],
+};
+
+let calls = 0;
+let fail = false;
+
+beforeEach(() => {
+  calls = 0;
+  fail = false;
+  sessionStorage.setItem(TOKEN_KEY, 'test-token');
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === '/doctor') {
+      calls += 1;
+      if (fail) return new Response(JSON.stringify({ error: 'internal error' }), { status: 500, headers: { 'content-type': 'application/json' } });
+      return new Response(JSON.stringify(report), { status: 200, headers: { 'content-type': 'application/json' } });
+    }
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+describe('DoctorLedger', () => {
+  test('nothing runs until asked; the ledger shows check, severity as set text, message, detail and fix; the verdict closes it', async () => {
+    render(<DoctorLedger />);
+    expect(calls).toBe(0);
+    await userEvent.click(screen.getByRole('button', { name: 'Check the vault' }));
+    await waitFor(() => expect(screen.getByRole('list', { name: 'Vault health' })).toBeTruthy());
+    expect(calls).toBe(1);
+    const rows = screen.getAllByRole('listitem');
+    expect(rows).toHaveLength(3);
+    expect(rows[0]!.querySelector('.v2-doctor-severity')?.textContent).toBe('ok');
+    expect(rows[0]!.querySelector('.v2-doctor-severity')?.className).toContain('v2-doctor-ok');
+    expect(rows[1]!.querySelector('.v2-doctor-fix')?.textContent).toBe('fix: git -C /tmp/vault init');
+    expect(rows[2]!.querySelector('.v2-doctor-detail')?.textContent).toContain('non-solicitation');
+    // No pill anywhere.
+    expect(document.querySelector('.v2-pill')).toBeNull();
+    expect(screen.getByRole('status').textContent).toContain('2 warnings — git first');
+    expect(screen.getByRole('button', { name: 'Check again' })).toBeTruthy();
+  });
+
+  test('a failed check says so and keeps the button', async () => {
+    fail = true;
+    render(<DoctorLedger />);
+    await userEvent.click(screen.getByRole('button', { name: 'Check the vault' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('button', { name: 'Check the vault' })).toBeTruthy();
+  });
+});

--- a/runtime/ui/src/v2/settings/DoctorLedger.tsx
+++ b/runtime/ui/src/v2/settings/DoctorLedger.tsx
@@ -1,0 +1,63 @@
+import { useState } from 'react';
+import { ApiError, fetchJson } from '../../api/client';
+import type { DoctorReport } from '../../api/types';
+
+/**
+ * "Check the vault" in Settings › Runtime (spec 2026-09-01 §7): one click
+ * runs the read-only doctor and lays the findings out as a ledger — check,
+ * severity as set text, the message, its detail and fix. No pills.
+ */
+export function DoctorLedger(): JSX.Element {
+  const [report, setReport] = useState<DoctorReport | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const run = async (): Promise<void> => {
+    setBusy(true);
+    setError(null);
+    try {
+      setReport(await fetchJson<DoctorReport>('/doctor'));
+    } catch (err) {
+      if (err instanceof ApiError && err.status === 401) return;
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="v2-doctor">
+      <h3 className="runin">Health</h3>
+      <p className="muted">Read-only checks over the vault: the config marker, the folders and their counts, how current the law areas are, git, whether your standards and clause library agree, and open matters behind a refreshed law area.</p>
+      <button type="button" disabled={busy} onClick={() => void run()}>
+        {busy ? 'Checking…' : report === null ? 'Check the vault' : 'Check again'}
+      </button>
+      {error !== null ? (
+        <p className="v2-notice v2-notice-error" role="alert">
+          {error}
+        </p>
+      ) : null}
+      {report === null ? null : (
+        <>
+          <div role="list" aria-label="Vault health">
+            {report.findings.map(f => (
+              <div key={f.check} role="listitem" className="v2-doctor-row">
+                <span className="v2-doctor-check">{f.check.replace(/-/g, ' ')}</span>
+                <span className={`v2-doctor-severity v2-doctor-${f.severity}`}>{f.severity}</span>
+                <span className="v2-doctor-body">
+                  <span className="v2-doctor-message">{f.message}</span>
+                  {f.detail === undefined ? null : <div className="v2-doctor-detail">{f.detail}</div>}
+                  {f.fix === undefined || f.severity === 'ok' ? null : <div className="v2-doctor-fix">fix: {f.fix}</div>}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="v2-doctor-verdict" role="status">
+            {report.summary}
+            <span className="muted"> · checked {new Date(report.at).toLocaleString()}</span>
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -41,6 +41,11 @@ function install(onPut: (body: unknown) => Response, getView: SettingsView = vie
   globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = String(input);
     if (url === '/settings' && (init?.method ?? 'GET') === 'GET') return json(getView);
+    // The Content group reads its own status; an all-current answer keeps
+    // these tests about the registry form.
+    if (url === '/content/status') {
+      return json({ shippedVersion: '0.0.0', vaultVersion: '0.0.0', receivedAt: null, lawManagement: 'plugin', autoApplyLawUpdates: false, items: [], counts: { current: 0, 'update-available': 0, 'user-modified': 0, 'vault-only': 0, missing: 0, 'upstream-changed': 0 } });
+    }
     if (url === '/settings' && init?.method === 'PUT') {
       const body: unknown = JSON.parse(String(init.body));
       puts.push(body);
@@ -70,7 +75,7 @@ describe('SettingsPage', () => {
     // Descendant, not child: `Health` draws its own heading inside its own
     // section, one level under the group card.
     const headings = Array.from(document.querySelectorAll('.v2-group h2'), el => el.textContent);
-    expect(headings).toEqual(['Providers', 'Default provider', 'Task routes', 'Step timeout', 'Test', 'Runtime']);
+    expect(headings).toEqual(['Providers', 'Default provider', 'Task routes', 'Step timeout', 'Test', 'Content', 'Runtime']);
     // The plain-language purpose lines (cou-84), one under each heading.
     expect(screen.getByText(/The models this runtime can call/)).toBeTruthy();
     expect(screen.getByText(/The model that answers when nothing more specific applies/)).toBeTruthy();

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -4,6 +4,8 @@ import type { Health as HealthData, SettingsErrorBody, SettingsView } from '../.
 import { Health } from '../../settings/Health';
 import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
+import { ContentGroup } from './ContentGroup';
+import { DoctorLedger } from './DoctorLedger';
 import {
   emptyRoute,
   emptyRow,
@@ -80,8 +82,10 @@ export function SettingsPage({ health }: SettingsPageProps): JSX.Element {
               </ul>
             )}
           </section>
+          <ContentGroup />
           <section className="v2-group">
             <Health health={health} effective={view.effective} file={view.file} />
+            <DoctorLedger />
           </section>
         </>
       )}

--- a/runtime/ui/vite.config.ts
+++ b/runtime/ui/vite.config.ts
@@ -14,7 +14,7 @@ import { defineConfig } from 'vite';
  */
 const RUNTIME_URL = process.env.RUNTIME_URL ?? 'http://127.0.0.1:7431';
 
-const API_PREFIXES = ['/health', '/threads', '/runs', '/vault', '/settings', '/proposals'];
+const API_PREFIXES = ['/health', '/threads', '/runs', '/vault', '/settings', '/proposals', '/docket', '/setup', '/content', '/doctor'];
 
 export default defineConfig({
   plugins: [react()],

--- a/skills/doctor/SKILL.md
+++ b/skills/doctor/SKILL.md
@@ -5,6 +5,8 @@ description: "Health check for a Counsel OS install: legal-root config, vault st
 
 # Doctor — Install Health Check
 
+> The vault checks below (steps 1, 2, 4B, 8, 10, 11) also run in the runtime, read-only: `bun runtime/src/cli.ts doctor`, `GET /doctor`, and **Check the vault** under Settings › Runtime in the web UI (spec 2026-09-01 §7). The environment checks (pandoc, python, the browse binary, qmd) stay here.
+
 You are running a health check on the user's Counsel OS install. Run every check below, collect the results, and present them as ONE table at the end — do not dump raw command output between checks, and do not narrate each step. Doctor is **read-only**: it never writes to the vault, the plugin tree, the config, or the home directory. Every non-healthy row gets a one-line fix command instead.
 
 Status meanings:

--- a/skills/update/SKILL.md
+++ b/skills/update/SKILL.md
@@ -190,6 +190,8 @@ Skip silently if the user does not use browse.
 
 ## Step 4: Compare Vault Content
 
+> The runtime carries the same rules (spec 2026-09-01 §6): `bun runtime/src/cli.ts update-content [--yes|--dry-run]`, `GET /content/status` + `POST /content/apply`, and the **Content** group in the web UI's Settings. A vault set up by the runtime keeps `.counsel/content-state.json` (what it received) and `.counsel/received/` (the practice seeds as received), which is what the runtime diffs practice against.
+
 Compare the plugin's shipped content to the user's vault.
 
 ### Law areas: plugin-managed by default


### PR DESCRIPTION
Runtime-owned setup, stage 2 — spec `docs/superpowers/specs/2026-09-01-runtime-owned-setup-design.md` §6–§7 (steps 5–6). Plan: `docs/superpowers/plans/2026-09-01-content-update-doctor.md`.

**Content updates** (`runtime/src/content/update.ts`) — the rules of `skills/update/SKILL.md` steps 4–7, mechanically. Every shipped law file is compared with the vault by frontmatter-stripped body hash against BOTH the shipped hash and the hash the vault last received (`.counsel/content-state.json`): `current` / `update-available` / `user-modified` (`managed-by: user`, `law_management: user`, an edited copy, or no baseline) / `missing` / `vault-only`. Practice is user-owned: never diffed seed-vs-vault, never overwritten; an upstream change is detected against the received seed's hash and shown as a unified diff against the received SNAPSHOT (`.counsel/received/`, written by `runSetup` from this PR on; a vault without one diffs against its own copy and says so). `applyUpdates` refuses the whole call on one non-applicable path. `auto_apply_law_updates: true` applies law updates at serve start (one log line). `readVaultConfig` gains the two flags.

**Doctor** (`runtime/src/doctor/`) — steps 1, 2, 4B, 8, 10, 11 of `skills/doctor/SKILL.md`, read-only, no environment checks: root/config marker, structure with counts (index.md excluded, overrides honoured), law currency against `frontmatter-policy.json` cadences (the Python's month arithmetic), vault git via an injected runner, standards ↔ library numeric divergence (time units only — see decisions), matter-aware law impact (frontmatter `law_areas` or the body's `**Law areas:**` line; folder matters included).

**Surfaces:** `GET /content/status`, `POST /content/apply`, `GET /doctor` (prefixes added to `API_PREFIXES` and the dev proxy); `counsel-os update-content [--yes|--dry-run]`, `counsel-os doctor` (exit 1 on a broken vault); Settings gains a **Content** group (versions, summary, ledger with apply/add per row, inline practice diffs, apply all) and **Check the vault** under Runtime (findings as a ledger, severity as set text). One line in each of the two skills points at the runtime.

**Tests:** `bun run test` 740 · `bun run ui:test` 417 · both typechecks · `ui:build`. Exercised on a fresh temp vault: `update-content --dry-run` reports everything current; `doctor` prints the table.

**Decisions the spec left open**
- The consistency check compares time units only (hours/days/months/years). With `%`/`×` included it flagged an uptime against a credit. On the real seed it still reports 4 possible divergences (assignment 60 vs 90 days, non-solicitation 12–18 vs 6 months, service-levels 1–4 vs 48 hours, escrow 30–60 vs 90 days) — those look like genuine seed inconsistencies worth a look, not heuristic noise.
- Law floors are not compared mechanically; the finding says so.
- Backups (doctor step 7) are out: the runtime has no backup command yet.
- A practice file the vault lacks may be added; a changed one is diff-only (no automatic merge of reference sections).