### PR TITLE
Retro in the runtime — the practice's feedback loop without the plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to Counsel OS are documented in this file. The format follow
 reconstructed from git history. New entries are prepended automatically by
 `scripts/release.sh`.
 
+## [Unreleased]
+
+Retro in the runtime — the practice's feedback loop without the plugin
+
+- A retro is a thread: `POST /retro` (Home's "run a retro" line when one is due; Settings › Runtime › Run a retro) and `bun runtime/src/cli.ts retro [--since <date>]` open a `Retro · <period>` thread whose header carries `task: retro`. Every step of that thread runs with the retro method (`skills/retro/SKILL.md`, now shipped content) and the runtime's own evidence for the period in its system prompt — conversations and steps by task and provider, runs with cost and errors, proposals by decision, documents produced, matters touched, memory, and the doctor's findings — and every knowledge change the retro suggests comes back as a proposal for the docket.
+- `GET /retro` says when the last retro ran and whether one is due: `retro_cadence_days` in `config.md` (default 90), or for a first retro, a vault with at least 3 matters or 10 conversations. `.counsel/retro.json` records the last retro.
+- A thread header can carry a `task`; the loop runs every step of such a thread as that task when the caller names none.
+
 ## [0.12.0] — 2026-09-01
 
 Standalone foundations — Word documents in TypeScript, runtime-owned setup, drag-in intake, stay signed in, new theme

--- a/docs/superpowers/plans/2026-09-01-runtime-retro.md
+++ b/docs/superpowers/plans/2026-09-01-runtime-retro.md
@@ -1,0 +1,95 @@
+# Retro in the Runtime — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The plugin's quarterly `/counsel-os:retro` has a runtime equivalent, so the practice's feedback loop survives without Claude Code: `POST /retro` and `counsel-os retro` open a retro THREAD whose steps carry the retro method and the runtime's own evidence for the period; every knowledge change the retro proposes lands as a proposal the founder approves in the docket; Home says when a retro is due; Settings runs one.
+
+**Architecture:** A retro is a normal counsel thread with `task: 'retro'` stamped on its header. Nothing special happens in the loop except the system prompt: when a step's task is `retro`, `assembleSystemPrompt` appends two sections — the body of `skills/retro/SKILL.md` (now shipped content) and the runtime's evidence for the period, rendered as markdown by `runtime/src/retro/evidence.ts` from the thread store, the run records, the matter overview, the memory folder and the doctor. `runtime/src/retro/index.ts` owns the cadence rule (`retro_cadence_days` in `config.md`, default 90), the state file `.counsel/retro.json` (`lastRetroAt`, `threadId`, `period`), the "due" verdict, and `startRetro`, which creates the thread, writes the state and returns the short first message. The UI sends that message through the ordinary step path. Writes stay where they are: the model's promotions and the snapshot go through `propose_update`, never a direct write.
+
+**Tech Stack:** Bun 1.3.x, TypeScript strict, `node:fs` for `.counsel/` (as the thread store), React 18 + happy-dom tests.
+
+**Spec:** `skills/retro/SKILL.md` (the method — ported as prompt content, not as code), `primitives/remember.md` (why writes are proposals), `docs/superpowers/specs/2026-09-01-runtime-owned-setup-design.md` §7 (the doctor the evidence reuses).
+
+## Global Constraints
+
+- The retro never writes to the vault itself. Evidence is read-only; the only writes are `.counsel/retro.json` and the thread files. Knowledge changes are proposals through `propose_update`.
+- `skills/retro/SKILL.md` joins `SHIPPED_ROOTS` so the compiled runtime carries it; the manifest is regenerated.
+- The retro method's volume gate stands: the evidence names the counts and the system prompt tells the model to state which mode it runs (statistical vs. harvest) — it is the model's call, not the runtime's.
+- Cadence: `retro_cadence_days` in `config.md` (default 90). Due when the last retro is older than the cadence, or when there has never been one and the vault has at least 3 matters or 10 threads.
+- Every new route's first segment (`retro`) is in `API_PREFIXES` (the vite proxy reads that list).
+- Tests never touch the real `~/.counsel-os` or a real vault.
+- UI: set text, small-caps run-ins, no pills, no modals, no wizard.
+- Commit prefixes `runtime:` / `ui:` / `docs:`; no trailers.
+
+---
+
+## File structure
+
+```
+runtime/src/
+  retro/
+    state.ts        read/write .counsel/retro.json
+    evidence.ts     gatherRetroEvidence, renderRetroEvidence (pure over injected reads)
+    index.ts        retroCadenceDays, retroStatus, startRetro, periodLabel
+    *.test.ts
+  threads/store.ts  ThreadHeader.task; create({ task })
+  loop/run-record.ts listAllRuns(vaultRoot, tenant)
+  loop/prompt.ts    AssembleSystemPromptOptions.sections (appended)
+  loop/counsel-loop.ts  task from header when the step names none; retro sections
+  content/source.ts SHIPPED_ROOTS += 'skills/retro'
+  server/routes.ts  GET /retro, POST /retro; API_PREFIXES += 'retro'
+  cli.ts            retro [--vault] [--since] [--provider]
+runtime/ui/src/
+  api/types.ts      RetroStatus, RetroStart, ThreadHeader.task
+  v2/Shell.tsx      startRetro → select thread, initialAsk
+  v2/home/HomePage.tsx   due line under the subline (onStartRetro)
+  v2/settings/RetroAction.tsx  last run + "Run a retro" (Settings › Runtime)
+  v2/settings/SettingsPage.tsx  mounts RetroAction (onStartRetro)
+  styles.css        .v2-retro-due, .v2-retro
+docs/superpowers/plans/2026-09-01-runtime-retro.md (this)
+CHANGELOG.md, skills/retro/SKILL.md (one note)
+```
+
+---
+
+### Task 1: Retro state + cadence + status
+
+**Files:** create `runtime/src/retro/state.ts`, `runtime/src/retro/index.ts`, tests; modify `runtime/src/vault/resolve-root.ts` (`retroCadenceDays` on `VaultConfig`).
+
+- [ ] Test: `readRetroState` on a vault with no file → `{}`; round-trip write/read; `retroCadenceDays` default 90 and override; `retroStatus` due rules (never run + 2 matters → not due; never run + 3 matters → due; last retro 89 days → not due; 91 → due; `daysSince`, `dueAt`).
+- [ ] Implement; run `bun test runtime/src/retro`; commit `runtime: retro state, cadence and due rule`.
+
+### Task 2: Evidence
+
+**Files:** create `runtime/src/retro/evidence.ts` + test; modify `runtime/src/loop/run-record.ts` (`listAllRuns`).
+
+- [ ] Test on a seeded temp vault: two threads (one in period, one before), step events with tasks/providers, a pending + an approved + a rejected proposal, an artifact event, run records (done, error, timeout), two matters (one touched in period), `memory/patterns.md` with 4 entries, one `memory/retro-2026-05-01.md`, an injected doctor report. Assert the counts and that `renderRetroEvidence` output matches a snapshot.
+- [ ] Implement; commit `runtime: retro evidence — what the runtime knows about the period`.
+
+### Task 3: The thread and the prompt
+
+**Files:** modify `threads/store.ts` (`task` on header, `create({task})`), `loop/prompt.ts` (`sections`), `loop/counsel-loop.ts` (task fallback to header; retro sections), `content/source.ts` (+`skills/retro`), regenerate manifest; `runtime/src/retro/index.ts` (`startRetro`).
+
+- [ ] Test: `startRetro` creates a thread titled `Retro · <period>` with `task: 'retro'`, writes state, returns the message; prompt test: with `sections` the prompt ends with them; loop test (fake provider): a step on a retro thread carries `task: 'retro'` on its `step` event without the caller naming it, and the fake provider's received system prompt contains "Retro evidence".
+- [ ] Implement; `bun run content:manifest`; commit `runtime: a retro is a thread — task on the header, method + evidence in the system prompt`.
+
+### Task 4: Routes + CLI
+
+**Files:** `server/routes.ts`, `cli.ts`, tests.
+
+- [ ] Test: `GET /retro` → status (401 without token); `POST /retro` → 201 `{ threadId, title, message, status }`, thread listed, state written; `since` honoured.
+- [ ] CLI: `retro [--since]` creates the thread, prints the id and title, then runs the first step through `runStep` when a provider resolves from the registry (`--provider` overrides), streaming NDJSON like `step`; without a resolvable provider it prints the message and exits 0 with a line saying to open the thread in the app.
+- [ ] Commit `runtime: GET/POST /retro and the retro command`.
+
+### Task 5: UI
+
+**Files:** `api/types.ts`, `v2/Shell.tsx`, `v2/home/HomePage.tsx`, `v2/settings/RetroAction.tsx`, `v2/settings/SettingsPage.tsx`, `styles.css`, tests.
+
+- [ ] HomePage: fetch `/retro` with the other reads; when `due`, one line under the subline: "Last retro 94 days ago · run a retro" / "No retro yet · run a retro". Test: due → line + click calls `onStartRetro`; not due → nothing; a failed read → nothing.
+- [ ] RetroAction in Settings › Runtime: "Last retro <date> (n days ago)" or "No retro yet", the cadence, and a "Run a retro" button → `onStartRetro`. Test.
+- [ ] Shell: `startRetro` → `POST /retro` → select the thread, go to chat, send the returned message as the first step. Test: the step request goes to the new thread with the message.
+- [ ] Commit `ui: a retro is one click — Home says when it is due, Settings runs it`.
+
+### Task 6: Docs
+
+- [ ] `skills/retro/SKILL.md`: one line that the runtime runs the same retro (`counsel-os retro`, Home, Settings) with the runtime's own evidence. `CHANGELOG.md` Unreleased. Commit `docs: retro in the runtime`.

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -22,6 +22,10 @@ import { renderReport, runDoctor } from './doctor/index';
 import { runInit } from './setup/init';
 import { defaultPluginRoot, startServer } from './server/serve';
 import { resolveLegalRoot } from './vault/resolve-root';
+import { ThreadStore } from './threads/store';
+import { startRetro } from './retro/index';
+import { runStep } from './loop/counsel-loop';
+import { loadRegistry } from './providers/registry';
 
 const { values, positionals } = parseArgs({
   args: Bun.argv.slice(2),
@@ -56,6 +60,7 @@ const { values, positionals } = parseArgs({
     changes: { type: 'string' },      // `docx read`: all | accept | reject
     format: { type: 'string' },       // `docx extract|check`: json | markdown | text
     'dry-run': { type: 'boolean' },        // `update-content`: report only
+    since: { type: 'string' },             // `retro`: the period start (YYYY-MM-DD); default = the last retro
     out: { type: 'string' },          // `docx apply`: where to write (default <original>-redline-<date>.docx)
     track: { type: 'boolean' },       // `docx apply`: native tracked changes
     author: { type: 'string' },       // `docx apply|compare`: the revision author
@@ -79,6 +84,8 @@ function usage(): never {
   console.error('       bun runtime/src/cli.ts docx check <file.docx|.md|.txt> [--format json|text] (mechanical QA)');
   console.error('       bun runtime/src/cli.ts update-content [--vault <dir>] [--yes] [--dry-run]');
   console.error('         compares the shipped law and practice content with the vault; applies law updates (never a file you changed)');
+  console.error('       bun runtime/src/cli.ts retro [--vault <dir>] [--since <YYYY-MM-DD>] [--provider <id>]');
+  console.error('         opens a retro thread over the runtime\'s record of the period and runs its first step; knowledge changes come back as proposals');
   console.error('       bun runtime/src/cli.ts doctor [--vault <dir>]');
   console.error('         read-only vault health: root config, structure, law currency, git, standards/library consistency, matter law impact');
   console.error('       bun runtime/src/cli.ts docx apply <file.docx> <redlines.json> [--out <file>] [--track] [--author <name>] (the redline; result JSON to stdout, exit 2 on any skip)');
@@ -295,6 +302,46 @@ if (cmd === 'serve') {
   const result = applyUpdates(deps, pending);
   console.log(`Applied ${result.applied.length}: ${result.applied.join(', ')}`);
   process.exit(0);
+} else if (cmd === 'retro') {
+  const vaultRoot = vaultForMaintenance();
+  const pluginRoot = defaultPluginRoot();
+  const store = new ThreadStore(vaultRoot);
+  const start = await startRetro({ vaultRoot, tenant: DEFAULT_TENANT, store }, values.since === undefined ? {} : { since: values.since });
+  console.error(`${start.title} — thread ${start.threadId}`);
+  // The first step runs here when a provider resolves; without one the
+  // thread still exists and the app can run it.
+  let loaded: ReturnType<typeof loadRegistry> | null = null;
+  try {
+    loaded = loadRegistry({ vaultRoot });
+  } catch (err) {
+    console.error(`no provider to run the retro on: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  if (loaded === null) {
+    console.log(start.message);
+    console.error('Open the retro thread in the app to run it.');
+    process.exit(0);
+  }
+  const vault = new FsVaultStore(vaultRoot, { search: fsSearch() });
+  let exit = 1;
+  const events = runStep(
+    {
+      tenant: DEFAULT_TENANT,
+      vaultRoot,
+      pluginRoot,
+      content: repoContentSource(pluginRoot),
+      vault,
+      store,
+      providers: loaded.providers,
+      router: loaded.router,
+      ...(stepTimeoutMs === undefined ? {} : { stepTimeoutMs }),
+    },
+    { threadId: start.threadId, message: start.message, ...(values.provider ? { providerId: values.provider } : {}) },
+  );
+  for await (const ev of events) {
+    console.log(JSON.stringify(ev));
+    if (isTerminal(ev)) exit = ev.type === 'done' ? 0 : 1;
+  }
+  process.exit(exit);
 } else if (cmd === 'doctor') {
   const vaultRoot = vaultForMaintenance();
   const report = runDoctor({ vaultRoot, pluginRoot: defaultPluginRoot() });

--- a/runtime/src/content/manifest.ts
+++ b/runtime/src/content/manifest.ts
@@ -875,7 +875,7 @@ export const MANIFEST: ContentManifest = {
       "hash": "7e8cb06ea00596bd3be5f768f4529a198ebbe3b654b9b639f51607eb023c0cbd"
     },
     "skills/retro/SKILL.md": {
-      "hash": "4975a92a57f7a4f6c9c1c81495f3b92a462a04e60fa197d7278b29bcd0675eff"
+      "hash": "1ecb3c3ea7ea628e316cb13626e5e04225f74aa6c4473be2973eb574c2a1d416"
     },
     "skills/demo/assets/sample-mutual-nda.docx": {
       "hash": "67025b706197311c96327e35df6401d78135b330567ecde92131067f405bd6e5"

--- a/runtime/src/content/manifest.ts
+++ b/runtime/src/content/manifest.ts
@@ -874,6 +874,9 @@ export const MANIFEST: ContentManifest = {
     "skills/counsel/SKILL.md": {
       "hash": "7e8cb06ea00596bd3be5f768f4529a198ebbe3b654b9b639f51607eb023c0cbd"
     },
+    "skills/retro/SKILL.md": {
+      "hash": "4975a92a57f7a4f6c9c1c81495f3b92a462a04e60fa197d7278b29bcd0675eff"
+    },
     "skills/demo/assets/sample-mutual-nda.docx": {
       "hash": "67025b706197311c96327e35df6401d78135b330567ecde92131067f405bd6e5"
     },

--- a/runtime/src/content/source.ts
+++ b/runtime/src/content/source.ts
@@ -16,6 +16,8 @@ export const SHIPPED_ROOTS: readonly string[] = [
   'templates/memory',
   'primitives',
   'skills/counsel',
+  // The retro method, read into a retro thread's system prompt (`retro/`).
+  'skills/retro',
   // The synthetic NDA the sample matter is made of (spec 2026-09-01 §4).
   'skills/demo/assets',
 ];

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -1511,8 +1511,10 @@ describe('runStep — the run record', () => {
     class BrokenStore extends ThreadStore {
       reads = 0;
       override async get(tenant: string, id: string): ReturnType<ThreadStore['get']> {
-        // 1: the existence check. 2: the header read. 3: the window replay.
-        if (++this.reads === 3) throw new Error('log read failed');
+        // The existence check reads the header alone (`store.header`), so
+        // `get` runs twice: 1: the header read for the prompt. 2: the window
+        // replay.
+        if (++this.reads === 2) throw new Error('log read failed');
         return super.get(tenant, id);
       }
     }

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -15,6 +15,7 @@ import { readPrimitiveTool } from './primitives';
 import { proposeUpdateTool } from './proposals';
 import { writeRunLog, type RunLogEntry, type ToolCallLog } from './run-log';
 import { finishRun, startRun, type RunPatch, type RunRecord } from './run-record';
+import { RETRO_TASK, retroSections } from '../retro/index';
 
 /**
  * Headroom left in the context window for the model's own reply and for the
@@ -173,12 +174,16 @@ export async function* runStep(
   const { tenant, store } = deps;
   const { threadId } = opts;
 
+  // The header alone: it decides the task (a retro thread runs every step
+  // as `retro` unless the caller names one) before the run is recorded.
+  let early: ThreadHeader;
   try {
-    await store.get(tenant, threadId);
+    early = await store.header(tenant, threadId);
   } catch {
     yield { type: 'error', message: `unknown thread: ${threadId}`, runId };
     return;
   }
+  if (opts.task === undefined && early.task !== undefined) opts = { ...opts, task: early.task };
 
   // The run record opens here — before the provider is even chosen — so
   // everything that follows is visible to `/runs` while it is happening and
@@ -285,6 +290,10 @@ export async function* runStep(
           available: scriptTools.map(t => t.name),
           unavailable: registry.unavailable(platform),
         },
+        // A retro step carries the retro method and the period's evidence
+        // (`retro/`): read fresh on every step of the thread, so a retro
+        // that runs over several turns keeps seeing the record.
+        ...(opts.task === RETRO_TASK ? { sections: await retroSections({ deps, cfg }) } : {}),
       });
 
       // An oversize system prompt is not a windowing problem — no amount of

--- a/runtime/src/loop/prompt.ts
+++ b/runtime/src/loop/prompt.ts
@@ -158,7 +158,7 @@ Unavailable: ${unavailableList}`;
 }
 
 /** Strips a leading `--- ... ---` YAML frontmatter block, if present. */
-function stripFrontmatter(text: string): string {
+export function stripFrontmatter(text: string): string {
   if (!text.startsWith('---')) return text;
   const closeIdx = text.indexOf('\n---', 3);
   if (closeIdx === -1) return text;
@@ -193,6 +193,9 @@ export interface AssembleSystemPromptOptions {
   platform: Platform;
   tools: AvailableTools;
   cfg: VaultConfig;
+  /** Extra sections appended after the matter, in order — the retro's
+   * method and evidence (`retro/`). Each becomes `## <heading>` + body. */
+  sections?: Array<{ heading: string; body: string }>;
 }
 
 /**
@@ -223,6 +226,10 @@ export function assembleSystemPrompt(
     if (matter !== null) {
       prompt += '\n\n## Current matter\n' + matter;
     }
+  }
+
+  for (const section of opts.sections ?? []) {
+    prompt += `\n\n## ${section.heading}\n` + section.body;
   }
 
   return prompt;

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -147,6 +147,29 @@ export function readRun(vaultRoot: string, tenant: Tenant, runId: string): RunRe
 }
 
 /**
+ * Every run of the tenant, newest first — the retro's evidence needs the
+ * whole period, not one thread. Same file rules as `listRuns`.
+ */
+export function listAllRuns(vaultRoot: string, tenant: Tenant): RunRecord[] {
+  const dir = runsDir(vaultRoot, tenant);
+  let names: string[];
+  try {
+    names = readdirSync(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw err;
+  }
+  const runs: RunRecord[] = [];
+  for (const name of names) {
+    if (!name.endsWith('.json')) continue;
+    const rec = readRecordAt(join(dir, name));
+    if (rec !== null) runs.push(rec);
+  }
+  runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt) || b.runId.localeCompare(a.runId));
+  return runs;
+}
+
+/**
  * Every run of one thread, newest first. `threadId` is matched against the
  * records' contents, never used as a path segment, so it needs no validation
  * of its own — an id that names no thread simply matches nothing.

--- a/runtime/src/retro/__snapshots__/evidence.test.ts.snap
+++ b/runtime/src/retro/__snapshots__/evidence.test.ts.snap
@@ -1,0 +1,44 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`gatherRetroEvidence renders the period as plain facts for the system prompt 1`] = `
+"Period: 2026-07-01 to 2026-09-01.
+
+### Conversations
+- 1 of 2 conversations touched in the period; 2 steps answered.
+- Steps by task: counsel 1, review 1.
+- Steps by provider: fake/fake 1, ollama/gemma4:e4b 1.
+- Titles (newest first):
+  - Check the Acme NDA term.
+
+### Runs
+- 3 runs: 1 done, 1 errored, 1 timed out, 0 abandoned; cost about $0.56.
+- Primitives consulted: evaluate 2, draft 1.
+- Tools called: vault_read 2, apply_redlines 1.
+- Errors seen:
+  - step timed out after 600s
+  - claude harness: Not logged in
+
+### Proposals (knowledge changes counsel raised)
+- approved: 1
+  - practice/standards/nda.md — Record the residuals fallback (in “Check the Acme NDA term.”, 2026-08-10)
+- rejected: 1
+  - memory/patterns.md — Log the pattern (in “Check the Acme NDA term.”, 2026-08-10)
+- pending: 1
+  - practice/methods/nda-triage.md — Promote the triage method (in “Check the Acme NDA term.”, 2026-08-10)
+
+### Documents produced
+- 1 documents (docx-redline 1); 5 edits applied, 1 skipped, 3 comments.
+  - matters/acme/acme-nda-redline-2026-08-10.docx
+
+### Matters
+- 1 of 2 matters touched in the period:
+  - matters/acme-nda.md — Acme — NDA · working · updated 2026-08-10
+
+### Memory
+- memory/patterns.md: 4 entries.
+- Previous retro snapshots: retro-2026-05-01.md.
+
+### Vault health (doctor)
+- 1 warning — git first
+  - warn: git — no commits since 2026-06-01"
+`;

--- a/runtime/src/retro/evidence.test.ts
+++ b/runtime/src/retro/evidence.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, utimesSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { DoctorReport } from '../doctor/index';
+import { startRun, finishRun } from '../loop/run-record';
+import { ThreadStore } from '../threads/store';
+import { FsVaultStore } from '../vault/fs-store';
+import { readVaultConfig } from '../vault/resolve-root';
+import { gatherRetroEvidence, renderRetroEvidence } from './evidence';
+
+const NOW = new Date('2026-09-01T12:00:00.000Z');
+const SINCE = '2026-07-01T00:00:00.000Z';
+
+async function seed(): Promise<{ vaultRoot: string; store: ThreadStore; vault: FsVaultStore }> {
+  const vaultRoot = mkdtempSync(join(tmpdir(), 'retro-evidence-'));
+  const store = new ThreadStore(vaultRoot, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'retro-codex-')) });
+  const vault = new FsVaultStore(vaultRoot);
+
+  // Two matters: one touched in the period, one before it.
+  mkdirSync(join(vaultRoot, 'matters'), { recursive: true });
+  writeFileSync(join(vaultRoot, 'matters', 'acme-nda.md'), '---\ncounsel-os-type: matter\ntitle: Acme — NDA\nstage: working\n---\n# Acme\n', 'utf8');
+  writeFileSync(join(vaultRoot, 'matters', 'old-msa.md'), '---\ncounsel-os-type: matter\ntitle: Old — MSA\n---\n# Old\n', 'utf8');
+  utimesSync(join(vaultRoot, 'matters', 'acme-nda.md'), new Date('2026-08-10T00:00:00Z'), new Date('2026-08-10T00:00:00Z'));
+  utimesSync(join(vaultRoot, 'matters', 'old-msa.md'), new Date('2026-05-10T00:00:00Z'), new Date('2026-05-10T00:00:00Z'));
+
+  // Memory: four pattern entries and one previous snapshot.
+  mkdirSync(join(vaultRoot, 'memory'), { recursive: true });
+  writeFileSync(join(vaultRoot, 'memory', 'patterns.md'), '# Patterns\n\n- one\n- two\n- three\n- four\n\ntrailing prose\n', 'utf8');
+  writeFileSync(join(vaultRoot, 'memory', 'retro-2026-05-01.md'), '# Retro\n', 'utf8');
+
+  // A thread in the period with a step, three proposals and an artifact.
+  const t1 = await store.create('default', { title: 'Check the Acme NDA term.' });
+  await store.append('default', t1.id, { t: 'user', at: '2026-08-10T10:00:00.000Z', content: 'Check the Acme NDA term.' });
+  await store.append('default', t1.id, { t: 'step', at: '2026-08-10T10:00:01.000Z', runId: 'r-1', provider: 'fake/fake', task: 'review' });
+  await store.append('default', t1.id, { t: 'proposal', at: '2026-08-10T10:01:00.000Z', id: 'p-1', path: 'practice/standards/nda.md', content: 'x', rationale: 'Record the residuals fallback\nmore', status: 'approved', expectedVersion: null });
+  await store.append('default', t1.id, { t: 'proposal', at: '2026-08-10T10:02:00.000Z', id: 'p-2', path: 'memory/patterns.md', content: 'x', rationale: 'Log the pattern', status: 'rejected', expectedVersion: null });
+  await store.append('default', t1.id, { t: 'proposal', at: '2026-08-10T10:03:00.000Z', id: 'p-3', path: 'practice/methods/nda-triage.md', content: 'x', rationale: 'Promote the triage method', status: 'pending', expectedVersion: null });
+  await store.append('default', t1.id, {
+    t: 'artifact',
+    at: '2026-08-10T10:04:00.000Z',
+    id: 'a-1',
+    kind: 'docx-redline',
+    path: 'matters/acme/acme-nda-redline-2026-08-10.docx',
+    source: 'matters/acme/acme-nda.docx',
+    author: 'Jack Wang',
+    tracked: true,
+    summary: { changes: 9, comments: 3, applied: 5, skipped: 1, clauses: 3, bytes: 41000 },
+  });
+  await store.append('default', t1.id, { t: 'step', at: '2026-08-11T10:00:01.000Z', runId: 'r-2', provider: 'ollama/gemma4:e4b' });
+  // Pin the header's updatedAt into the period (append stamps "now").
+  writeFileSync(join(vaultRoot, '.counsel', 'threads', 'default', `${t1.id}.json`), JSON.stringify({ ...(await store.header('default', t1.id)), updatedAt: '2026-08-11T10:00:01.000Z' }), 'utf8');
+
+  // A thread from before the period: not read at all.
+  const t0 = await store.create('default', { title: 'Old question' });
+  await store.append('default', t0.id, { t: 'step', at: '2026-04-01T10:00:00.000Z', runId: 'r-0', provider: 'fake/fake' });
+  writeFileSync(join(vaultRoot, '.counsel', 'threads', 'default', `${t0.id}.json`), JSON.stringify({ ...(await store.header('default', t0.id)), updatedAt: '2026-04-01T10:00:00.000Z' }), 'utf8');
+
+  // Run records: done, error, timeout in the period; one before it.
+  const base = { threadId: t1.id, tenant: 'default' as const, message: 'm', provider: 'fake/fake', primitivesRead: ['evaluate'], toolCalls: [{ name: 'vault_read', ms: 3, isError: false }], proposals: [] };
+  const runId = (n: number): string => `00000000-0000-4000-8000-00000000000${n}`;
+  startRun(vaultRoot, { ...base, runId: runId(1), startedAt: '2026-08-10T10:00:01.000Z', status: 'running' });
+  finishRun(vaultRoot, 'default', runId(1), { status: 'done', costUsd: 0.46, usage: { inputTokens: 10, outputTokens: 5 } });
+  startRun(vaultRoot, { ...base, runId: runId(2), startedAt: '2026-08-11T10:00:01.000Z', status: 'running', primitivesRead: ['evaluate', 'draft'], toolCalls: [{ name: 'vault_read', ms: 3, isError: false }, { name: 'apply_redlines', ms: 900, isError: false }] });
+  finishRun(vaultRoot, 'default', runId(2), { status: 'error', error: 'claude harness: Not logged in', costUsd: 0.1 });
+  startRun(vaultRoot, { ...base, runId: runId(3), startedAt: '2026-08-12T10:00:01.000Z', status: 'running', primitivesRead: [], toolCalls: [] });
+  finishRun(vaultRoot, 'default', runId(3), { status: 'timeout', error: 'step timed out after 600s' });
+  startRun(vaultRoot, { ...base, runId: runId(4), startedAt: '2026-04-01T10:00:01.000Z', status: 'running' });
+  finishRun(vaultRoot, 'default', runId(4), { status: 'done', costUsd: 9 });
+
+  return { vaultRoot, store, vault };
+}
+
+const doctor: DoctorReport = {
+  at: NOW.toISOString(),
+  vault: '/v',
+  verdict: 'warnings',
+  summary: '1 warning — git first',
+  findings: [
+    { check: 'root', severity: 'ok', message: 'config.md marks the root' },
+    { check: 'git', severity: 'warn', message: 'no commits since 2026-06-01', fix: 'commit' },
+  ],
+};
+
+describe('gatherRetroEvidence', () => {
+  test('counts the period from the runtime record, and only the period', async () => {
+    const { vaultRoot, store, vault } = await seed();
+    const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW, doctor: () => doctor });
+
+    expect(e.threads.total).toBe(2);
+    expect(e.threads.inPeriod).toBe(1);
+    expect(e.threads.steps).toBe(2);
+    expect(e.threads.byTask).toEqual({ review: 1, counsel: 1 });
+    expect(e.threads.byProvider).toEqual({ 'fake/fake': 1, 'ollama/gemma4:e4b': 1 });
+    expect(e.threads.titles).toEqual(['Check the Acme NDA term.']);
+
+    expect(e.runs).toMatchObject({ inPeriod: 3, done: 1, error: 1, timeout: 1, abandoned: 0, costUsd: 0.56 });
+    expect(e.runs.primitives).toEqual({ evaluate: 2, draft: 1 });
+    expect(e.runs.tools).toEqual({ vault_read: 2, apply_redlines: 1 });
+    // Newest first, like the run listing.
+    expect(e.runs.errors).toEqual(['step timed out after 600s', 'claude harness: Not logged in']);
+
+    expect(e.proposals.approved.map(p => p.path)).toEqual(['practice/standards/nda.md']);
+    expect(e.proposals.approved[0]!.rationale).toBe('Record the residuals fallback');
+    expect(e.proposals.rejected.map(p => p.path)).toEqual(['memory/patterns.md']);
+    expect(e.proposals.pending.map(p => p.path)).toEqual(['practice/methods/nda-triage.md']);
+
+    expect(e.artifacts).toEqual({ count: 1, byKind: { 'docx-redline': 1 }, applied: 5, skipped: 1, comments: 3, paths: ['matters/acme/acme-nda-redline-2026-08-10.docx'] });
+
+    expect(e.matters.total).toBe(2);
+    expect(e.matters.touched).toEqual([{ path: 'matters/acme-nda.md', title: 'Acme — NDA', stage: 'working', updated: '2026-08-10' }]);
+
+    expect(e.memory).toEqual({ patternsEntries: 4, previousRetros: ['retro-2026-05-01.md'] });
+    expect(e.doctor).toBe(doctor);
+  });
+
+  test('all time reads everything; no doctor is said, not assumed', async () => {
+    const { vaultRoot, store, vault } = await seed();
+    const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: null, now: NOW });
+    expect(e.threads.inPeriod).toBe(2);
+    expect(e.runs.inPeriod).toBe(4);
+    expect(e.matters.touched).toHaveLength(2);
+    expect(e.doctor).toBeNull();
+    expect(renderRetroEvidence(e)).toContain('Vault health (doctor)\n- not run.');
+  });
+
+  test('renders the period as plain facts for the system prompt', async () => {
+    const { vaultRoot, store, vault } = await seed();
+    const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW, doctor: () => doctor });
+    expect(renderRetroEvidence(e)).toMatchSnapshot();
+  });
+});

--- a/runtime/src/retro/evidence.ts
+++ b/runtime/src/retro/evidence.ts
@@ -1,0 +1,276 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Tenant, VaultStore } from '../core/types';
+import type { DoctorReport } from '../doctor/index';
+import { listAllRuns, type RunRecord } from '../loop/run-record';
+import type { ThreadEvent, ThreadHeader, ThreadStore } from '../threads/store';
+import { vaultOverview, type MatterOverview } from '../vault/overview';
+import type { VaultConfig } from '../vault/resolve-root';
+
+/**
+ * What the runtime knows about the period, gathered for the retro's system
+ * prompt. The plugin's retro reads matter and entity files; the runtime has
+ * more — every conversation, every step's tools and cost, every proposal
+ * and how it was decided, every document produced — so the retro starts
+ * from the record rather than from the model's memory of it.
+ *
+ * Read-only. Bounded where a vault can be large (threads are read in full
+ * only when they were touched in the period).
+ */
+export interface RetroEvidence {
+  period: { from: string | null; to: string };
+  threads: {
+    inPeriod: number;
+    total: number;
+    /** Steps (user turns answered) in the period. */
+    steps: number;
+    byTask: Record<string, number>;
+    byProvider: Record<string, number>;
+    /** Titles of the period's threads, newest first, capped. */
+    titles: string[];
+  };
+  runs: {
+    inPeriod: number;
+    done: number;
+    error: number;
+    timeout: number;
+    abandoned: number;
+    costUsd: number;
+    /** The most-consulted primitives, by step count. */
+    primitives: Record<string, number>;
+    /** Tool calls by name. */
+    tools: Record<string, number>;
+    /** Error messages, deduplicated, capped. */
+    errors: string[];
+  };
+  proposals: {
+    approved: ProposalNote[];
+    rejected: ProposalNote[];
+    pending: ProposalNote[];
+  };
+  artifacts: {
+    count: number;
+    byKind: Record<string, number>;
+    applied: number;
+    skipped: number;
+    comments: number;
+    paths: string[];
+  };
+  matters: {
+    total: number;
+    touched: MatterNote[];
+  };
+  memory: {
+    patternsEntries: number | null;
+    previousRetros: string[];
+  };
+  doctor: DoctorReport | null;
+}
+
+export interface ProposalNote {
+  path: string;
+  rationale: string;
+  thread: string;
+  at: string;
+}
+
+export interface MatterNote {
+  path: string;
+  title: string;
+  stage: string | null;
+  updated: string;
+}
+
+export interface RetroEvidenceDeps {
+  vaultRoot: string;
+  tenant: Tenant;
+  store: ThreadStore;
+  vault: VaultStore;
+  cfg: VaultConfig;
+  /** The period start; `null` = all time. */
+  since: string | null;
+  now?: Date;
+  /** The doctor, injected so the evidence stays pure in tests; `null` skips it. */
+  doctor?: () => DoctorReport | null;
+}
+
+const TITLE_CAP = 40;
+const ERROR_CAP = 10;
+const RATIONALE_CAP = 160;
+
+function inPeriod(at: string, since: string | null, to: string): boolean {
+  return (since === null || at >= since) && at <= to;
+}
+
+function bump(map: Record<string, number>, key: string): void {
+  map[key] = (map[key] ?? 0) + 1;
+}
+
+function firstLine(text: string): string {
+  const line = text.split('\n').find(l => l.trim() !== '') ?? '';
+  return line.length > RATIONALE_CAP ? `${line.slice(0, RATIONALE_CAP - 1)}…` : line;
+}
+
+export async function gatherRetroEvidence(deps: RetroEvidenceDeps): Promise<RetroEvidence> {
+  const now = deps.now ?? new Date();
+  const to = now.toISOString();
+  const since = deps.since;
+
+  // Threads: headers for every thread, events only for the period's.
+  const headers = await deps.store.list(deps.tenant);
+  const period = headers.filter(h => inPeriod(h.updatedAt, since, to)).sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+  const threads: RetroEvidence['threads'] = { inPeriod: period.length, total: headers.length, steps: 0, byTask: {}, byProvider: {}, titles: [] };
+  const proposals: RetroEvidence['proposals'] = { approved: [], rejected: [], pending: [] };
+  const artifacts: RetroEvidence['artifacts'] = { count: 0, byKind: {}, applied: 0, skipped: 0, comments: 0, paths: [] };
+  for (const header of period) {
+    if (threads.titles.length < TITLE_CAP) threads.titles.push(titleOf(header));
+    let events: ThreadEvent[];
+    try {
+      ({ events } = await deps.store.get(deps.tenant, header.id));
+    } catch {
+      continue; // deleted mid-scan: not the retro's problem
+    }
+    for (const ev of events) {
+      if (!('t' in ev)) continue;
+      if (ev.t === 'step' && inPeriod(ev.at, since, to)) {
+        threads.steps += 1;
+        bump(threads.byTask, ev.task ?? 'counsel');
+        bump(threads.byProvider, ev.provider);
+      } else if (ev.t === 'proposal' && inPeriod(ev.at, since, to)) {
+        const note: ProposalNote = { path: ev.path, rationale: firstLine(ev.rationale), thread: titleOf(header), at: ev.at };
+        proposals[ev.status].push(note);
+      } else if (ev.t === 'artifact' && inPeriod(ev.at, since, to)) {
+        artifacts.count += 1;
+        bump(artifacts.byKind, ev.kind);
+        artifacts.applied += ev.summary.applied;
+        artifacts.skipped += ev.summary.skipped;
+        artifacts.comments += ev.summary.comments;
+        if (artifacts.paths.length < TITLE_CAP) artifacts.paths.push(ev.path);
+      }
+    }
+  }
+
+  // Runs: the record of every step — status, cost, what it consulted.
+  const runs: RetroEvidence['runs'] = { inPeriod: 0, done: 0, error: 0, timeout: 0, abandoned: 0, costUsd: 0, primitives: {}, tools: {}, errors: [] };
+  for (const rec of listAllRuns(deps.vaultRoot, deps.tenant)) {
+    if (!inPeriod(rec.startedAt, since, to)) continue;
+    runs.inPeriod += 1;
+    if (rec.status === 'done') runs.done += 1;
+    else if (rec.status === 'error') runs.error += 1;
+    else if (rec.status === 'timeout') runs.timeout += 1;
+    else if (rec.status === 'abandoned') runs.abandoned += 1;
+    runs.costUsd += rec.costUsd ?? 0;
+    for (const p of rec.primitivesRead) bump(runs.primitives, p);
+    for (const call of rec.toolCalls) bump(runs.tools, call.name === '' ? 'unnamed' : call.name);
+    if (rec.error !== undefined && rec.error !== '' && runs.errors.length < ERROR_CAP && !runs.errors.includes(rec.error)) runs.errors.push(rec.error);
+  }
+  runs.costUsd = Math.round(runs.costUsd * 100) / 100;
+
+  // Matters: the overview, cut to the ones touched in the period.
+  const overview = await vaultOverview(deps.vault, deps.tenant, deps.cfg);
+  const sinceMs = since === null ? 0 : Date.parse(since);
+  const touched = overview.matters
+    .filter(m => m.mtimeMs >= sinceMs && m.mtimeMs <= now.getTime())
+    .map(matterNote);
+  const matters: RetroEvidence['matters'] = { total: overview.matters.length, touched };
+
+  return {
+    period: { from: since, to },
+    threads,
+    runs,
+    proposals,
+    artifacts,
+    matters,
+    memory: readMemory(deps.vaultRoot),
+    doctor: deps.doctor === undefined ? null : deps.doctor(),
+  };
+}
+
+function titleOf(header: ThreadHeader): string {
+  return header.title?.trim() || 'Untitled';
+}
+
+function matterNote(m: MatterOverview): MatterNote {
+  const stage = (m.frontmatter['stage'] ?? '').trim();
+  return { path: m.path, title: m.title, stage: stage === '' ? null : stage, updated: new Date(m.mtimeMs).toISOString().slice(0, 10) };
+}
+
+/** `memory/patterns.md`'s entry count (top-level bullets and headings —
+ * the skill's "log bloat" check) and the previous retro snapshots. */
+function readMemory(vaultRoot: string): RetroEvidence['memory'] {
+  let patternsEntries: number | null = null;
+  try {
+    const text = readFileSync(join(vaultRoot, 'memory', 'patterns.md'), 'utf8');
+    patternsEntries = text.split('\n').filter(l => /^(- |\* |\d+\. |## )/.test(l)).length;
+  } catch {
+    patternsEntries = null;
+  }
+  let previousRetros: string[] = [];
+  try {
+    previousRetros = readdirSync(join(vaultRoot, 'memory'))
+      .filter(n => /^retro-\d{4}-\d{2}-\d{2}\.md$/.test(n))
+      .sort()
+      .reverse();
+  } catch {
+    previousRetros = [];
+  }
+  return { patternsEntries, previousRetros };
+}
+
+function counts(map: Record<string, number>): string {
+  const entries = Object.entries(map).sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+  return entries.length === 0 ? 'none' : entries.map(([k, v]) => `${k} ${v}`).join(', ');
+}
+
+/** The evidence as the markdown section the system prompt carries. Plain
+ * facts, no verdicts: the method decides what they mean. */
+export function renderRetroEvidence(e: RetroEvidence): string {
+  const from = e.period.from === null ? 'all time' : e.period.from.slice(0, 10);
+  const lines: string[] = [];
+  lines.push(`Period: ${from} to ${e.period.to.slice(0, 10)}.`);
+  lines.push('');
+  lines.push('### Conversations');
+  lines.push(`- ${e.threads.inPeriod} of ${e.threads.total} conversations touched in the period; ${e.threads.steps} steps answered.`);
+  lines.push(`- Steps by task: ${counts(e.threads.byTask)}.`);
+  lines.push(`- Steps by provider: ${counts(e.threads.byProvider)}.`);
+  if (e.threads.titles.length > 0) {
+    lines.push('- Titles (newest first):');
+    for (const t of e.threads.titles) lines.push(`  - ${t}`);
+  }
+  lines.push('');
+  lines.push('### Runs');
+  lines.push(`- ${e.runs.inPeriod} runs: ${e.runs.done} done, ${e.runs.error} errored, ${e.runs.timeout} timed out, ${e.runs.abandoned} abandoned; cost about $${e.runs.costUsd.toFixed(2)}.`);
+  lines.push(`- Primitives consulted: ${counts(e.runs.primitives)}.`);
+  lines.push(`- Tools called: ${counts(e.runs.tools)}.`);
+  if (e.runs.errors.length > 0) {
+    lines.push('- Errors seen:');
+    for (const err of e.runs.errors) lines.push(`  - ${err}`);
+  }
+  lines.push('');
+  lines.push('### Proposals (knowledge changes counsel raised)');
+  for (const status of ['approved', 'rejected', 'pending'] as const) {
+    const list = e.proposals[status];
+    lines.push(`- ${status}: ${list.length}`);
+    for (const p of list) lines.push(`  - ${p.path} — ${p.rationale} (in “${p.thread}”, ${p.at.slice(0, 10)})`);
+  }
+  lines.push('');
+  lines.push('### Documents produced');
+  lines.push(`- ${e.artifacts.count} documents (${counts(e.artifacts.byKind)}); ${e.artifacts.applied} edits applied, ${e.artifacts.skipped} skipped, ${e.artifacts.comments} comments.`);
+  for (const p of e.artifacts.paths) lines.push(`  - ${p}`);
+  lines.push('');
+  lines.push('### Matters');
+  lines.push(`- ${e.matters.touched.length} of ${e.matters.total} matters touched in the period:`);
+  for (const m of e.matters.touched) lines.push(`  - ${m.path} — ${m.title}${m.stage === null ? '' : ` · ${m.stage}`} · updated ${m.updated}`);
+  lines.push('');
+  lines.push('### Memory');
+  lines.push(`- memory/patterns.md: ${e.memory.patternsEntries === null ? 'absent' : `${e.memory.patternsEntries} entries`}.`);
+  lines.push(`- Previous retro snapshots: ${e.memory.previousRetros.length === 0 ? 'none' : e.memory.previousRetros.join(', ')}.`);
+  lines.push('');
+  lines.push('### Vault health (doctor)');
+  if (e.doctor === null) lines.push('- not run.');
+  else {
+    lines.push(`- ${e.doctor.summary}`);
+    for (const f of e.doctor.findings) if (f.severity !== 'ok') lines.push(`  - ${f.severity}: ${f.check} — ${f.message}`);
+  }
+  return lines.join('\n');
+}

--- a/runtime/src/retro/index.test.ts
+++ b/runtime/src/retro/index.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ThreadStore } from '../threads/store';
+import { DEFAULT_RETRO_CADENCE_DAYS, periodLabel, readRetroState, retroCadenceDays, retroStatus, startRetro } from './index';
+
+const NOW = new Date('2026-09-01T12:00:00.000Z');
+const cfg = { retroCadenceDays: undefined } as { retroCadenceDays?: number };
+
+describe('retroCadenceDays', () => {
+  test('quarterly by default, config.md overrides', () => {
+    expect(retroCadenceDays({})).toBe(DEFAULT_RETRO_CADENCE_DAYS);
+    expect(retroCadenceDays({ retroCadenceDays: 60 })).toBe(60);
+  });
+});
+
+describe('retroStatus', () => {
+  test('never run: due once the vault has enough to look back on', () => {
+    const small = retroStatus({ state: {}, cfg, counts: { matters: 2, threads: 4 }, now: NOW });
+    expect(small.due).toBe(false);
+    expect(small.lastRetroAt).toBeNull();
+    expect(small.reason).toContain('No retro yet');
+    expect(retroStatus({ state: {}, cfg, counts: { matters: 3, threads: 0 }, now: NOW }).due).toBe(true);
+    expect(retroStatus({ state: {}, cfg, counts: { matters: 0, threads: 10 }, now: NOW }).due).toBe(true);
+  });
+
+  test('last retro inside the cadence: not due, with the next date', () => {
+    const s = retroStatus({ state: { lastRetroAt: '2026-06-05T00:00:00.000Z', threadId: 't' }, cfg, counts: { matters: 9, threads: 9 }, now: NOW });
+    expect(s.due).toBe(false);
+    expect(s.daysSince).toBe(88);
+    expect(s.dueAt).toBe('2026-09-03T00:00:00.000Z');
+    expect(s.threadId).toBe('t');
+    expect(s.reason).toBe('Last retro 88 days ago · next due 2026-09-03');
+  });
+
+  test('older than the cadence: due', () => {
+    const s = retroStatus({ state: { lastRetroAt: '2026-05-01T00:00:00.000Z' }, cfg, counts: { matters: 0, threads: 0 }, now: NOW });
+    expect(s.due).toBe(true);
+    expect(s.daysSince).toBe(123);
+    expect(s.reason).toBe('Last retro 123 days ago');
+    // A shorter cadence moves the line.
+    expect(retroStatus({ state: { lastRetroAt: '2026-08-10T00:00:00.000Z' }, cfg: { retroCadenceDays: 14 }, counts: { matters: 0, threads: 0 }, now: NOW }).due).toBe(true);
+  });
+
+  test('an unreadable date counts as never', () => {
+    expect(retroStatus({ state: { lastRetroAt: 'yesterday' }, cfg, counts: { matters: 5, threads: 0 }, now: NOW }).lastRetroAt).toBeNull();
+  });
+});
+
+describe('startRetro', () => {
+  test('opens a retro thread, records the state, returns the first message', async () => {
+    const vaultRoot = mkdtempSync(join(tmpdir(), 'retro-start-'));
+    const store = new ThreadStore(vaultRoot, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'retro-codex-')) });
+    const start = await startRetro({ vaultRoot, tenant: 'default', store, now: () => NOW });
+    expect(start.title).toBe('Retro · all time · to 2026-09-01');
+    expect(start.period).toEqual({ from: null, to: NOW.toISOString() });
+    expect(start.message).toContain('all time');
+    expect(start.message).toContain('as a proposal');
+    const header = await store.header('default', start.threadId);
+    expect(header.task).toBe('retro');
+    expect(header.title).toBe(start.title);
+    expect(readRetroState(vaultRoot)).toEqual({ lastRetroAt: NOW.toISOString(), threadId: start.threadId, period: start.period });
+
+    // The next retro starts where this one ended; an explicit --since wins.
+    const later = new Date('2026-12-01T12:00:00.000Z');
+    const second = await startRetro({ vaultRoot, tenant: 'default', store, now: () => later });
+    expect(second.title).toBe('Retro · 2026-09-01 to 2026-12-01');
+    const explicit = await startRetro({ vaultRoot, tenant: 'default', store, now: () => later }, { since: '2026-10-15' });
+    expect(explicit.period.from).toBe('2026-10-15T00:00:00.000Z');
+    const bad = await startRetro({ vaultRoot, tenant: 'default', store, now: () => later }, { since: 'last tuesday' });
+    expect(bad.period.from).toBe(later.toISOString()); // the previous retro's time, not a guess
+  });
+});
+
+describe('periodLabel', () => {
+  test('all time and a dated span', () => {
+    expect(periodLabel(null, NOW)).toBe('all time · to 2026-09-01');
+    expect(periodLabel('2026-06-01T00:00:00.000Z', NOW)).toBe('2026-06-01 to 2026-09-01');
+  });
+});

--- a/runtime/src/retro/index.ts
+++ b/runtime/src/retro/index.ts
@@ -1,0 +1,195 @@
+import { repoContentSource } from '../content/repo';
+import type { ContentSource } from '../content/source';
+import type { Tenant, VaultStore } from '../core/types';
+import { runDoctor } from '../doctor/index';
+import { stripFrontmatter } from '../loop/prompt';
+import type { ThreadHeader, ThreadStore } from '../threads/store';
+import type { VaultConfig } from '../vault/resolve-root';
+import { gatherRetroEvidence, renderRetroEvidence } from './evidence';
+import { readRetroState, writeRetroState, type RetroState } from './state';
+
+export { readRetroState, writeRetroState, retroStatePath, type RetroState } from './state';
+export { gatherRetroEvidence, renderRetroEvidence, type RetroEvidence, type RetroEvidenceDeps } from './evidence';
+
+/** Quarterly, as `skills/retro/SKILL.md` says ("run quarterly, or every ~10
+ * closed matters"). `retro_cadence_days` in `config.md` overrides it. */
+export const DEFAULT_RETRO_CADENCE_DAYS = 90;
+
+/** With no retro ever run, a vault this small has nothing to look back on:
+ * the skill puts the useful threshold near ten matters, and three matters
+ * or ten conversations is where a first retro starts to say something. */
+export const FIRST_RETRO_MIN_MATTERS = 3;
+export const FIRST_RETRO_MIN_THREADS = 10;
+
+/** The task name stamped on a retro thread's header; the loop keys the
+ * system prompt's retro sections on it. */
+export const RETRO_TASK = 'retro';
+
+export function retroCadenceDays(cfg: Pick<VaultConfig, 'retroCadenceDays'>): number {
+  return cfg.retroCadenceDays ?? DEFAULT_RETRO_CADENCE_DAYS;
+}
+
+export interface RetroStatus {
+  lastRetroAt: string | null;
+  threadId: string | null;
+  cadenceDays: number;
+  /** Whole days since the last retro; `null` when there has never been one. */
+  daysSince: number | null;
+  /** When the next retro falls due; `null` when there has never been one. */
+  dueAt: string | null;
+  due: boolean;
+  /** Why `due` is what it is, as a sentence the UI can show. */
+  reason: string;
+}
+
+const DAY_MS = 86_400_000;
+
+export function daysBetween(from: Date, to: Date): number {
+  return Math.floor((to.getTime() - from.getTime()) / DAY_MS);
+}
+
+/**
+ * Due when the last retro is older than the cadence — or, with none ever
+ * run, when the vault holds enough to look back on (`FIRST_RETRO_MIN_*`).
+ * `counts` come from the caller so this stays pure.
+ */
+export function retroStatus(opts: {
+  state: RetroState;
+  cfg: Pick<VaultConfig, 'retroCadenceDays'>;
+  counts: { matters: number; threads: number };
+  now?: Date;
+}): RetroStatus {
+  const now = opts.now ?? new Date();
+  const cadenceDays = retroCadenceDays(opts.cfg);
+  const last = opts.state.lastRetroAt === undefined ? null : new Date(opts.state.lastRetroAt);
+  if (last === null || Number.isNaN(last.getTime())) {
+    const enough = opts.counts.matters >= FIRST_RETRO_MIN_MATTERS || opts.counts.threads >= FIRST_RETRO_MIN_THREADS;
+    return {
+      lastRetroAt: null,
+      threadId: null,
+      cadenceDays,
+      daysSince: null,
+      dueAt: null,
+      due: enough,
+      reason: enough
+        ? 'No retro yet'
+        : `No retro yet — worth one once the vault has ${FIRST_RETRO_MIN_MATTERS} matters or ${FIRST_RETRO_MIN_THREADS} conversations`,
+    };
+  }
+  const daysSince = Math.max(0, daysBetween(last, now));
+  const dueAt = new Date(last.getTime() + cadenceDays * DAY_MS);
+  const due = daysSince >= cadenceDays;
+  return {
+    lastRetroAt: last.toISOString(),
+    threadId: opts.state.threadId ?? null,
+    cadenceDays,
+    daysSince,
+    dueAt: dueAt.toISOString(),
+    due,
+    reason: due
+      ? `Last retro ${daysSince} day${daysSince === 1 ? '' : 's'} ago`
+      : `Last retro ${daysSince} day${daysSince === 1 ? '' : 's'} ago · next due ${dueAt.toISOString().slice(0, 10)}`,
+  };
+}
+
+/** "since 2026-06-01" / "all time" — the period the retro covers, in the
+ * thread title and the first message. */
+export function periodLabel(from: string | null, to: Date): string {
+  const end = to.toISOString().slice(0, 10);
+  return from === null ? `all time · to ${end}` : `${from.slice(0, 10)} to ${end}`;
+}
+
+export interface StartRetroDeps {
+  vaultRoot: string;
+  tenant: Tenant;
+  store: ThreadStore;
+  now?: () => Date;
+}
+
+export interface RetroStart {
+  threadId: string;
+  title: string;
+  period: { from: string | null; to: string };
+  /** The first user turn. Short on purpose: the method and the evidence
+   * travel in the system prompt (keyed on the thread's task), not in the
+   * bubble. */
+  message: string;
+}
+
+/**
+ * Opens the retro thread and records it. The period starts at `since` when
+ * the caller names one, else at the last retro, else "all time". Writing
+ * the state BEFORE the model has said anything is deliberate: the thread
+ * exists, the founder can return to it, and "due" should not keep firing
+ * while a retro is under way.
+ */
+export async function startRetro(deps: StartRetroDeps, opts: { since?: string } = {}): Promise<RetroStart> {
+  const now = deps.now?.() ?? new Date();
+  const previous = readRetroState(deps.vaultRoot);
+  const from = normalizeSince(opts.since) ?? previous.lastRetroAt ?? null;
+  const period = { from, to: now.toISOString() };
+  const title = `Retro · ${periodLabel(from, now)}`;
+  const header: ThreadHeader = await deps.store.create(deps.tenant, { title, task: RETRO_TASK });
+  writeRetroState(deps.vaultRoot, { lastRetroAt: now.toISOString(), threadId: header.id, period });
+  const message =
+    `Run the practice retro for ${periodLabel(from, now)}. ` +
+    'Work the retro method in your instructions over the evidence there, state which mode you are running and why, ' +
+    'and propose every knowledge change — promotions, position updates, the snapshot — as a proposal so I can approve each one.';
+  return { threadId: header.id, title, period, message };
+}
+
+/** A `since` is a date; a bad one is ignored rather than guessed at. */
+function normalizeSince(raw: string | undefined): string | null {
+  if (raw === undefined || raw.trim() === '') return null;
+  const t = Date.parse(raw);
+  return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
+export interface RetroSectionsDeps {
+  vaultRoot: string;
+  tenant: Tenant;
+  store: ThreadStore;
+  vault: VaultStore;
+  pluginRoot: string;
+  content?: ContentSource;
+}
+
+/**
+ * The two sections a retro step's system prompt carries (`prompt.ts`
+ * `sections`): the retro method — `skills/retro/SKILL.md`, shipped content,
+ * frontmatter stripped — and the runtime's evidence for the period recorded
+ * in `.counsel/retro.json`. The method's writes are re-stated as proposals,
+ * because the skill was written for a host where the model writes files
+ * itself and this host never lets it.
+ */
+export async function retroSections(opts: { deps: RetroSectionsDeps; cfg: VaultConfig; now?: Date }): Promise<Array<{ heading: string; body: string }>> {
+  const { deps } = opts;
+  const content = deps.content ?? repoContentSource(deps.pluginRoot);
+  const method = stripFrontmatter(content.read('skills/retro/SKILL.md'));
+  const state = readRetroState(deps.vaultRoot);
+  const evidence = await gatherRetroEvidence({
+    vaultRoot: deps.vaultRoot,
+    tenant: deps.tenant,
+    store: deps.store,
+    vault: deps.vault,
+    cfg: opts.cfg,
+    since: state.period?.from ?? null,
+    ...(opts.now === undefined ? {} : { now: opts.now }),
+    doctor: () => {
+      try {
+        return runDoctor({ vaultRoot: deps.vaultRoot, pluginRoot: deps.pluginRoot });
+      } catch {
+        return null; // the doctor failing is a finding for another day, not a reason to skip the retro
+      }
+    },
+  });
+  const hostNote =
+    'This host is the counsel-os runtime, not Claude Code. Every write the method describes — promoting a playbook, ' +
+    'updating a standard, appending to memory/patterns.md, saving the memory/retro-<date>.md snapshot — goes through ' +
+    '`propose_update`, one proposal per file, so the lawyer approves each in the docket. Never ask whether to save; propose it. ' +
+    'The evidence below is the runtime\'s own record of the period; read matter and entity files for the rest.';
+  return [
+    { heading: 'Retro method', body: `${hostNote}\n\n${method}` },
+    { heading: 'Retro evidence (from the runtime)', body: renderRetroEvidence(evidence) },
+  ];
+}

--- a/runtime/src/retro/index.ts
+++ b/runtime/src/retro/index.ts
@@ -5,6 +5,7 @@ import { runDoctor } from '../doctor/index';
 import { stripFrontmatter } from '../loop/prompt';
 import type { ThreadHeader, ThreadStore } from '../threads/store';
 import type { VaultConfig } from '../vault/resolve-root';
+import { vaultOverview } from '../vault/overview';
 import { gatherRetroEvidence, renderRetroEvidence } from './evidence';
 import { readRetroState, writeRetroState, type RetroState } from './state';
 
@@ -90,6 +91,18 @@ export function retroStatus(opts: {
       ? `Last retro ${daysSince} day${daysSince === 1 ? '' : 's'} ago`
       : `Last retro ${daysSince} day${daysSince === 1 ? '' : 's'} ago · next due ${dueAt.toISOString().slice(0, 10)}`,
   };
+}
+
+/** `retroStatus` with the counts read from the vault and the thread store —
+ * what `GET /retro`, Home and Settings show. */
+export async function retroStatusFor(deps: { vaultRoot: string; tenant: Tenant; store: ThreadStore; vault: VaultStore; cfg: VaultConfig; now?: Date }): Promise<RetroStatus> {
+  const [headers, overview] = await Promise.all([deps.store.list(deps.tenant), vaultOverview(deps.vault, deps.tenant, deps.cfg)]);
+  return retroStatus({
+    state: readRetroState(deps.vaultRoot),
+    cfg: deps.cfg,
+    counts: { matters: overview.matters.length, threads: headers.length },
+    ...(deps.now === undefined ? {} : { now: deps.now }),
+  });
 }
 
 /** "since 2026-06-01" / "all time" — the period the retro covers, in the

--- a/runtime/src/retro/state.test.ts
+++ b/runtime/src/retro/state.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readRetroState, retroStatePath, writeRetroState } from './state';
+
+function vault(): string {
+  return mkdtempSync(join(tmpdir(), 'retro-state-'));
+}
+
+describe('retro state', () => {
+  test('no file is no retro yet', () => {
+    expect(readRetroState(vault())).toEqual({});
+  });
+
+  test('round-trips, atomically, under .counsel', () => {
+    const root = vault();
+    const state = { lastRetroAt: '2026-06-01T10:00:00.000Z', threadId: 'abc', period: { from: null, to: '2026-06-01T10:00:00.000Z' } };
+    writeRetroState(root, state);
+    expect(retroStatePath(root)).toBe(join(root, '.counsel', 'retro.json'));
+    expect(readRetroState(root)).toEqual(state);
+  });
+
+  test('a corrupt or foreign file reads as no retro, never as an error', () => {
+    const root = vault();
+    mkdirSync(join(root, '.counsel'), { recursive: true });
+    writeFileSync(retroStatePath(root), '{not json', 'utf8');
+    expect(readRetroState(root)).toEqual({});
+    writeFileSync(retroStatePath(root), JSON.stringify({ lastRetroAt: 42, threadId: 'x', period: { from: 1 } }), 'utf8');
+    expect(readRetroState(root)).toEqual({ threadId: 'x' });
+  });
+});

--- a/runtime/src/retro/state.ts
+++ b/runtime/src/retro/state.ts
@@ -1,0 +1,55 @@
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+/**
+ * `.counsel/retro.json` — when the practice last ran a retro, and in which
+ * thread. Runtime bookkeeping, so it lives under `.counsel/` next to the
+ * threads and the content state, written through `node:fs` like they are
+ * (the vault store refuses that prefix on purpose: no model-reachable tool
+ * can touch it).
+ */
+export interface RetroState {
+  /** ISO time the last retro thread was opened. */
+  lastRetroAt?: string;
+  threadId?: string;
+  /** The period that retro covered: `from` is `null` for "all time". */
+  period?: { from: string | null; to: string };
+}
+
+export function retroStatePath(vaultRoot: string): string {
+  return join(vaultRoot, '.counsel', 'retro.json');
+}
+
+/** `{}` when there has never been a retro, or the file is unreadable — a
+ * corrupt state file must not stop a retro from starting. */
+export function readRetroState(vaultRoot: string): RetroState {
+  const path = retroStatePath(vaultRoot);
+  if (!existsSync(path)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as unknown;
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) return {};
+    const rec = parsed as Record<string, unknown>;
+    const out: RetroState = {};
+    if (typeof rec['lastRetroAt'] === 'string') out.lastRetroAt = rec['lastRetroAt'];
+    if (typeof rec['threadId'] === 'string') out.threadId = rec['threadId'];
+    const period = rec['period'];
+    if (typeof period === 'object' && period !== null) {
+      const p = period as Record<string, unknown>;
+      if (typeof p['to'] === 'string' && (p['from'] === null || typeof p['from'] === 'string')) {
+        out.period = { from: p['from'] as string | null, to: p['to'] };
+      }
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Atomic: the file is either the old state or the new one. */
+export function writeRetroState(vaultRoot: string, state: RetroState): void {
+  const path = retroStatePath(vaultRoot);
+  mkdirSync(dirname(path), { recursive: true });
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+  renameSync(tmp, path);
+}

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -24,6 +24,9 @@ beforeEach(() => {
   vaultRoot = mkdtempSync(join(tmpdir(), 'routes-vault-'));
   pluginRoot = mkdtempSync(join(tmpdir(), 'routes-plugin-'));
   mkdirSync(join(pluginRoot, 'skills', 'counsel'), { recursive: true });
+  // The retro method is shipped content too (`retro/`): a retro step reads it.
+  mkdirSync(join(pluginRoot, 'skills', 'retro'), { recursive: true });
+  writeFileSync(join(pluginRoot, 'skills', 'retro', 'SKILL.md'), '---\nname: retro\n---\n# Retro\n\nStep 6: harvest promotable knowledge.\n', 'utf8');
   writeFileSync(join(pluginRoot, 'skills', 'counsel', 'SKILL.md'), '---\nname: counsel\n---\n\nBODY.\n', 'utf8');
   mkdirSync(join(pluginRoot, 'primitives'), { recursive: true });
   writeFileSync(join(pluginRoot, 'primitives', 'draft.md'), 'DRAFT.\n', 'utf8');
@@ -1440,5 +1443,53 @@ describe('the session cookie', () => {
     const viaBearer = await call(app, 'POST', '/session/clear');
     expect(viaBearer.status).toBe(204);
     expect(viaBearer.headers.getSetCookie()).toEqual(['counsel_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Strict']);
+  });
+});
+
+describe('retro (skills/retro in the runtime)', () => {
+  test('GET /retro says whether one is due; POST /retro opens the thread and records it', async () => {
+    const app = appWithFake();
+    expect((await call(app, 'GET', '/retro', { token: null })).status).toBe(401);
+
+    const before = (await (await call(app, 'GET', '/retro')).json()) as { due: boolean; lastRetroAt: string | null; cadenceDays: number };
+    expect(before).toMatchObject({ due: false, lastRetroAt: null, cadenceDays: 90 });
+
+    // Three matters make a first retro worth running.
+    for (const n of ['a', 'b', 'c']) await vault.write('default', `matters/${n}.md`, `---\ncounsel-os-type: matter\n---\n# ${n}\n`);
+    expect(((await (await call(app, 'GET', '/retro')).json()) as { due: boolean }).due).toBe(true);
+
+    expect((await call(app, 'POST', '/retro', { body: { since: 'not a date' } })).status).toBe(400);
+
+    const res = await call(app, 'POST', '/retro', { body: { since: '2026-06-01' } });
+    expect(res.status).toBe(201);
+    const start = (await res.json()) as { threadId: string; title: string; message: string; period: { from: string | null }; status: { due: boolean; threadId: string } };
+    expect(start.title).toMatch(/^Retro · 2026-06-01 to \d{4}-\d{2}-\d{2}$/);
+    expect(start.period.from).toBe('2026-06-01T00:00:00.000Z');
+    expect(start.message).toContain('as a proposal');
+    expect(start.status).toMatchObject({ due: false, threadId: start.threadId });
+
+    const header = (await store.list('default')).find(h => h.id === start.threadId)!;
+    expect(header.task).toBe('retro');
+    expect(header.title).toBe(start.title);
+    expect(existsSync(join(vaultRoot, '.counsel', 'retro.json'))).toBe(true);
+  });
+
+  test('a step on the retro thread runs as the retro task, with the method and the evidence in its prompt', async () => {
+    const provider = new FakeModelProvider([{ text: 'Running in harvest mode.' }]);
+    const app = appWith([provider]);
+    const { threadId, message } = (await (await call(app, 'POST', '/retro', { body: {} })).json()) as { threadId: string; message: string };
+    const res = await call(app, 'POST', `/threads/${threadId}/steps`, { body: { message } });
+    expect(res.status).toBe(200);
+    await res.text();
+    const { events } = await store.get('default', threadId);
+    const step = events.find(ev => 't' in ev && ev.t === 'step') as { task?: string } | undefined;
+    expect(step?.task).toBe('retro');
+    // The caller named no task; the thread did — and the prompt carries the
+    // method and the record, with every write re-stated as a proposal.
+    const system = provider.lastRequest?.system ?? '';
+    expect(system).toContain('## Retro method');
+    expect(system).toContain('propose_update');
+    expect(system).toContain('## Retro evidence (from the runtime)');
+    expect(system).toContain('Period: all time to');
   });
 });

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -15,6 +15,7 @@ import { readVaultConfig } from '../vault/resolve-root';
 import { applyUpdates, contentStatus, UpdateError } from '../content/update';
 import { repoContentSource } from '../content/repo';
 import { runDoctor } from '../doctor/index';
+import { retroStatusFor, startRetro } from '../retro/index';
 import { systemGit, type GitRunner } from '../setup/run';
 import { authorize, CLEAR_SESSION_COOKIE, withSessionCookie } from './auth';
 import {
@@ -61,7 +62,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session', 'retro'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -91,6 +92,12 @@ const PatchThreadBody = z
   .object({ title: z.string().max(200).optional(), matter: MATTER_PATH.nullable().optional() })
   .strict()
   .refine(b => b.title !== undefined || b.matter !== undefined, { message: 'nothing to change' });
+
+/** `POST /retro`: an optional period start; a bad date is a 400 like any
+ * other schema failure rather than a silently ignored one. */
+const RetroBody = z.object({
+  since: z.string().refine(v => !Number.isNaN(Date.parse(v)), 'since must be a date').optional(),
+});
 
 const StepBody = z.object({
   message: z.string().min(1),
@@ -742,6 +749,18 @@ export function createApp(deps: ServerDeps): App {
   const doctorRoute = (): Response =>
     json(runDoctor({ vaultRoot: deps.vaultRoot, pluginRoot: deps.pluginRoot, git: deps.git === undefined ? systemGit() : deps.git }));
 
+  /** `GET /retro` — when the practice last ran a retro and whether one is
+   * due (`retro/`); `POST /retro` — open the retro thread. The step itself
+   * is the ordinary `POST /threads/:id/steps` with the returned message:
+   * the thread's `task` is what makes it a retro. */
+  const retroDeps = () => ({ vaultRoot: deps.vaultRoot, tenant: deps.tenant, store: deps.store, vault: deps.vault, cfg: readVaultConfig(deps.vaultRoot) });
+  const retroStatusRoute = async (): Promise<Response> => json(await retroStatusFor(retroDeps()));
+  const retroStartRoute = async (req: Request): Promise<Response> => {
+    const input = await body(req, RetroBody);
+    const start = await startRetro(retroDeps(), input.since === undefined ? {} : { since: input.since });
+    return json({ ...start, status: await retroStatusFor(retroDeps()) }, 201);
+  };
+
   const docketRoute = async (): Promise<Response> =>
     json(await vaultDocket(deps.vault, deps.tenant, readVaultConfig(deps.vaultRoot)));
 
@@ -911,6 +930,11 @@ export function createApp(deps: ServerDeps): App {
       }
 
       if (segments.length === 1 && first === 'doctor' && method === 'GET') return doctorRoute();
+
+      if (segments.length === 1 && first === 'retro') {
+        if (method === 'GET') return await retroStatusRoute();
+        if (method === 'POST') return await retroStartRoute(req);
+      }
 
       return fail(404, `no route for ${method} ${url.pathname}`);
     }

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -23,6 +23,10 @@ export interface ThreadHeader {
   id: string;
   title?: string;
   matter?: string;
+  /** A task every step of this thread runs as, when the caller names none —
+   * `retro` for a retro thread, whose system prompt carries the method and
+   * the period's evidence. Absent for an ordinary conversation. */
+  task?: string;
   createdAt: string;
   updatedAt: string;
   sessions: Record<string, string>;
@@ -169,7 +173,7 @@ export class ThreadStore {
       .map(line => JSON.parse(line) as ThreadEvent);
   }
 
-  async create(tenant: Tenant, init: { title?: string; matter?: string } = {}): Promise<ThreadHeader> {
+  async create(tenant: Tenant, init: { title?: string; matter?: string; task?: string } = {}): Promise<ThreadHeader> {
     this.validateTenant(tenant);
     const id = randomUUID();
     const now = new Date().toISOString();
@@ -177,6 +181,7 @@ export class ThreadStore {
       id,
       title: init.title,
       matter: init.matter,
+      ...(init.task === undefined ? {} : { task: init.task }),
       createdAt: now,
       updatedAt: now,
       sessions: {},
@@ -208,6 +213,14 @@ export class ThreadStore {
     }
     this.writeHeader(tenant, header);
     return this.presentHeader(tenant, header);
+  }
+
+  /** The header alone, presented — for a caller that needs the thread's
+   * matter or task before it has any reason to read the log. */
+  async header(tenant: Tenant, id: string): Promise<ThreadHeader> {
+    this.validateTenant(tenant);
+    this.validateId(id);
+    return this.presentHeader(tenant, this.readHeader(tenant, id));
   }
 
   async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -29,6 +29,10 @@ export interface VaultConfig {
   /** `law_management: user` — the user owns ALL law content; the runtime
    * never syncs it (the plugin's `law-refresh` maintains it). */
   lawManagement: 'plugin' | 'user';
+  /** `retro_cadence_days: 60` — how often the practice retro is due. Absent
+   * → the retro module's default (quarterly). Optional so the many literal
+   * `VaultConfig`s in tests stay as they are. */
+  retroCadenceDays?: number;
 }
 
 const CWD_WALK_MAX_DEPTH = 3;
@@ -229,10 +233,14 @@ export function readVaultConfig(root: string): VaultConfig {
   };
 
   const flag = (raw: string | undefined): string => (raw ?? '').trim().replace(/^["']|["']$/g, '').toLowerCase();
+  // A cadence must be a positive whole number of days; anything else is
+  // ignored rather than turned into a surprising schedule.
+  const cadence = Number(flag(findOverride('retro_cadence_days')));
   return {
     entitiesPath: findOverride('entities_path') || 'entities',
     mattersPath: findOverride('matters_path') || 'matters',
     autoApplyLawUpdates: flag(findOverride('auto_apply_law_updates')) === 'true',
     lawManagement: flag(findOverride('law_management')) === 'user' ? 'user' : 'plugin',
+    ...(Number.isInteger(cadence) && cadence > 0 ? { retroCadenceDays: cadence } : {}),
   };
 }

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -82,6 +82,8 @@ export interface ThreadHeader {
   id: string;
   title?: string;
   matter?: string;
+  /** Every step of this thread runs as this task — `retro` for a retro. */
+  task?: string;
   createdAt: string;
   updatedAt: string;
   sessions: Record<string, string>;
@@ -434,4 +436,27 @@ export interface DoctorReport {
   findings: DoctorFinding[];
   verdict: 'healthy' | 'warnings' | 'broken';
   summary: string;
+}
+
+/** `GET /retro` (retro in the runtime). COPIED from
+ * `runtime/src/retro/index.ts`; a change there is a change here. */
+export interface RetroStatus {
+  lastRetroAt: string | null;
+  threadId: string | null;
+  cadenceDays: number;
+  daysSince: number | null;
+  dueAt: string | null;
+  due: boolean;
+  /** Why `due` is what it is, as a sentence. */
+  reason: string;
+}
+
+/** `POST /retro` — the retro thread, opened; the page sends `message` as
+ * the thread's first step. COPIED from `runtime/src/retro/index.ts`. */
+export interface RetroStart {
+  threadId: string;
+  title: string;
+  period: { from: string | null; to: string };
+  message: string;
+  status: RetroStatus;
 }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -963,3 +963,11 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
   outline-offset: 2px;
   border-radius: 4px;
 }
+
+/* The retro (skills/retro, in the runtime): one quiet line on Home when it
+   is due, and the Settings › Runtime row. Set text, no pill. */
+.v2-retro-due { margin: 4px 0 0; font: italic 13px/1.5 var(--serif); color: var(--fg-muted); }
+.v2-retro-due .v2-link { font: inherit; }
+.v2-retro { margin-top: 22px; }
+.v2-retro-line { margin: 6px 0 10px; font-size: 13px; color: var(--fg-muted); }
+.v2-retro-due-word { color: var(--warn, var(--accent)); font-style: italic; }

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -794,3 +794,48 @@ describe('Shell, the vault index refresh', () => {
     await waitFor(() => expect(fetched.filter(u => u.startsWith('/vault/index'))).toHaveLength(2));
   });
 });
+
+describe('Shell, running a retro (skills/retro in the runtime)', () => {
+  test('run a retro opens the retro thread and sends its first message as a step', async () => {
+    const retroHeader = { id: 't-r', title: 'Retro · all time · to 2026-09-01', task: 'retro', createdAt: at, updatedAt: at, sessions: {} };
+    const calls: Array<{ method: string; url: string; body?: unknown }> = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({ method, url, body: init?.body === undefined ? undefined : JSON.parse(String(init.body)) });
+      if (url.startsWith('/health')) return json(health);
+      if (url.startsWith('/runs')) return json([]);
+      if (url === '/threads') return json(calls.some(c => c.method === 'POST' && c.url === '/retro') ? [retroHeader, acme] : [acme]);
+      if (url === '/retro' && method === 'GET') {
+        return json({ lastRetroAt: '2026-05-01T00:00:00.000Z', threadId: 't-old', cadenceDays: 90, daysSince: 123, dueAt: '2026-07-30T00:00:00.000Z', due: true, reason: 'Last retro 123 days ago' });
+      }
+      if (url === '/retro' && method === 'POST') {
+        return new Response(JSON.stringify({ threadId: 't-r', title: retroHeader.title, period: { from: null, to: at }, message: 'Run the practice retro for all time.', status: { due: false } }), { status: 201, headers: { 'content-type': 'application/json' } });
+      }
+      if (url === '/threads/t-r/steps') {
+        return new Response('event: done\ndata: {"type":"done","output":null}\n\n', { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      }
+      if (url === '/threads/t-r') return json({ header: retroHeader, events: [] } satisfies Thread);
+      if (url.startsWith('/threads/')) return json({ header: acme, events: [] } satisfies Thread);
+      if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
+      if (url.startsWith('/proposals')) return json([]);
+      if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
+      if (url.startsWith('/vault/list') || url.startsWith('/vault/index')) return json([]);
+      if (url.startsWith('/settings')) return json(settings);
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as unknown as typeof fetch;
+
+    globalThis.history.replaceState(null, '', '#/');
+    render(<Shell />);
+    await userEvent.click(await screen.findByRole('button', { name: 'run a retro' }));
+
+    await waitFor(() => expect(calls.some(c => c.method === 'POST' && c.url === '/threads/t-r/steps')).toBe(true));
+    const step = calls.find(c => c.method === 'POST' && c.url === '/threads/t-r/steps')!;
+    expect((step.body as { message: string }).message).toBe('Run the practice retro for all time.');
+    // The thread is the one open on screen, and the URL names it.
+    expect(globalThis.location.hash).toBe('#/chat?thread=t-r');
+    await waitFor(() => expect(document.querySelector('.v2-thread-head h1')?.textContent).toContain('Retro ·'));
+    // No thread was created by the page: the runtime opened it.
+    expect(calls.some(c => c.method === 'POST' && c.url === '/threads')).toBe(false);
+  });
+});

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import { bootstrapToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
-import type { Health, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
+import type { Health, RetroStart, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
 import { VAULT_CHANGED_EVENT } from './intake';
@@ -277,6 +277,32 @@ export function Shell(): JSX.Element {
     return { threads: sorted, fresh };
   }, []);
 
+  /**
+   * A retro (skills/retro, in the runtime): `POST /retro` opens the retro
+   * thread — its header carries `task: retro`, which is what puts the method
+   * and the period's evidence into every step's prompt — and the pane sends
+   * the returned first message as an ordinary step. Same one-shot `initialAsk`
+   * as home's ask box, aimed at an existing thread instead of a draft.
+   */
+  const startRetro = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const start = await fetchJson<RetroStart>('/retro', { method: 'POST', body: JSON.stringify({}) });
+      setNotFound(false);
+      setSelected(start.threadId);
+      setDraft(false);
+      setChatKey(k => k + 1);
+      setInitialAsk(current => ({ text: start.message, nonce: (current?.nonce ?? 0) + 1 }));
+      setRoute('chat');
+      setVaultPath(null);
+      globalThis.history.replaceState(null, '', `#/chat?thread=${encodeURIComponent(start.threadId)}`);
+      void loadThreads();
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setError(`could not start the retro: ${detail(err)}`);
+    }
+  }, [loadThreads]);
+
+
   /** Bumped by the setup page once a vault exists: re-runs the initial load. */
   const [attempt, setAttempt] = useState(0);
   useEffect(() => {
@@ -467,7 +493,7 @@ export function Shell(): JSX.Element {
 
         {/* The pages wait for /health: before it answers, the runtime may be
             in setup mode, and Home's own reads would be 409s. */}
-        {route === 'home' && health !== null ? <HomePage threads={threads} onAsk={startAsk} onOpenThread={openThread} health={health} /> : null}
+        {route === 'home' && health !== null ? <HomePage threads={threads} onAsk={startAsk} onOpenThread={openThread} health={health} onStartRetro={() => void startRetro()} /> : null}
 
         {route === 'vault' && health !== null ? (
           <VaultPage
@@ -481,7 +507,7 @@ export function Shell(): JSX.Element {
 
         {route === 'settings' && health !== null ? (
           <main className="v2-page">
-            <SettingsPage health={health} />
+            <SettingsPage health={health} onStartRetro={() => void startRetro()} />
           </main>
         ) : null}
       </div>

--- a/runtime/ui/src/v2/home/HomePage.test.tsx
+++ b/runtime/ui/src/v2/home/HomePage.test.tsx
@@ -44,6 +44,7 @@ let pending: PendingProposal[] = [];
 let docketBody: DocketView = { deadlines: [], skipped: 0 };
 let overviewBody: VaultOverview = overview;
 let truncatedHeader = false;
+let retroBody: Record<string, unknown> | null = null;
 
 function json(body: unknown, headers: Record<string, string> = {}): Response {
   return new Response(JSON.stringify(body), {
@@ -68,6 +69,7 @@ beforeEach(() => {
   docketBody = { deadlines: [], skipped: 0 };
   overviewBody = overview;
   truncatedHeader = false;
+  retroBody = null;
   sessionStorage.setItem(TOKEN_KEY, 'test-token');
   history.replaceState(null, '', '/#/');
   globalThis.fetch = (async (input: RequestInfo | URL) => {
@@ -75,6 +77,7 @@ beforeEach(() => {
     if (url.startsWith('/vault/overview')) return json(overviewBody);
     if (url.startsWith('/proposals')) return json(pending, truncatedHeader ? { 'x-counsel-truncated': '1' } : {});
     if (url.startsWith('/docket')) return json(docketBody);
+    if (url.startsWith('/retro')) return retroBody === null ? new Response('nope', { status: 404 }) : json(retroBody);
     if (url.startsWith('/vault/list')) return json([]);
     throw new Error(`unexpected fetch: ${url}`);
   }) as unknown as typeof fetch;
@@ -475,5 +478,29 @@ describe('HomePage document intake (docx spec §6)', () => {
     fireEvent.drop(document.querySelector('.v2-ask')!, { dataTransfer: dt([NDA()]) });
     await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
     expect(screen.getByRole('alert').textContent).toContain('larger than the 25 MB limit');
+  });
+});
+
+describe('HomePage, the retro due line (skills/retro in the runtime)', () => {
+  test('due: one line of set text under the greeting; run a retro hands off to the shell', async () => {
+    retroBody = { lastRetroAt: '2026-05-01T00:00:00.000Z', threadId: 't', cadenceDays: 90, daysSince: 123, dueAt: '2026-07-30T00:00:00.000Z', due: true, reason: 'Last retro 123 days ago' };
+    let started = 0;
+    mount({ onStartRetro: () => (started += 1) });
+    const line = await screen.findByText(/Last retro 123 days ago/);
+    expect(line.className).toBe('v2-retro-due');
+    await userEvent.click(screen.getByRole('button', { name: 'run a retro' }));
+    expect(started).toBe(1);
+  });
+
+  test('not due, or unreadable: nothing', async () => {
+    retroBody = { lastRetroAt: '2026-08-20T00:00:00.000Z', threadId: 't', cadenceDays: 90, daysSince: 12, dueAt: '2026-11-18T00:00:00.000Z', due: false, reason: 'Last retro 12 days ago · next due 2026-11-18' };
+    mount();
+    await waitFor(() => expect(screen.getByText('Vendora × Worldpay — documentation')).toBeTruthy());
+    expect(document.querySelector('.v2-retro-due')).toBeNull();
+    cleanup();
+    retroBody = null;
+    mount();
+    await waitFor(() => expect(screen.getByText('Vendora × Worldpay — documentation')).toBeTruthy());
+    expect(document.querySelector('.v2-retro-due')).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/home/HomePage.tsx
+++ b/runtime/ui/src/v2/home/HomePage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, fetchJsonWithHeaders, moveFile } from '../../api/client';
-import type { DocketEntry, DocketView, Health, PendingProposal, ThreadHeader, VaultOverview } from '../../api/types';
+import type { DocketEntry, DocketView, Health, PendingProposal, RetroStatus, ThreadHeader, VaultOverview } from '../../api/types';
 import { ProviderNotice } from '../ProviderNotice';
 import { Tree } from '../../vault/Tree';
 import { MatterPicker } from '../chat/MatterPicker';
@@ -73,6 +73,8 @@ export interface HomePageProps {
   /** For the swap notice above the ask box (cou-95). Absent = no notice. */
   health?: Health | null;
   onOpenThread: (id: string) => void;
+  /** "run a retro" on the due line: the shell opens the retro thread. */
+  onStartRetro?: () => void;
 }
 
 /**
@@ -82,13 +84,15 @@ export interface HomePageProps {
  * `/vault/overview` + `/proposals?status=pending`, fetched on mount — the
  * shell mounts this page per visit to Home, so the docket is always current.
  */
-export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps): JSX.Element {
+export function HomePage({ threads, onAsk, onOpenThread, health, onStartRetro }: HomePageProps): JSX.Element {
   const [overview, setOverview] = useState<VaultOverview | null>(null);
   const [pending, setPending] = useState<PendingProposal[]>([]);
   /** The proposal scan was bounded — there may be proposals it never saw. */
   const [truncated, setTruncated] = useState(false);
   /** The deadline sweep (`GET /docket`): dated obligations off the matters. */
   const [docket, setDocket] = useState<DocketView>({ deadlines: [], skipped: 0 });
+  /** `GET /retro`: shown only when a retro is due; a failed read shows nothing. */
+  const [retro, setRetro] = useState<RetroStatus | null>(null);
   /** The "later" group unfolds in place; it starts folded. */
   const [laterOpen, setLaterOpen] = useState(false);
   const [vaultError, setVaultError] = useState<string | null>(null);
@@ -137,11 +141,15 @@ export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps
    */
   useEffect(() => {
     void (async () => {
-      const [ov, proposals, sweep] = await Promise.allSettled([
+      const [ov, proposals, sweep, retroRead] = await Promise.allSettled([
         fetchJson<VaultOverview>('/vault/overview'),
         fetchJsonWithHeaders<PendingProposal[]>('/proposals?status=pending'),
         fetchJson<unknown>('/docket'),
+        fetchJson<RetroStatus>('/retro'),
       ]);
+      // The retro line is a courtesy: an older runtime without /retro, or a
+      // failed read, shows nothing rather than an error.
+      if (retroRead.status === 'fulfilled' && typeof retroRead.value === 'object' && retroRead.value !== null && typeof retroRead.value.due === 'boolean') setRetro(retroRead.value);
       if (ov.status === 'fulfilled') setOverview(ov.value);
       else setVaultError(failureNote(ov.reason, 'could not read the vault'));
       if (proposals.status === 'fulfilled') {
@@ -200,6 +208,15 @@ export function HomePage({ threads, onAsk, onOpenThread, health }: HomePageProps
       <div className="v2-home-wrap">
         <div className="v2-hi">{greetingFor()}</div>
         {subline === null ? null : <div className="v2-sub">{subline}</div>}
+        {retro !== null && retro.due ? (
+          <p className="v2-retro-due" role="status">
+            {retro.reason}
+            {' · '}
+            <button type="button" className="v2-link" onClick={onStartRetro}>
+              run a retro
+            </button>
+          </p>
+        ) : null}
 
         <ProviderNotice health={health} />
         <div

--- a/runtime/ui/src/v2/settings/RetroAction.test.tsx
+++ b/runtime/ui/src/v2/settings/RetroAction.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { TOKEN_KEY } from '../../api/token';
+import type { RetroStatus } from '../../api/types';
+import { RetroAction, retroDateLabel } from './RetroAction';
+
+const realFetch = globalThis.fetch;
+let status: RetroStatus | null = null;
+
+function json(body: unknown, code = 200): Response {
+  return new Response(JSON.stringify(body), { status: code, headers: { 'content-type': 'application/json' } });
+}
+
+beforeEach(() => {
+  sessionStorage.setItem(TOKEN_KEY, 'test-token');
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url === '/retro') return status === null ? json({ error: 'no route' }, 404) : json(status);
+    throw new Error(`unexpected fetch: ${url}`);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  sessionStorage.clear();
+  status = null;
+});
+
+describe('RetroAction', () => {
+  test('never run: says so with the cadence, and the button opens a retro', async () => {
+    status = { lastRetroAt: null, threadId: null, cadenceDays: 90, daysSince: null, dueAt: null, due: false, reason: 'No retro yet' };
+    let started = 0;
+    render(<RetroAction onStart={() => (started += 1)} />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toBe('No retro yet · due every 90 days'));
+    await userEvent.click(screen.getByRole('button', { name: 'Run a retro' }));
+    expect(started).toBe(1);
+  });
+
+  test('last run and due now, as set text', async () => {
+    status = { lastRetroAt: '2026-05-01T10:00:00.000Z', threadId: 't', cadenceDays: 60, daysSince: 123, dueAt: '2026-06-30T10:00:00.000Z', due: true, reason: 'Last retro 123 days ago' };
+    render(<RetroAction onStart={() => {}} />);
+    await waitFor(() => expect(screen.getByRole('status').textContent).toContain('(123 days ago) · due every 60 days · due now'));
+    expect(screen.getByRole('status').textContent).toContain(retroDateLabel('2026-05-01T10:00:00.000Z'));
+    expect(document.querySelector('.v2-pill')).toBeNull();
+  });
+
+  test('an older runtime without /retro keeps the row and the action, with no line', async () => {
+    render(<RetroAction onStart={() => {}} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Run a retro' })).toBeTruthy());
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+});

--- a/runtime/ui/src/v2/settings/RetroAction.tsx
+++ b/runtime/ui/src/v2/settings/RetroAction.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { ApiError, fetchJson } from '../../api/client';
+import type { RetroStatus } from '../../api/types';
+
+export interface RetroActionProps {
+  /** The shell opens the retro thread and sends its first step. Absent =
+   * the button does nothing visible, so the row still reads. */
+  onStart?: () => void;
+}
+
+/** `2026-06-05` as the row shows it. */
+export function retroDateLabel(iso: string): string {
+  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+/**
+ * Settings › Runtime: the practice retro (`skills/retro`, in the runtime).
+ * One line of set text — when it last ran and how often it is due — and
+ * the action. The retro itself is a conversation: the button opens it.
+ */
+export function RetroAction({ onStart }: RetroActionProps): JSX.Element {
+  const [status, setStatus] = useState<RetroStatus | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        setStatus(await fetchJson<RetroStatus>('/retro'));
+      } catch (err) {
+        // An older runtime has no /retro; the row then says only what the
+        // action does. A 401 is the shell's to report.
+        if (err instanceof ApiError && err.status === 401) return;
+        setStatus(null);
+      }
+    })();
+  }, []);
+
+  return (
+    <div className="v2-retro">
+      <h3 className="runin">Retro</h3>
+      <p className="muted">
+        A look back over the practice — what counsel learned, which positions drifted, what to promote from the matters into your standards, methods and memory. It runs as a conversation; every change it suggests comes back as a proposal for you to approve.
+      </p>
+      <p className="v2-retro-line" role="status">
+        {status === null ? null : status.lastRetroAt === null ? (
+          <span>No retro yet · due every {status.cadenceDays} days</span>
+        ) : (
+          <span>
+            Last retro {retroDateLabel(status.lastRetroAt)}
+            {status.daysSince === null ? null : ` (${status.daysSince} day${status.daysSince === 1 ? '' : 's'} ago)`} · due every {status.cadenceDays} days
+            {status.due ? <em className="v2-retro-due-word"> · due now</em> : null}
+          </span>
+        )}
+      </p>
+      <button type="button" onClick={onStart} disabled={onStart === undefined}>
+        Run a retro
+      </button>
+    </div>
+  );
+}

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
 import { ContentGroup } from './ContentGroup';
 import { DoctorLedger } from './DoctorLedger';
+import { RetroAction } from './RetroAction';
 import {
   emptyRoute,
   emptyRow,
@@ -25,6 +26,8 @@ import {
 
 export interface SettingsPageProps {
   health: HealthData | null;
+  /** Runtime › "Run a retro": the shell opens the retro thread. */
+  onStartRetro?: () => void;
 }
 
 /** The subscription provider every install already has. Named here so the
@@ -38,7 +41,7 @@ const CLAUDE_BUILTIN = 'claude-sub/claude-opus-5';
  * then Test, then Runtime, read-only. Each group opens with a plain line
  * saying what it is for.
  */
-export function SettingsPage({ health }: SettingsPageProps): JSX.Element {
+export function SettingsPage({ health, onStartRetro }: SettingsPageProps): JSX.Element {
   const [view, setView] = useState<SettingsView | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -86,6 +89,7 @@ export function SettingsPage({ health }: SettingsPageProps): JSX.Element {
           <section className="v2-group">
             <Health health={health} effective={view.effective} file={view.file} />
             <DoctorLedger />
+            <RetroAction onStart={onStartRetro} />
           </section>
         </>
       )}

--- a/skills/retro/SKILL.md
+++ b/skills/retro/SKILL.md
@@ -5,6 +5,8 @@ description: "Practice analytics: matter and counterparty trends, knowledge-base
 
 # Retro — Practice Analytics
 
+> The counsel-os runtime runs this same retro without Claude Code: `bun runtime/src/cli.ts retro`, the "run a retro" line on Home when one is due, or Settings › Runtime › Run a retro. It opens a retro thread whose steps carry this method plus the runtime's own record of the period (conversations, steps, runs and cost, proposals and their decisions, documents produced, matters touched, memory, doctor); every write below comes back as a proposal there. Cadence: `retro_cadence_days` in `config.md` (default 90).
+
 You are running a retrospective analysis of the user's legal practice. Your job is to analyze accumulated data in the memory and matters files, identify trends, and recommend improvements to positions, processes, and priorities.
 
 **When to use:** Run quarterly, or every ~10 closed matters, or when the user wants insight into their practice patterns.


### PR DESCRIPTION
The plugin's quarterly `/counsel-os:retro` had no runtime equivalent. This makes a retro a normal counsel THREAD:

- `POST /retro` and `counsel-os retro [--since <date>]` open a `Retro · <period>` thread with `task: retro` on its header, record `.counsel/retro.json`, and return a short first message; the UI (Home's due line, Settings › Runtime › Run a retro) sends it as an ordinary step.
- The loop runs every step of a thread as the header's task when the caller names none. For `retro`, the system prompt carries two extra sections: the retro method (`skills/retro/SKILL.md`, now in `SHIPPED_ROOTS`) with a host note that every write is a `propose_update`, and the runtime's evidence for the period — conversations and steps by task/provider, runs with cost and errors, proposals by decision, documents produced (applied/skipped/comments), matters touched, `memory/patterns.md` size and previous snapshots, and the doctor's findings. Read-only; regenerated on every step of the thread.
- `GET /retro`: last retro, cadence (`retro_cadence_days` in `config.md`, default 90), days since, due. First retro is due once the vault has 3 matters or 10 conversations.
- No modal, no wizard: one line on Home when due, one row in Settings.

Tests: `bun run test` 899 · `bun run ui:test` 478 · typechecks clean · `ui:build` ok. New: `runtime/src/retro/{state,index,evidence}.test.ts` (seeded temp vault, evidence snapshot), routes (`GET`/`POST /retro`, a step on the retro thread runs as `retro` and the fake provider's system prompt carries both sections), `RetroAction.test.tsx`, Home due-line tests, a Shell test for the hand-off. One existing loop test adjusted: the existence check now reads the header alone, so it counts two full reads instead of three.

Plan: `docs/superpowers/plans/2026-09-01-runtime-retro.md`.