### PR TITLE
Hero-flow polish: outline without markup, index after every step, Word-path verbs, folder-matter documents, cut titles, attachment chips, answers open with substance

### DIFF
--- a/primitives/draft.md
+++ b/primitives/draft.md
@@ -300,7 +300,9 @@ Check what's available:
 
 Tracked changes are generated natively (`apply_redlines.py --track` writes
 `w:ins`/`w:del` revision markup directly), so Microsoft Word is NOT required
-to produce a redline.
+to produce a redline — and in the counsel-os app the reader shows the result
+with its strikes, inserts and comments, so the answer names the redline's
+vault path rather than asking the lawyer to open Word to check it.
 
 | Tier | Requirements | Action |
 |---|---|---|

--- a/primitives/redline-output.md
+++ b/primitives/redline-output.md
@@ -142,10 +142,16 @@ Before shipping the tracked-changes output:
    ```
    On a `.docx` it checks the accept-all view — the document as it will read once the changes are accepted. Fix any `error`-severity findings (dangling cross-references especially — renumbering is exactly when these appear) before proceeding. See `read --qa`.
 2. **Extract and re-read the revisions** — `extract_redlines.py` on the output lists every insertion/deletion with its paragraph context; confirm each maps to an intended edit and nothing extra crept in.
-3. **Open the redline in Word (or ask the user to)** and confirm:
+3. **Look at the redline** and confirm:
    - Strike and insert markings render where expected
    - No insertions are merged into adjacent text incorrectly
    - The flow reads naturally with tracked changes accepted
+
+   In the counsel-os app the reader renders tracked changes and comments
+   directly: point the lawyer at the redline's vault path (and at the
+   "redlined document" slip in the thread when the runtime produced one) —
+   do not tell them to open Word to see whether it worked. Word remains the
+   place to confirm how it will look to the counterparty.
 
 Don't ship without visual verification.
 

--- a/runtime/src/content/manifest.ts
+++ b/runtime/src/content/manifest.ts
@@ -854,7 +854,7 @@ export const MANIFEST: ContentManifest = {
       "hash": "e1fdfa347fd6c588cb80a82cb3f8976bca16230a2c58767ab4ce3ff9c16da987"
     },
     "primitives/draft.md": {
-      "hash": "58169a60ca9dd60315857e1675f9e7aa723b516b08ad98a1d5e245bfc14f53de"
+      "hash": "70ca0c8ef201df8c5bb9f33dc76a65e2cf05e03d142ab31effabe48bef67fc36"
     },
     "primitives/evaluate.md": {
       "hash": "2d832826117b04e90197a054aad436389a5e7233fe8061f6f0460dd6564a39a4"
@@ -863,7 +863,7 @@ export const MANIFEST: ContentManifest = {
       "hash": "b5450cb972146345e732e52ce4a3e31c180059ae65c7485a81a604fac2cc8dfd"
     },
     "primitives/redline-output.md": {
-      "hash": "c5dc33723e2fb4d76f2ddac3c76147406a691314c2db0777d39708126ed530d9"
+      "hash": "3ba8a24311a8410e4075b6b518d2f58af2b20a88940acd8bff1c610fa86b64f8"
     },
     "primitives/remember.md": {
       "hash": "2125beb53f6072aca69a8bb720b7ed5478abc15951f911e6ab36c9ddeaafab66"
@@ -872,7 +872,7 @@ export const MANIFEST: ContentManifest = {
       "hash": "a7aa8f6e808a17e7de8687d4948cdd49c1d094e2fe76283d788c199498c6ad14"
     },
     "skills/counsel/SKILL.md": {
-      "hash": "95b9b1011e261549c94c4b1fe2e902cf0d0dd252699a8aaca2ac9ee6e6fa3e79"
+      "hash": "ed6233198e5ac4d59b8c5ffa3c3e903792eeaeada8e2b8663c40f80efc2838ba"
     },
     "skills/demo/assets/sample-mutual-nda.docx": {
       "hash": "67025b706197311c96327e35df6401d78135b330567ecde92131067f405bd6e5"

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -181,7 +181,7 @@ describe('ThreadStore', () => {
     await store.append('default', header.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: long });
 
     const listed = await store.list('default');
-    expect(listed[0]?.title).toBe('What is our position on liability caps in vendor agreements');
+    expect(listed[0]?.title).toBe('What is our position on liability caps in vendor agreements…');
 
     const onDisk = JSON.parse(readFileSync(join(root, '.counsel', 'threads', 'default', `${header.id}.json`), 'utf8')) as { title?: string };
     expect(onDisk.title).toBeUndefined();

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -69,7 +69,8 @@ function titleFrom(message: string): string {
   if (line.length <= TITLE_MAX) return line;
   const cut = line.slice(0, TITLE_MAX);
   const space = cut.lastIndexOf(' ');
-  return (space > TITLE_MAX / 2 ? cut.slice(0, space) : cut).trimEnd();
+  // A cut title says it was cut: "…and" read as a sentence that ends there.
+  return `${(space > TITLE_MAX / 2 ? cut.slice(0, space) : cut).trimEnd()}…`;
 }
 
 export class ThreadStore {

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -405,6 +405,8 @@ a { color: var(--accent); }
 .v2-transcript { flex: 1; overflow-y: auto; padding: var(--s5) var(--s6); display: flex; flex-direction: column; gap: var(--s5); }
 .v2-turn { max-width: 56rem; width: 100%; margin: 0 auto; }
 .v2-turn-user { display: flex; justify-content: flex-end; }
+.v2-user-text p { margin: 0; }
+.v2-user-files { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
 .v2-user-text {
   margin: 0;
   max-width: 44rem;
@@ -507,6 +509,11 @@ a { color: var(--accent); }
 .v2-vrow:hover { background: var(--bg-raised); }
 .v2-vrow[aria-current="page"] { background: var(--bg-hover); color: var(--fg); }
 .v2-vrow-ind { padding-left: 24px; }
+/* A folder matter: chevron beside the title row; its documents indent under it. */
+.v2-vmatter-row { display: flex; align-items: center; }
+.v2-vmatter-row .v2-vrow { flex: 1; min-width: 0; }
+.v2-vfold { background: none; border: none; padding: 4px 4px 4px 8px; cursor: pointer; color: var(--fg-faint); display: flex; align-items: center; flex-shrink: 0; }
+.v2-vmatter .v2-vrow-ind { padding-left: 32px; }
 .v2-vdir { font-weight: 500; }
 .v2-tri { color: var(--fg-faint); font-size: 10px; width: 10px; flex-shrink: 0; }
 .v2-vname { overflow: hidden; text-overflow: ellipsis; }

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -771,8 +771,6 @@ describe('Shell, a printed link opened into the session-lost tab', () => {
     expect(globalThis.location.hash).not.toContain('token');
   });
 });
-  });
-});
 
 describe('Shell, the vault index refresh', () => {
   test('an upload announcement re-reads /vault/index', async () => {

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { clearToken, TOKEN_KEY } from '../api/token';
 import { routeFromHash, vaultPathFromHash } from '../app';
 import type { Health, SettingsView, Thread, ThreadEvent, ThreadHeader } from '../api/types';
+import { VAULT_CHANGED_EVENT } from './intake';
 import { Shell } from './Shell';
 
 const realFetch = globalThis.fetch;
@@ -768,5 +769,30 @@ describe('Shell, a printed link opened into the session-lost tab', () => {
     expect(screen.queryByLabelText('Session lost')).toBeNull();
     expect(sessionStorage.getItem(TOKEN_KEY)).toBe(hex);
     expect(globalThis.location.hash).not.toContain('token');
+  });
+});
+  });
+});
+
+describe('Shell, the vault index refresh', () => {
+  test('an upload announcement re-reads /vault/index', async () => {
+    sessionStorage.setItem(TOKEN_KEY, 'test-token');
+    const fetched: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      fetched.push(url);
+      if (url.startsWith('/health')) return json({ ...health, setup: false });
+      if (url === '/threads') return json([]);
+      if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
+      if (url.startsWith('/vault/index')) return json(['matters/inbox/nda.docx']);
+      if (url.startsWith('/proposals')) return json([]);
+      if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
+      return json([]);
+    }) as unknown as typeof fetch;
+    globalThis.location.hash = '#/';
+    render(<Shell />);
+    await waitFor(() => expect(fetched.filter(u => u.startsWith('/vault/index'))).toHaveLength(1));
+    globalThis.dispatchEvent(new Event(VAULT_CHANGED_EVENT));
+    await waitFor(() => expect(fetched.filter(u => u.startsWith('/vault/index'))).toHaveLength(2));
   });
 });

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -5,6 +5,7 @@ import { onUnauthorized } from '../api/unauthorized';
 import type { Health, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
+import { VAULT_CHANGED_EVENT } from './intake';
 import type { ComposerSeed } from './chat/Composer';
 import { Drawer } from './Drawer';
 import { HomePage } from './home/HomePage';
@@ -259,6 +260,14 @@ export function Shell(): JSX.Element {
 
   useEffect(() => onUnauthorized(() => setUnauthorized(true)), []);
 
+  /** An upload landed a file in the vault (`intake.ts` announces it): the
+   * index must know the path before the message that names it is sent. */
+  useEffect(() => {
+    const onChanged = (): void => void loadIndex();
+    globalThis.addEventListener(VAULT_CHANGED_EVENT, onChanged);
+    return () => globalThis.removeEventListener(VAULT_CHANGED_EVENT, onChanged);
+  }, [loadIndex]);
+
   const loadThreads = useCallback(async (): Promise<{ threads: ThreadHeader[]; fresh: boolean }> => {
     const ticket = ++listSeq.current;
     const list = await fetchJson<ThreadHeader[]>('/threads');
@@ -429,7 +438,12 @@ export function Shell(): JSX.Element {
                   }
                   void loadThreads();
                 }}
-                onThreadTouched={() => void loadThreads()}
+                onThreadTouched={() => {
+                  void loadThreads();
+                  // A finished step may have written files (a redline beside
+                  // its source): their paths must become chips in the answer.
+                  void loadIndex();
+                }}
                 seed={seed}
                 onSeedUsed={seedUsed}
                 initialAsk={initialAsk}

--- a/runtime/ui/src/v2/chat/Steps.test.tsx
+++ b/runtime/ui/src/v2/chat/Steps.test.tsx
@@ -54,3 +54,13 @@ describe('Steps', () => {
     expect(screen.getByText('error')).toBeTruthy();
   });
 });
+
+describe('Steps spacing', () => {
+  test('a verb with no object is followed by the time with one separator, no stray space', () => {
+    const tool: ToolCallView = { id: 'c-9', name: 'docket_sweep', input: {}, hasResult: true, output: { deadlines: [] }, isError: false };
+    render(<Steps tools={[tool]} ms={{ 'c-9': 12 }} />);
+    const line = document.querySelector('[data-testid="step-c-9"]')!;
+    expect(line.textContent).toMatch(/^Ran docket_sweep · 12 ms/);
+    expect(line.textContent).not.toContain('  ');
+  });
+});

--- a/runtime/ui/src/v2/chat/Steps.tsx
+++ b/runtime/ui/src/v2/chat/Steps.tsx
@@ -44,13 +44,21 @@ function Step({
 
   return (
     <li className={`v2-step v2-step-${state}`} data-testid={`step-${tool.id}`}>
-      <span className="v2-step-verb">{verb}</span>{' '}
+      <span className="v2-step-verb">{verb}</span>
+      {/* The space belongs to the object: a verb with no object read as
+          "Ran check_document  · 12 ms", two spaces before the dot. */}
       {object === undefined ? null : path !== null && onOpenFile !== undefined ? (
-        <button type="button" className="v2-step-path" onClick={() => onOpenFile(path)}>
-          {object}
-        </button>
+        <>
+          {' '}
+          <button type="button" className="v2-step-path" onClick={() => onOpenFile(path)}>
+            {object}
+          </button>
+        </>
       ) : (
-        <code className="v2-step-object">{object}</code>
+        <>
+          {' '}
+          <code className="v2-step-object">{object}</code>
+        </>
       )}
       {ms === undefined ? null : <span className="v2-step-ms"> · {Math.round(ms)} ms</span>}
       {state === 'running' ? (

--- a/runtime/ui/src/v2/chat/Turn.test.tsx
+++ b/runtime/ui/src/v2/chat/Turn.test.tsx
@@ -2,7 +2,7 @@ import { cleanup, render, screen, userEvent } from '../../test/dom';
 
 import { afterEach, describe, expect, test } from 'bun:test';
 import { emptyAssistantTurn, type AssistantTurn } from '../../chat/turns';
-import { TurnView } from './Turn';
+import { splitAttachments, TurnView } from './Turn';
 
 afterEach(cleanup);
 
@@ -226,5 +226,27 @@ describe('TurnView step failure (cou-95)', () => {
     expect(document.querySelector('.v2-step-failure p')?.textContent).toBe('Ollama is not running on this machine. Start it, then retry.');
     expect(document.querySelector('details summary')?.textContent).toBe('show answer');
     expect(document.querySelector('details pre')?.textContent).toBe('partial');
+  });
+});
+
+describe('TurnView user bubble attachments', () => {
+  test('the trailing attachment line reads as chips, the text stays plain', () => {
+    render(<TurnView turn={{ kind: 'user', content: 'Review this NDA.\n\n`matters/acme/nda.docx` `practice/standards/nda.md`' }} threadId="t-1" onReload={() => {}} />);
+    expect(document.querySelector('.v2-user-text p')?.textContent).toBe('Review this NDA.');
+    const chips = Array.from(document.querySelectorAll('.v2-user-files .v2-file-chip'), el => el.textContent);
+    expect(chips).toEqual(['matters/acme/nda.docx', 'practice/standards/nda.md']);
+    expect(document.querySelector('.v2-user-text')?.textContent).not.toContain('`');
+  });
+
+  test('a message with no attachment line renders as it was typed, backticks included', () => {
+    render(<TurnView turn={{ kind: 'user', content: 'What does `Effective Date` mean here?' }} threadId="t-1" onReload={() => {}} />);
+    expect(document.querySelector('.v2-user-text p')?.textContent).toBe('What does `Effective Date` mean here?');
+    expect(document.querySelector('.v2-user-files')).toBeNull();
+  });
+
+  test('splitAttachments only recognises the last line, by shape', () => {
+    expect(splitAttachments('`a.md`')).toEqual({ text: '', files: ['a.md'] });
+    expect(splitAttachments('x\n`a.md` `b/c.docx`\n')).toEqual({ text: 'x', files: ['a.md', 'b/c.docx'] });
+    expect(splitAttachments('`a.md` and more')).toEqual({ text: '`a.md` and more', files: [] });
   });
 });

--- a/runtime/ui/src/v2/chat/Turn.tsx
+++ b/runtime/ui/src/v2/chat/Turn.tsx
@@ -29,6 +29,21 @@ export interface TurnProps {
   onRetry?: () => void;
 }
 
+/**
+ * The attachment line `withAttachments` puts at the end of a message —
+ * backticked vault paths, space-separated — read as chips, the way the
+ * composer showed them. User text is never markdown-rendered; only that one
+ * trailing line is recognised, by shape.
+ */
+export function splitAttachments(content: string): { text: string; files: string[] } {
+  const trimmed = content.replace(/\s+$/, '');
+  const lines = trimmed.split('\n');
+  const last = lines[lines.length - 1] ?? '';
+  if (!/^`[^`\n]+`(\s+`[^`\n]+`)*$/.test(last.trim())) return { text: content, files: [] };
+  const files = Array.from(last.matchAll(/`([^`]+)`/g), m => m[1]!);
+  return { text: lines.slice(0, -1).join('\n').replace(/\s+$/, ''), files };
+}
+
 /** The record's per-call timings, keyed onto this turn's tool ids. The
  * record lists calls in order without ids, so it is paired by position and
  * checked by name; a `null` ms (never paired with a result) is left out. */
@@ -156,9 +171,21 @@ function StepFailure({
  */
 export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onReload, onDecided, onOpenFile, vaultPaths, onRetry }: TurnProps): JSX.Element {
   if (turn.kind === 'user') {
+    const { text, files } = splitAttachments(turn.content);
     return (
       <article className="v2-turn v2-turn-user">
-        <p className="v2-user-text">{turn.content}</p>
+        <div className="v2-user-text">
+          {text === '' ? null : <p>{text}</p>}
+          {files.length === 0 ? null : (
+            <div className="v2-user-files">
+              {files.map(file => (
+                <code key={file} className="v2-file-chip">
+                  {file}
+                </code>
+              ))}
+            </div>
+          )}
+        </div>
       </article>
     );
   }

--- a/runtime/ui/src/v2/intake.ts
+++ b/runtime/ui/src/v2/intake.ts
@@ -55,6 +55,10 @@ export function refusalFor(name: string, err: unknown): string {
   return `Could not add ${name}: ${err instanceof Error ? err.message : String(err)}`;
 }
 
+/** Fired on `globalThis` when an upload lands a file in the vault, so the
+ * Shell refreshes its path index without a prop through every page. */
+export const VAULT_CHANGED_EVENT = 'counsel:vault-changed';
+
 export type IntakeStatus = { kind: 'busy'; text: string } | { kind: 'done'; up: Uploaded; text: string } | { kind: 'error'; text: string };
 
 /** The files a drop carried, Word documents first (so a mixed drop adds
@@ -87,6 +91,7 @@ export async function intake(files: File[], dest: string | undefined, onStatus: 
   try {
     const up = await uploadFile(file, dest);
     onStatus({ kind: 'done', up, text: addedLine(up).text });
+    globalThis.dispatchEvent(new Event(VAULT_CHANGED_EVENT));
     return up;
   } catch (err) {
     if (err instanceof ApiError && err.status === 401) return null;

--- a/runtime/ui/src/v2/threads.test.ts
+++ b/runtime/ui/src/v2/threads.test.ts
@@ -21,8 +21,9 @@ describe('titleFor', () => {
 
   test('cut at 60 characters, no trailing space', () => {
     const long = 'a'.repeat(50) + ' ' + 'b'.repeat(20);
-    expect(titleFor(long)).toBe('a'.repeat(50));
-    expect(titleFor('x'.repeat(61))).toBe('x'.repeat(60));
+    // Cut on the word, and the cut is visible.
+    expect(titleFor(long)).toBe(`${'a'.repeat(50)}…`);
+    expect(titleFor('x'.repeat(61))).toBe(`${'x'.repeat(60)}…`);
   });
 });
 

--- a/runtime/ui/src/v2/threads.ts
+++ b/runtime/ui/src/v2/threads.ts
@@ -21,7 +21,8 @@ export function titleFor(message: string): string {
   const space = cut.lastIndexOf(' ');
   // Only back off to a space in the second half: `'A ' + 'x'.repeat(70)` has
   // one at index 1, and honouring it would title the thread "A".
-  return (space > TITLE_MAX / 2 ? cut.slice(0, space) : cut).trimEnd();
+  // A cut title says it was cut: "…and" read as a sentence that ends there.
+  return `${(space > TITLE_MAX / 2 ? cut.slice(0, space) : cut).trimEnd()}…`;
 }
 
 /**

--- a/runtime/ui/src/v2/vault/VaultTree.test.tsx
+++ b/runtime/ui/src/v2/vault/VaultTree.test.tsx
@@ -115,3 +115,60 @@ describe('VaultTree', () => {
     expect(opened).toEqual(['practice/standards/nda.md', 'matters/2026-06-vendora.md']);
   });
 });
+
+describe('VaultTree, folder matters', () => {
+  const folderOverview: VaultOverview = {
+    matters: [
+      { path: 'matters/2026-06-vendora.md', title: 'Vendora × Worldpay', frontmatter: {}, mtimeMs: 1 },
+      { path: 'matters/sample-mutual-nda/matter.md', title: 'Acme — Mutual NDA (sample)', frontmatter: {}, mtimeMs: 2 },
+    ],
+    groups: { practice: 0, knowledge: 0, other: 0 },
+  };
+  const docs: VaultEntry[] = [
+    { path: 'matters/sample-mutual-nda/matter.md', kind: 'file' },
+    { path: 'matters/sample-mutual-nda/sample-mutual-nda.docx', kind: 'file' },
+    { path: 'matters/sample-mutual-nda/sample-mutual-nda-redline-2026-09-01.docx', kind: 'file' },
+  ];
+
+  beforeEach(() => {
+    const prev = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/vault/list?dir=matters%2Fsample-mutual-nda') return json(docs);
+      return prev(input, init);
+    }) as unknown as typeof fetch;
+  });
+
+  test('a folder matter unfolds its documents, prettified; a flat matter has no chevron', async () => {
+    const opened: string[] = [];
+    render(<VaultTree overview={folderOverview} root={[{ path: 'matters', kind: 'dir' }]} selected={null} onOpen={path => opened.push(path)} />);
+    expect(screen.queryByRole('button', { name: /documents in Vendora/ })).toBeNull();
+    expect(screen.queryByText('Sample mutual nda')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show documents in Acme — Mutual NDA (sample)' }));
+    await waitFor(() => expect(screen.getByText('Sample mutual nda')).toBeTruthy());
+    expect(screen.getByText('Sample mutual nda redline 2026 09 01')).toBeTruthy();
+    // matter.md itself is the matter row, not a document under it.
+    expect(screen.queryByText('Matter')).toBeNull();
+    expect(screen.getByText('Sample mutual nda redline 2026 09 01').closest('button')?.getAttribute('title')).toBe('sample-mutual-nda-redline-2026-09-01.docx');
+
+    await userEvent.click(screen.getByText('Sample mutual nda redline 2026 09 01'));
+    expect(opened).toEqual(['matters/sample-mutual-nda/sample-mutual-nda-redline-2026-09-01.docx']);
+    // The title row still opens the matter file.
+    await userEvent.click(screen.getByText('Acme — Mutual NDA (sample)'));
+    expect(opened.at(-1)).toBe('matters/sample-mutual-nda/matter.md');
+  });
+
+  test('a document open inside a folder matter unfolds that matter', async () => {
+    render(
+      <VaultTree
+        overview={folderOverview}
+        root={[{ path: 'matters', kind: 'dir' }]}
+        selected="matters/sample-mutual-nda/sample-mutual-nda-redline-2026-09-01.docx"
+        onOpen={() => {}}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('Sample mutual nda redline 2026 09 01')).toBeTruthy());
+    expect(screen.getByText('Sample mutual nda redline 2026 09 01').closest('button')?.getAttribute('aria-current')).toBe('page');
+  });
+});

--- a/runtime/ui/src/v2/vault/VaultTree.tsx
+++ b/runtime/ui/src/v2/vault/VaultTree.tsx
@@ -3,7 +3,13 @@ import { ApiError, fetchJson } from '../../api/client';
 import type { VaultEntry, VaultOverview } from '../../api/types';
 import { ancestorsOf, baseName, orderEntries, ROOT } from '../../vault/Tree';
 import { Chevron } from '../icons';
+import { prettifyName } from './frontmatter';
 import { groupRoot, monthLabel } from './tree';
+
+/** A folder matter is `matters/<dir>/matter.md`; its documents live beside it. */
+export function matterFolderOf(path: string): string | null {
+  return path.endsWith('/matter.md') ? path.slice(0, -'/matter.md'.length) : null;
+}
 
 export interface VaultTreeProps {
   overview: VaultOverview;
@@ -72,6 +78,19 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
     if (groups.other.some(entry => selected === entry.path || selected.startsWith(`${entry.path}/`))) setOtherOpen(true);
   }, [selected, groups.other, ensure]);
 
+  /** A selected document inside a folder matter unfolds that matter, so the
+   * open redline has a row marking where it lives. */
+  useEffect(() => {
+    if (selected === null) return;
+    for (const matter of groups.matters) {
+      const folder = matterFolderOf(matter.path);
+      if (folder !== null && selected !== matter.path && selected.startsWith(`${folder}/`)) {
+        setOpen(prev => (prev.has(folder) ? prev : new Set(prev).add(folder)));
+        ensure(folder);
+      }
+    }
+  }, [selected, groups.matters, ensure]);
+
   const toggle = (dir: string): void => {
     setOpen(prev => {
       const next = new Set(prev);
@@ -82,13 +101,13 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
     ensure(dir);
   };
 
-  const fileRow = (path: string, name: string, indent: boolean): JSX.Element => (
+  const fileRow = (path: string, name: string, indent: boolean, hover: string = name): JSX.Element => (
     <button
       key={path}
       type="button"
       className={indent ? 'v2-vrow v2-vrow-ind' : 'v2-vrow'}
       aria-current={selected === path ? 'page' : undefined}
-      title={name}
+      title={hover}
       onClick={() => onOpen(path)}
     >
       <span className="v2-vname">{name}</span>
@@ -121,21 +140,55 @@ export function VaultTree({ overview, root, selected, onOpen }: VaultTreeProps):
       {groups.matters.length === 0 ? null : (
         <>
           <div className="v2-vgroup">Matters</div>
-          {groups.matters.map(matter => (
-            <button
-              key={matter.path}
-              type="button"
-              className="v2-vrow v2-vrow-ind"
-              aria-current={selected === matter.path ? 'page' : undefined}
-              // The 300px pane clips most matter titles; the whole title
-              // is one hover away (cou-93 item 5).
-              title={matter.title}
-              onClick={() => onOpen(matter.path)}
-            >
-              <span className="v2-vname">{matter.title}</span>
-              <span className="v2-vmonth">{monthLabel(matter)}</span>
-            </button>
-          ))}
+          {groups.matters.map(matter => {
+            const folder = matterFolderOf(matter.path);
+            const row = (
+              <button
+                key={matter.path}
+                type="button"
+                className={folder === null ? 'v2-vrow v2-vrow-ind' : 'v2-vrow'}
+                aria-current={selected === matter.path ? 'page' : undefined}
+                // The 300px pane clips most matter titles; the whole title
+                // is one hover away (cou-93 item 5).
+                title={matter.title}
+                onClick={() => onOpen(matter.path)}
+              >
+                <span className="v2-vname">{matter.title}</span>
+                <span className="v2-vmonth">{monthLabel(matter)}</span>
+              </button>
+            );
+            if (folder === null) return row;
+            // A folder matter carries its documents (the NDA, its redline):
+            // a chevron unfolds them under the matter, prettified like any
+            // file row, so a lawyer finds the redline where the matter is.
+            const isOpen = open.has(folder);
+            const docs = (levels[folder] ?? []).filter(child => child.path !== matter.path);
+            return (
+              <div key={matter.path} className="v2-vmatter">
+                <div className="v2-vmatter-row">
+                  <button
+                    type="button"
+                    className="v2-vfold"
+                    aria-label={`${isOpen ? 'Hide' : 'Show'} documents in ${matter.title}`}
+                    aria-expanded={isOpen}
+                    onClick={() => toggle(folder)}
+                  >
+                    <span className="v2-tri" aria-hidden="true">
+                      <Chevron open={isOpen} />
+                    </span>
+                  </button>
+                  {row}
+                </div>
+                {isOpen
+                  ? docs.map(child =>
+                      child.kind === 'dir'
+                        ? dirNode(child, true)
+                        : fileRow(child.path, prettifyName(baseName(child.path)), true, baseName(child.path)),
+                    )
+                  : null}
+              </div>
+            );
+          })}
         </>
       )}
 

--- a/runtime/ui/src/v2/vault/outline.test.ts
+++ b/runtime/ui/src/v2/vault/outline.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { outlineOf } from './outline';
+import { outlineOf, stripCritic } from './outline';
 
 describe('outlineOf', () => {
   test('H2s in order; H1s and H3s are not sections', () => {
@@ -12,5 +12,21 @@ describe('outlineOf', () => {
 
   test('no H2s, no outline', () => {
     expect(outlineOf('just prose\n')).toEqual([]);
+  });
+
+  test('a converted Word document\'s tracked changes do not leak into the outline', () => {
+    expect(outlineOf('## {++No ++}Residuals\n## Term{-- (old)--}\n## Notice{>>why<<}\n## {~~two~>one~~} year\n')).toEqual([
+      'No Residuals',
+      'Term',
+      'Notice',
+      'one year',
+    ]);
+  });
+});
+
+describe('stripCritic', () => {
+  test('keeps insertions, drops deletions and comments, resolves substitutions', () => {
+    expect(stripCritic('{++a++} b {--c--} {>>d<<} {~~e~>f~~}')).toBe('a b f');
+    expect(stripCritic('plain')).toBe('plain');
   });
 });

--- a/runtime/ui/src/v2/vault/outline.ts
+++ b/runtime/ui/src/v2/vault/outline.ts
@@ -1,5 +1,19 @@
 /** The reading pane's outline column (spec §3.4): the body's H2s, in order.
  * Fenced code is skipped so an example heading is not a section. */
+/** CriticMarkup a converted Word document carries (`{++ins++}`, `{--del--}`,
+ * `{>>comment<<}`, `{~~a~>b~~}`), read the way the page renders it:
+ * insertions kept, deletions and comments dropped, substitutions resolved to
+ * their new text. The outline is a list of headings, not a redline. */
+export function stripCritic(text: string): string {
+  return text
+    .replace(/\{\+\+([\s\S]*?)\+\+\}/g, '$1')
+    .replace(/\{--[\s\S]*?--\}/g, '')
+    .replace(/\{>>[\s\S]*?<<\}/g, '')
+    .replace(/\{~~[\s\S]*?~>([\s\S]*?)~~\}/g, '$1')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 export function outlineOf(body: string): string[] {
   const out: string[] = [];
   let fenced = false;
@@ -10,7 +24,7 @@ export function outlineOf(body: string): string[] {
     }
     if (fenced) continue;
     const m = /^##\s+(.+)$/.exec(line);
-    if (m !== null) out.push(m[1]!.trim());
+    if (m !== null) out.push(stripCritic(m[1]!));
   }
   return out;
 }

--- a/runtime/ui/src/v2/verbs.test.ts
+++ b/runtime/ui/src/v2/verbs.test.ts
@@ -27,6 +27,14 @@ describe('verbFor', () => {
     expect(verbFor(tool('vault_list', {}))).toEqual({ verb: 'Listed the vault' });
   });
 
+  test('the Word read path reads as file verbs, and their paths open the reader', () => {
+    expect(verbFor(tool('docx_read', { path: 'matters/acme/nda.docx' }))).toEqual({ verb: 'Read', object: 'matters/acme/nda.docx' });
+    expect(verbFor(tool('extract_redlines', { path: 'matters/acme/nda-redline.docx' })).verb).toBe('Extracted changes from');
+    expect(verbFor(tool('check_document', { path: 'matters/acme/nda.docx' })).verb).toBe('Checked');
+    expect(pathOf(tool('docx_read', { path: 'matters/acme/nda.docx' }))).toBe('matters/acme/nda.docx');
+    expect(pathOf(tool('check_document', { path: 'matters/acme/nda.docx' }))).toBe('matters/acme/nda.docx');
+  });
+
   test('a nameless tool never reads as Ran <argument>', () => {
     // Threads persisted before the harness named its results (cou-78).
     expect(verbFor(tool('', { dir: '.' })).verb).toBe('Called a tool');

--- a/runtime/ui/src/v2/verbs.ts
+++ b/runtime/ui/src/v2/verbs.ts
@@ -18,6 +18,11 @@ const TABLE: Record<string, string> = {
   read_primitive: 'Consulted primitive',
   propose_update: 'Proposed',
   vault_write: 'Wrote',
+  // The Word read path (docx stage 1): file verbs, so their paths open the
+  // reader like a vault_read does.
+  docx_read: 'Read',
+  extract_redlines: 'Extracted changes from',
+  check_document: 'Checked',
 };
 
 /** The platform's script tools (`runtime/src/tools/builtin.ts`) — the one
@@ -25,8 +30,6 @@ const TABLE: Record<string, string> = {
  * run. Everything else unknown reads "Called". */
 const SCRIPT_TOOLS: ReadonlySet<string> = new Set([
   'docket_sweep',
-  'extract_redlines',
-  'check_document',
   'clean_format',
   'apply_redlines',
   'word_compare',
@@ -35,7 +38,7 @@ const SCRIPT_TOOLS: ReadonlySet<string> = new Set([
 const SEARCH_LIKE = /grep|search|find/i;
 
 /** The verbs whose object is a vault path a drawer can open. */
-const FILE_VERBS: ReadonlySet<string> = new Set(['Read', 'Proposed', 'Wrote']);
+const FILE_VERBS: ReadonlySet<string> = new Set(['Read', 'Proposed', 'Wrote', 'Extracted changes from', 'Checked']);
 
 function objectOf(input: unknown): string | undefined {
   if (typeof input !== 'object' || input === null) return undefined;

--- a/skills/counsel/SKILL.md
+++ b/skills/counsel/SKILL.md
@@ -358,6 +358,7 @@ User's vault (all knowledge — discovered via config + Knowledge Base Search):
 
 ## Output Standards
 
+- **Open with the substance.** Working narration ("I'll start by reading…", "Let me check…") belongs nowhere in the answer; the first line is the finding, the bottom line, or the document — the work line above the answer already shows what was read.
 - Always provide **specific counter-language** for issues that need revision, not just flags
 - Prioritize by tier: **Tier 1** (must-have) → **Tier 2** (strong preference) → **Tier 3** (nice-to-have)
 - All internal memos are **privileged attorney-client communication** unless stated otherwise


### PR DESCRIPTION
Seven fixes from the end-to-end hero run on a throwaway vault (init with the sample matter → attach the NDA → review → redline → reader → download), each with a test.

1. **Outline**: CriticMarkup stripped from converted Word headings (`{++No ++}Residuals` → `No Residuals`; deletions and comments dropped; substitutions resolved).
2. **Vault index**: refreshed after every finished step (`onThreadTouched`) and after an upload (`counsel:vault-changed` event from `intake.ts`), so a redline a step wrote is a chip in the answer.
3. **Verbs**: `docx_read` → Read, `extract_redlines` → Extracted changes from, `check_document` → Checked; all file verbs (path opens the reader). `Steps` no longer prints two spaces before ` · N ms` when there is no object.
4. **Folder matters** in the vault tree unfold their documents (chevron; lazy `/vault/list?dir=`; prettified names, full filename on hover); a document open inside a folder matter unfolds it.
5. **Titles**: a title cut at 60 characters ends with `…` (UI `titleFor` and the store's derived rule, in step).
6. **User bubble**: the trailing attachment line renders as mono chips, not literal backticks; user text is never markdown-rendered.
7. **Primitives / skill**: `redline-output.md` and `draft.md` point the lawyer at the redline's vault path (the reader renders tracked changes and comments), Word kept as the alternative; `skills/counsel/SKILL.md` output standards: the answer opens with the substance, no working narration. Prompt snapshot and content manifest regenerated.

Tests: `bun run ui:test` 445 pass · `bun run test` 777 pass · both typechecks clean · `ui:build` ok.