### PR TITLE
runtime+ui: a matter that stays on this machine — the per-matter privacy policy (providers spec §7)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -50,6 +50,7 @@ entities_path: entities
 matters_path: matters
 auto_apply_law_updates: false
 law_management: plugin
+default_locality: any
 entity_properties:
   type_field: counsel-os-type
   values: [counterparty, vendor, customer, prospect, matter]
@@ -64,6 +65,16 @@ syncing law content entirely, and `/counsel-os:law-refresh` maintains it instead
 For per-file ownership, set `managed-by: user` in an individual law file's
 frontmatter — update skips marked files (even under auto-apply) and law-refresh
 maintains them. Custom law areas the user creates are user-owned automatically.
+
+`default_locality: local` keeps every matter on this machine: a step for any
+matter runs only on a local model (Ollama, LM Studio, another loopback
+server), never on a cloud provider. A matter opts out with `stays_local: false`
+in its frontmatter, and any matter can opt in alone with `stays_local: true`
+(a folder matter's `matter.md` governs everything in its folder). The policy is
+decided before the first model call — from the conversation's linked matter,
+else a matter document attached to the message, else this default — and is
+never downgraded silently: with no local model loaded the step does not run
+and the app says so.
 
 ## Documents in matters
 

--- a/docs/superpowers/plans/2026-09-01-matter-policy.md
+++ b/docs/superpowers/plans/2026-09-01-matter-policy.md
@@ -1,0 +1,26 @@
+# Matter privacy policy — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** a matter marked `stays_local: true` (or a vault whose default locality is `local`) never has a step run on a cloud provider — decided before the first call, enforced by the runtime, shown in the UI, never downgraded silently.
+
+**Architecture:** one pure policy module (`runtime/src/vault/policy.ts`) reads the declaration; the router gains a `localOnly` path with an `isLocal(caps)` helper; the counsel loop evaluates the policy right after the thread header, before the user turn is appended and before the provider is resolved; the step route pre-flights the same check and answers 409 without streaming; `GET /threads/:id` reports the header-derived policy so the UI can show it.
+
+**Tech stack:** Bun/TypeScript runtime, React UI, bun test + happy-dom.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-providers-design.md` §7, §9–§11 step 4.
+
+## Global constraints
+- `isLocal(caps)` = `caps.auth === 'local'` today; step 1 of the providers track switches it to `caps.locality`. One helper, one comment.
+- An inferred matter never sets policy.
+- No new pills, modals, or banners: set text in the existing notice/line slots.
+- No edits to Settings/first-run provider rows beyond the one checkbox.
+
+## Tasks
+1. [x] `VaultConfig.defaultLocality` from `default_locality` in config.md (resolve-root) — test.
+2. [x] `vault/policy.ts`: `matterFor(path)`, `matterPolicy`, `policyForStep` (explicit link → attachment chips → vault default; folder matters; `stays_local: false` beats a local vault default) — tests.
+3. [x] Router: `isLocal`, `resolve(task, { localOnly })`, `MatterStaysLocalError` — tests (best local; prefer honoured when local; explicit cloud refused by the loop; none → typed error).
+4. [x] Loop: policy computed after the header, provider resolved BEFORE the user append; run record carries `policy: 'stays-local'`; exports `policyForOptions` + `resolveStepProvider` for the route — tests.
+5. [x] Routes: `POST /threads/:id/steps` pre-flight → 409 `{ error: 'matter-stays-local', message }`; `GET /threads/:id` carries `policy` — tests.
+6. [x] Setup: `staysLocalDefault` in the plan → `default_locality: local` in config.md — tests; CONFIGURATION.md.
+7. [x] UI: thread `policy` type; header `· stays local` and the "link it" offer for an inferred `stays_local` matter; composer policy notice; 409 shown without Retry; switcher greys cloud rows; reader facts `stays local · yes`; first-run checkbox — tests.

--- a/runtime/src/core/types.ts
+++ b/runtime/src/core/types.ts
@@ -170,3 +170,11 @@ export class RouterError extends Error {
   readonly code = 'router';
 }
 
+/** A matter's privacy policy could not be honoured (providers spec §7): the
+ * caller named a cloud provider for a matter that stays local, or no local
+ * model is loaded. The route answers 409 `matter-stays-local`; the step never
+ * runs. */
+export class MatterStaysLocalError extends Error {
+  readonly code = 'matter-stays-local';
+}
+

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -404,7 +404,7 @@ describe('runStep', () => {
     expect(events[0]!.type).toBe('error');
   });
 
-  test('(f) a router hard error yields a single error, with only the user event appended', async () => {
+  test('(f) a router hard error yields a single error, with nothing appended — the provider is chosen before the user turn is written', async () => {
     const fake = new FakeModelProvider([{ text: 'never' }]);
     const router = new Router(
       { default: 'fake/fake', tasks: { classify: { prefer: 'nope/nope', require: { contextTokens: 10_000_000 } } } },
@@ -417,7 +417,7 @@ describe('runStep', () => {
     expect(events).toHaveLength(1);
     expect(events[0]!.type).toBe('error');
     expect((events[0] as Extract<StepEvent, { type: 'error' }>).message).toContain('classify');
-    expect(await logKinds(id)).toEqual(['user']);
+    expect(await logKinds(id)).toEqual([]);
     expect(fake.lastRequest).toBeUndefined();
   });
 
@@ -429,7 +429,7 @@ describe('runStep', () => {
 
     expect(events).toHaveLength(1);
     expect(events[0]!.type).toBe('error');
-    expect(await logKinds(id)).toEqual(['user']);
+    expect(await logKinds(id)).toEqual([]);
   });
 
   test('a resume failure drops the stored session and replays the log once', async () => {
@@ -1588,5 +1588,76 @@ describe('runStep — the run record', () => {
     const second = await collect(runStep(deps([fake]), { threadId: id, message: 'second' }));
 
     expect(listRuns(vaultRoot, 'default', id).map(r => r.runId)).toEqual([second[0]!.runId, first[0]!.runId]);
+  });
+});
+
+describe('the matter privacy policy (providers spec §7)', () => {
+  function cloud(id = 'anthropic/cloud'): ModelProvider {
+    const fake = new FakeModelProvider([{ text: 'from the cloud' }]);
+    return { id, kind: 'direct', capabilities: { ...fake.capabilities, auth: 'apikey' }, run: req => fake.run(req) };
+  }
+  function local(id = 'ollama/local'): ModelProvider {
+    const fake = new FakeModelProvider([{ text: 'from this machine' }]);
+    return { id, kind: 'direct', capabilities: { ...fake.capabilities, auth: 'local' }, run: req => fake.run(req) };
+  }
+
+  test('a linked matter that stays local runs on the best local provider, and the record says so', async () => {
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const providers = [cloud(), local()];
+    const { id } = await store.create('default', { matter: 'matters/acme.md' });
+    const events = await collect(runStep(deps(providers), { threadId: id, message: 'review it' }));
+    expect(events.map(e => e.type)).toContain('done');
+    const { events: log } = await store.get('default', id);
+    const stepEv = log.find(e => 't' in e && e.t === 'step') as { provider: string };
+    expect(stepEv.provider).toBe('ollama/local');
+    const [rec] = listRuns(vaultRoot, 'default', id);
+    expect(rec!.policy).toBe('stays-local');
+    expect(rec!.provider).toBe('ollama/local');
+  });
+
+  test('an explicit cloud provider for such a matter is refused before the user turn is appended', async () => {
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const { id } = await store.create('default', { matter: 'matters/acme.md' });
+    const events = await collect(runStep(deps([cloud(), local()]), { threadId: id, message: 'review it', providerId: 'anthropic/cloud' }));
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect((events[0] as { message: string }).message).toContain('stays on this machine');
+    const { events: log } = await store.get('default', id);
+    expect(log.filter(e => 't' in e && e.t === 'user')).toHaveLength(0);
+    const [rec] = listRuns(vaultRoot, 'default', id);
+    expect(rec!.status).toBe('error');
+  });
+
+  test('no local provider at all: the step never runs, the sentence is the founder\'s', async () => {
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const { id } = await store.create('default', { matter: 'matters/acme.md' });
+    const events = await collect(runStep(deps([cloud()]), { threadId: id, message: 'review it' }));
+    expect(events.map(e => e.type)).toEqual(['error']);
+    expect((events[0] as { message: string }).message).toBe('This matter stays on this machine, and no local model is loaded.');
+    const { events: log } = await store.get('default', id);
+    expect(log).toHaveLength(0);
+  });
+
+  test('an attached document under a stays-local matter decides for an unlinked thread; an inferred matter never does', async () => {
+    await vault.write('default', 'matters/acme/matter.md', '---\nstays_local: true\n---\n# Acme\n');
+    const providers = [cloud(), local()];
+    const { id } = await store.create('default', {});
+    await collect(runStep(deps(providers), { threadId: id, message: 'Review this.\n\n`matters/acme/nda.docx`' }));
+    let { events: log } = await store.get('default', id);
+    expect((log.find(e => 't' in e && e.t === 'step') as { provider: string }).provider).toBe('ollama/local');
+
+    // The same thread, a plain message, still unlinked: the header carries
+    // no matter, so the policy is the vault's (none) — cloud is fine.
+    await collect(runStep(deps(providers), { threadId: id, message: 'and now a general question' }));
+    ({ events: log } = await store.get('default', id));
+    const steps = log.filter(e => 't' in e && e.t === 'step') as Array<{ provider: string }>;
+    expect(steps[1]!.provider).toBe('anthropic/cloud');
+  });
+
+  test('the vault default applies to every unlinked thread', async () => {
+    writeFileSync(join(vaultRoot, 'config.md'), 'counsel-os-config: true\nlegal_root: x\ndefault_locality: local\n', 'utf8');
+    const { id } = await store.create('default', {});
+    await collect(runStep(deps([cloud(), local()]), { threadId: id, message: 'hello' }));
+    const { events: log } = await store.get('default', id);
+    expect((log.find(e => 't' in e && e.t === 'step') as { provider: string }).provider).toBe('ollama/local');
   });
 });

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -6,6 +6,9 @@ import type { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent, type ThreadHeader } from '../threads/store';
 import { window } from '../threads/window';
 import { readVaultConfig, type VaultConfig } from '../vault/resolve-root';
+import { policyForStep, readerOver, type StepPolicy } from '../vault/policy';
+import { isLocal } from '../router/router';
+import { MatterStaysLocalError } from '../core/types';
 import { guardedVaultTools } from '../vault/vault-tools';
 import { builtinTools } from '../tools/builtin';
 import { ToolRegistry } from '../tools/registry';
@@ -115,14 +118,35 @@ function bindToThread(deps: CounselLoopDeps, provider: ModelProvider, threadId: 
   });
 }
 
-function resolveProvider(deps: CounselLoopDeps, opts: RunStepOptions): ModelProvider {
+/**
+ * The matter's privacy policy for one step (providers spec §7), from the
+ * thread's explicit matter, the message's attachment chips, or the vault
+ * default — decided before any provider is chosen.
+ */
+export async function policyForOptions(
+  deps: Pick<CounselLoopDeps, 'tenant' | 'vaultRoot' | 'vault'>,
+  opts: { matter?: string | undefined; message: string },
+): Promise<StepPolicy> {
+  return policyForStep({ ...(opts.matter === undefined ? {} : { matter: opts.matter }), message: opts.message }, readVaultConfig(deps.vaultRoot), readerOver(deps.vault, deps.tenant));
+}
+
+/**
+ * The provider for a step, honouring the policy: an explicit `providerId`
+ * that is not local is refused outright under `localOnly` (never a silent
+ * swap), and the router's local-only path picks among what is loaded.
+ */
+export function resolveStepProvider(deps: CounselLoopDeps, opts: RunStepOptions, policy: StepPolicy): ModelProvider {
   if (opts.providerId) {
     const found = deps.providers.find(p => p.id === opts.providerId);
     if (!found) throw new Error(`unknown provider: ${opts.providerId}`);
+    if (policy.localOnly && !isLocal(found.capabilities)) {
+      throw new MatterStaysLocalError(`This matter stays on this machine; ${found.id} is not a local model.`);
+    }
     return found;
   }
-  return deps.router.resolve(opts.task);
+  return deps.router.resolve(opts.task, { localOnly: policy.localOnly });
 }
+
 
 /**
  * The tools a counsel step gets: the vault tools with the `remember` gate
@@ -184,6 +208,10 @@ export async function* runStep(
     return;
   }
   if (opts.task === undefined && early.task !== undefined) opts = { ...opts, task: early.task };
+  // The matter's privacy policy, from the header and the message — before
+  // the run opens, before the user turn is appended, before any provider is
+  // looked at (providers spec §7).
+  const policy = await policyForOptions(deps, { ...(early.matter === undefined ? {} : { matter: early.matter }), message: opts.message });
 
   // The run record opens here — before the provider is even chosen — so
   // everything that follows is visible to `/runs` while it is happening and
@@ -227,6 +255,20 @@ export async function* runStep(
   // `running` for a step nothing was wrong with.
   let deadline: Deadline | undefined;
   try {
+    // The provider is chosen BEFORE the user turn is appended: a step the
+    // policy refuses (a cloud provider named for a matter that stays local,
+    // or no local model at all) never ran, so the transcript must not show
+    // a question nobody answered.
+    let provider: ModelProvider;
+    try {
+      provider = bindToThread(deps, resolveStepProvider(deps, opts, policy), threadId);
+    } catch (err) {
+      failRun(message(err));
+      yield { type: 'error', message: message(err), runId };
+      return;
+    }
+    patchRun(deps, runId, { provider: provider.id, ...(policy.localOnly ? { policy: 'stays-local' as const } : {}) });
+
     const userFailed = await tryPersist(() =>
       store.append(tenant, threadId, { t: 'user', at: nowIso(), content: opts.message }),
     );
@@ -235,16 +277,6 @@ export async function* runStep(
       yield { type: 'error', message: userFailed, runId };
       return;
     }
-
-    let provider: ModelProvider;
-    try {
-      provider = bindToThread(deps, resolveProvider(deps, opts), threadId);
-    } catch (err) {
-      failRun(message(err));
-      yield { type: 'error', message: message(err), runId };
-      return;
-    }
-    patchRun(deps, runId, { provider: provider.id });
 
     const stepFailed = await tryPersist(() =>
       store.append(tenant, threadId, {

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -48,6 +48,9 @@ export interface RunRecord {
    * (web-ui spec §4.3): `error` says what went wrong, this says what the
    * model actually wrote. Unset for every other kind of failure. */
   errorText?: string;
+  /** `stays-local` when the matter's privacy policy chose the provider
+   * (providers spec §7) — the record shows the policy was in force. */
+  policy?: 'stays-local';
 }
 
 /**

--- a/runtime/src/router/router.test.ts
+++ b/runtime/src/router/router.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { Router, parseRouterConfig } from './router';
-import { RouterError } from '../core/types';
+import { MatterStaysLocalError, RouterError } from '../core/types';
 import type { ModelProvider } from '../core/types';
 
 function p(id: string, caps: Partial<ModelProvider['capabilities']> = {}): ModelProvider {
@@ -37,5 +37,40 @@ describe('Router', () => {
   });
   test('missing default provider is a hard error', () => {
     expect(() => new Router({ default: 'x/y' }, providers).resolve()).toThrow(RouterError);
+  });
+});
+
+describe('Router, a matter that stays local (providers spec §7)', () => {
+  const local = p('ollama/qwen3', { auth: 'local', contextTokens: 32_000 });
+  const localBig = p('ollama/big', { auth: 'local', contextTokens: 128_000, tools: false });
+  const cloud = p('anthropic/claude-opus-5');
+
+  test('ignores a cloud default and picks the best local provider — tools first, then context', () => {
+    const router = new Router({ default: cloud.id }, [cloud, localBig, local]);
+    expect(router.resolve(undefined, { localOnly: true }).id).toBe('ollama/qwen3');
+    const noTools = new Router({ default: cloud.id }, [cloud, localBig]);
+    expect(noTools.resolve(undefined, { localOnly: true }).id).toBe('ollama/big');
+  });
+
+  test('honours a local preference and a local default', () => {
+    const router = new Router({ default: local.id, tasks: { draft: { prefer: localBig.id } } }, [cloud, localBig, local]);
+    expect(router.resolve('draft', { localOnly: true }).id).toBe('ollama/big');
+    expect(router.resolve('other', { localOnly: true }).id).toBe('ollama/qwen3');
+  });
+
+  test('a cloud preference is skipped, never used', () => {
+    const router = new Router({ default: cloud.id, tasks: { review: { prefer: cloud.id } } }, [cloud, local]);
+    expect(router.resolve('review', { localOnly: true }).id).toBe('ollama/qwen3');
+  });
+
+  test('no local provider is a typed error, not a cloud fallback', () => {
+    const router = new Router({ default: cloud.id }, [cloud]);
+    expect(() => router.resolve(undefined, { localOnly: true })).toThrow(MatterStaysLocalError);
+    expect(() => router.resolve(undefined, { localOnly: true })).toThrow('no local model is loaded');
+  });
+
+  test('without the option nothing changes', () => {
+    const router = new Router({ default: cloud.id }, [cloud, local]);
+    expect(router.resolve().id).toBe(cloud.id);
   });
 });

--- a/runtime/src/router/router.ts
+++ b/runtime/src/router/router.ts
@@ -1,5 +1,5 @@
 import type { Capabilities, ModelProvider } from '../core/types';
-import { RouterError } from '../core/types';
+import { MatterStaysLocalError, RouterError } from '../core/types';
 
 export type Require = Partial<Pick<Capabilities, 'tools' | 'caching' | 'thinking' | 'contextTokens'>>;
 
@@ -22,8 +22,24 @@ export function parseRouterConfig(yamlText: string): RouterConfig {
   return raw as RouterConfig;
 }
 
+/**
+ * Whether a provider keeps the text on this machine. Today the credential
+ * type stands in for locality; providers step 1 adds `Capabilities.locality`
+ * (an OpenAI-compatible server on loopback is local too) and this becomes
+ * `caps.locality === 'local'`. One helper so that change is one line.
+ */
+export function isLocal(caps: Capabilities): boolean {
+  return caps.auth === 'local';
+}
+
+export interface ResolveOptions {
+  /** The matter stays on this machine (providers spec §7): only local
+   * providers are candidates, whatever the route or the default say. */
+  localOnly?: boolean;
+}
+
 function satisfies(caps: Capabilities, req: Require | undefined, allowRemote: boolean): boolean {
-  if (!allowRemote && caps.auth !== 'local') return false;
+  if (!allowRemote && !isLocal(caps)) return false;
   if (!req) return true;
   if (req.tools !== undefined && caps.tools !== req.tools) return false;
   if (req.caching !== undefined && caps.caching !== req.caching) return false;
@@ -39,8 +55,9 @@ export class Router {
     for (const p of providers) this.byId.set(p.id, p);
   }
 
-  resolve(task?: string): ModelProvider {
+  resolve(task?: string, options: ResolveOptions = {}): ModelProvider {
     const route = task ? this.cfg.tasks?.[task] : undefined;
+    if (options.localOnly === true) return this.resolveLocal(route);
     const allowRemote = route?.allow_remote ?? true;
 
     if (route) {
@@ -56,5 +73,27 @@ export class Router {
       );
     }
     return def;
+  }
+
+  /**
+   * The stays-local path: the route's preference and the default count only
+   * when they are local; otherwise the best local provider — one with tools
+   * first, then the largest context — and a typed error when there is none.
+   * Never a cloud provider, whatever the config says.
+   */
+  private resolveLocal(route: TaskRoute | undefined): ModelProvider {
+    const local = [...this.byId.values()].filter(p => isLocal(p.capabilities));
+    if (local.length === 0) throw new MatterStaysLocalError('This matter stays on this machine, and no local model is loaded.');
+    if (route) {
+      const preferred = this.byId.get(route.prefer);
+      if (preferred && isLocal(preferred.capabilities) && satisfies(preferred.capabilities, route.require, false)) return preferred;
+    }
+    const def = this.byId.get(this.cfg.default);
+    if (def && isLocal(def.capabilities) && (!route || satisfies(def.capabilities, route.require, false))) return def;
+    const ranked = [...local].sort((a, b) => {
+      if (a.capabilities.tools !== b.capabilities.tools) return a.capabilities.tools ? -1 : 1;
+      return b.capabilities.contextTokens - a.capabilities.contextTokens;
+    });
+    return ranked[0]!;
   }
 }

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1493,3 +1493,59 @@ describe('retro (skills/retro in the runtime)', () => {
     expect(system).toContain('Period: all time to');
   });
 });
+
+describe('matter privacy policy over HTTP (providers spec §7)', () => {
+  const localCaps: Capabilities = { tools: true, caching: false, thinking: false, contextTokens: 1_000_000, auth: 'local' };
+  function cloudFake(id: string): ModelProvider {
+    const fake = new FakeModelProvider([{ text: 'cloud' }]);
+    return { id, kind: 'direct', capabilities: { ...localCaps, auth: 'apikey' }, run: req => fake.run(req) };
+  }
+  function localFake(id: string): ModelProvider {
+    const fake = new FakeModelProvider([{ text: 'local' }]);
+    return { id, kind: 'direct', capabilities: localCaps, run: req => fake.run(req) };
+  }
+
+  test('GET /threads/:id carries the policy its explicit matter implies', async () => {
+    const app = appWith([cloudFake('anthropic/c'), localFake('ollama/l')]);
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const id = await newThread(app);
+    let body = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { policy: unknown };
+    expect(body.policy).toEqual({ localOnly: false, source: 'none' });
+    expect((await call(app, 'PATCH', `/threads/${id}`, { body: { matter: 'matters/acme.md' } })).status).toBe(200);
+    body = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { policy: unknown };
+    expect(body.policy).toEqual({ localOnly: true, source: 'matter' });
+  });
+
+  test('a cloud provider named for a stays-local matter is a 409 before anything streams', async () => {
+    const app = appWith([cloudFake('anthropic/c'), localFake('ollama/l')]);
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const id = await newThread(app);
+    await call(app, 'PATCH', `/threads/${id}`, { body: { matter: 'matters/acme.md' } });
+    const res = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'hi', provider: 'anthropic/c' } });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: 'matter-stays-local', message: 'This matter stays on this machine; anthropic/c is not a local model.' });
+    const { events } = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { events: unknown[] };
+    expect(events).toHaveLength(0);
+  });
+
+  test('no local provider loaded is the founder\'s sentence, 409', async () => {
+    const app = appWith([cloudFake('anthropic/c')]);
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const id = await newThread(app);
+    await call(app, 'PATCH', `/threads/${id}`, { body: { matter: 'matters/acme.md' } });
+    const res = await call(app, 'POST', `/threads/${id}/steps`, { body: { message: 'hi' } });
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { message: string }).message).toBe('This matter stays on this machine, and no local model is loaded.');
+  });
+
+  test('with a local provider the step streams on it', async () => {
+    const app = appWith([cloudFake('anthropic/c'), localFake('ollama/l')]);
+    await vault.write('default', 'matters/acme.md', '---\nstays_local: true\n---\n# Acme\n');
+    const id = await newThread(app);
+    await call(app, 'PATCH', `/threads/${id}`, { body: { matter: 'matters/acme.md' } });
+    const { res } = await step(app, id, { message: 'hi' });
+    expect(res.status).toBe(200);
+    const { events } = (await (await call(app, 'GET', `/threads/${id}`)).json()) as { events: Array<Record<string, unknown>> };
+    expect(events.find(e => e['t'] === 'step')?.['provider']).toBe('ollama/l');
+  });
+});

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
-import { RouterError } from '../core/types';
-import { DEFAULT_STEP_TIMEOUT_MS, runStep, type CounselLoopDeps } from '../loop/counsel-loop';
+import { MatterStaysLocalError, RouterError } from '../core/types';
+import { DEFAULT_STEP_TIMEOUT_MS, runStep, type CounselLoopDeps, policyForOptions, resolveStepProvider } from '../loop/counsel-loop';
 import { pendingProposals } from '../loop/pending-proposals';
 import { applyProposal } from '../loop/proposals';
 import { listRuns, readRun, type RunRecord } from '../loop/run-record';
@@ -435,7 +435,14 @@ export function createApp(deps: ServerDeps): App {
     return json(await deps.store.create(deps.tenant, init), 201);
   };
 
-  const getThread = async (id: string): Promise<Response> => json(await loadThread(deps, id));
+  /** The thread plus the privacy policy its EXPLICIT matter (or the vault
+   * default) implies — what the UI shows before the reader sends anything.
+   * Attachment chips are only known at send time and are judged there. */
+  const getThread = async (id: string): Promise<Response> => {
+    const thread = await loadThread(deps, id);
+    const policy = await policyForOptions({ tenant: deps.tenant, vaultRoot: deps.vaultRoot, vault: deps.vault }, { ...(thread.header.matter === undefined ? {} : { matter: thread.header.matter }), message: '' });
+    return json({ ...thread, policy: { localOnly: policy.localOnly, source: policy.source } });
+  };
 
   const patchThread = async (req: Request, id: string): Promise<Response> => {
     const patch = await body(req, PatchThreadBody);
@@ -458,9 +465,19 @@ export function createApp(deps: ServerDeps): App {
 
   const steps = async (req: Request, id: string): Promise<Response> => {
     const input = await body(req, StepBody);
-    await loadThread(deps, id);
+    const { header } = await loadThread(deps, id);
     const loop = loopDeps();
     checkProvider(loop, input);
+    // The matter's privacy policy, decided here before anything streams
+    // (providers spec §7): a refused step is a 409, not an error event in a
+    // transcript that never got the question.
+    const policy = await policyForOptions(loop, { ...(header.matter === undefined ? {} : { matter: header.matter }), message: input.message });
+    try {
+      resolveStepProvider(loop, { threadId: id, message: input.message, ...(input.task === undefined ? {} : { task: input.task }), ...(input.provider === undefined ? {} : { providerId: input.provider }) }, policy);
+    } catch (err) {
+      if (err instanceof MatterStaysLocalError) return json({ error: 'matter-stays-local', message: err.message }, 409);
+      throw err;
+    }
 
     let outputSchema: z.ZodType<unknown> | undefined;
     if (input.outputSchema) {

--- a/runtime/src/setup/plan.test.ts
+++ b/runtime/src/setup/plan.test.ts
@@ -62,3 +62,17 @@ describe('configFor', () => {
     expect(text).toContain("# law_management: plugin");
   });
 });
+
+describe('configFor and the vault-wide locality (providers spec §7)', () => {
+  test('the default is a commented line; the first-run checkbox writes it live', () => {
+    expect(configFor('/v')).toContain('# default_locality: any');
+    expect(configFor('/v', { defaultLocality: 'local' })).toContain('\ndefault_locality: local');
+    expect(configFor('/v', { defaultLocality: 'local' })).not.toContain('# default_locality');
+  });
+
+  test('the plan carries staysLocalDefault, off unless asked', () => {
+    const plan = SetupPlan.parse({ vault: '/v', identity: { name: 'J', role: 'solo' } });
+    expect(plan.staysLocalDefault).toBe(false);
+    expect(SetupPlan.parse({ vault: '/v', identity: { name: 'J', role: 'solo' }, staysLocalDefault: true }).staysLocalDefault).toBe(true);
+  });
+});

--- a/runtime/src/setup/plan.ts
+++ b/runtime/src/setup/plan.ts
@@ -30,6 +30,9 @@ export const SetupPlan = z.object({
   defaultProvider: z.string().trim().min(1).optional(),
   /** `git init` + initial commit when git is on PATH. */
   git: z.boolean().default(true),
+  /** First-run: "Keep every matter on this machine unless I say otherwise"
+   * → `default_locality: local` in config.md (providers spec §7). */
+  staysLocalDefault: z.boolean().default(false),
 });
 export type SetupPlan = z.infer<typeof SetupPlan>;
 export type SetupPlanInput = z.input<typeof SetupPlan>;
@@ -104,7 +107,10 @@ General defaults — escalate uncapped liability, broad indemnities, and anythin
 }
 
 /** `{legal_root}/config.md`, verbatim from the setup skill (Step 1). */
-export function configFor(vault: string): string {
+export function configFor(vault: string, opts: { defaultLocality?: 'local' | 'any' } = {}): string {
+  const locality = opts.defaultLocality === 'local'
+    ? 'default_locality: local        # every matter stays on this machine unless its frontmatter says stays_local: false'
+    : '# default_locality: any          # local = every matter stays on this machine unless its frontmatter says stays_local: false';
   return `# Counsel OS Configuration
 
 counsel-os-config: true
@@ -116,6 +122,7 @@ legal_root: ${vault}
 # matters_path: matters
 # auto_apply_law_updates: false   # true = update applies law content without per-area approval
 # law_management: plugin          # 'user' = you own ALL law content; update stops syncing it (/counsel-os:law-refresh maintains it)
+${locality}
 # entity_properties:
 #   type_field: counsel-os-type
 #   values: [counterparty, vendor, customer, prospect, matter]

--- a/runtime/src/setup/run.ts
+++ b/runtime/src/setup/run.ts
@@ -241,7 +241,7 @@ export function runSetup(plan: SetupPlan, deps: SetupDeps): SetupResult {
   };
 
   // 1. The marker. On adoption the existing config stands, overrides and all.
-  place('config', 'config.md', configFor(vault));
+  place('config', 'config.md', configFor(vault, { defaultLocality: plan.staysLocalDefault ? 'local' : 'any' }));
 
   // 2. The per-machine pointer — a cache, always refreshed to this vault.
   mkdirSync(deps.home, { recursive: true, mode: 0o700 });

--- a/runtime/src/vault/policy.test.ts
+++ b/runtime/src/vault/policy.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'bun:test';
+import type { VaultConfig } from './resolve-root';
+import { attachmentPaths, matterFor, matterPolicy, policyForStep, type ReadText } from './policy';
+
+const cfg: VaultConfig = { entitiesPath: 'entities', mattersPath: 'matters', autoApplyLawUpdates: false, lawManagement: 'plugin' };
+const localVault: VaultConfig = { ...cfg, defaultLocality: 'local' };
+
+function reader(files: Record<string, string>): ReadText {
+  return async path => files[path] ?? null;
+}
+
+const files = {
+  'matters/acme.md': '---\ntitle: Acme\nstays_local: true\n---\n# Acme\n',
+  'matters/open.md': '---\ntitle: Open\nstays_local: false\n---\n# Open\n',
+  'matters/silent.md': '---\ntitle: Silent\n---\n# Silent\n',
+  'matters/folder/matter.md': '---\nstays_local: yes\n---\n# Folder\n',
+  'matters/flat-folder.md': '---\nstays_local: true\n---\n# Flat with a folder of documents\n',
+};
+
+describe('matterFor', () => {
+  test('a flat matter is its own file; a document in a folder is governed by its matter.md', async () => {
+    expect(await matterFor('matters/acme.md', cfg, reader(files))).toBe('matters/acme.md');
+    expect(await matterFor('matters/folder/nda.docx', cfg, reader(files))).toBe('matters/folder/matter.md');
+  });
+
+  test('a folder with no matter.md falls back to the flat matter of the same name', async () => {
+    expect(await matterFor('matters/flat-folder/nda.docx', cfg, reader(files))).toBe('matters/flat-folder.md');
+  });
+
+  test('outside the matters directory, or a stray non-markdown file, governs nothing', async () => {
+    expect(await matterFor('practice/standards/nda.md', cfg, reader(files))).toBeNull();
+    expect(await matterFor('matters/loose.docx', cfg, reader(files))).toBeNull();
+    expect(await matterFor('matters/ghost/x.docx', cfg, reader(files))).toBeNull();
+  });
+});
+
+describe('matterPolicy', () => {
+  test('the matter says so', async () => {
+    expect(await matterPolicy('matters/acme.md', cfg, reader(files))).toEqual({ localOnly: true, source: 'matter', matter: 'matters/acme.md' });
+    expect(await matterPolicy('matters/folder/matter.md', cfg, reader(files))).toEqual({ localOnly: true, source: 'matter', matter: 'matters/folder/matter.md' });
+  });
+
+  test('a matter that says false beats a vault default of local', async () => {
+    expect(await matterPolicy('matters/open.md', localVault, reader(files))).toEqual({ localOnly: false, source: 'matter', matter: 'matters/open.md' });
+  });
+
+  test('a silent matter falls to the vault default; no default is none', async () => {
+    expect(await matterPolicy('matters/silent.md', localVault, reader(files))).toEqual({ localOnly: true, source: 'vault' });
+    expect(await matterPolicy('matters/silent.md', cfg, reader(files))).toEqual({ localOnly: false, source: 'none' });
+    expect(await matterPolicy(null, cfg, reader(files))).toEqual({ localOnly: false, source: 'none' });
+  });
+
+  test('a matter file that is gone reads as silent', async () => {
+    expect(await matterPolicy('matters/missing.md', localVault, reader(files))).toEqual({ localOnly: true, source: 'vault' });
+  });
+});
+
+describe('attachmentPaths', () => {
+  test('the trailing line of backticked paths, and nothing else', () => {
+    expect(attachmentPaths('Review this.\n\n`matters/acme/nda.docx` `practice/standards/nda.md`')).toEqual(['matters/acme/nda.docx', 'practice/standards/nda.md']);
+    expect(attachmentPaths('`matters/acme/nda.docx`\n')).toEqual(['matters/acme/nda.docx']);
+    expect(attachmentPaths('Use `vault_read` on it')).toEqual([]);
+    expect(attachmentPaths('plain question')).toEqual([]);
+  });
+});
+
+describe('policyForStep', () => {
+  test('the explicit matter link decides first', async () => {
+    expect(await policyForStep({ matter: 'matters/acme.md', message: 'hi `matters/open.md`' }, cfg, reader(files))).toMatchObject({ localOnly: true, source: 'matter' });
+    expect(await policyForStep({ matter: 'matters/open.md', message: 'hi' }, localVault, reader(files))).toMatchObject({ localOnly: false, source: 'matter' });
+  });
+
+  test('else the first attached path that belongs to a matter', async () => {
+    expect(await policyForStep({ message: 'Review this.\n\n`practice/standards/nda.md` `matters/folder/nda.docx`' }, cfg, reader(files))).toEqual({ localOnly: true, source: 'matter', matter: 'matters/folder/matter.md' });
+  });
+
+  test('else the vault default', async () => {
+    expect(await policyForStep({ message: 'hello' }, localVault, reader(files))).toEqual({ localOnly: true, source: 'vault' });
+    expect(await policyForStep({ message: 'hello' }, cfg, reader(files))).toEqual({ localOnly: false, source: 'none' });
+  });
+
+  test('a malformed chip is prose', async () => {
+    expect(await policyForStep({ message: '`../escape.md`' }, cfg, reader(files))).toEqual({ localOnly: false, source: 'none' });
+  });
+});

--- a/runtime/src/vault/policy.ts
+++ b/runtime/src/vault/policy.ts
@@ -1,0 +1,126 @@
+/**
+ * The per-matter privacy policy (providers spec §7).
+ *
+ * A matter that says `stays_local: true` in its frontmatter, or a vault whose
+ * `config.md` sets `default_locality: local`, never has a step run on a
+ * cloud provider. The policy is decided from what is known at SEND time —
+ * the thread's explicit matter link, else a matter path riding along as an
+ * attachment chip, else the vault default — never from what the model later
+ * reads. An inferred matter (the header's courtesy) sets nothing: the reader
+ * links the matter if they want the guarantee.
+ */
+import { parseFrontmatter } from './overview';
+import type { VaultConfig } from './resolve-root';
+
+export interface StepPolicy {
+  localOnly: boolean;
+  /** Where the answer came from: the matter's own frontmatter, the vault
+   * default, or nothing said anywhere. */
+  source: 'matter' | 'vault' | 'none';
+  /** The matter file the policy was read from, when `source` is `matter`. */
+  matter?: string;
+}
+
+/** Reads a vault file as text, or `null` when it is not there. */
+export type ReadText = (path: string) => Promise<string | null>;
+
+/** The sentence the lawyer sees when the policy cannot be honoured. */
+export const NO_LOCAL_MODEL = 'This matter stays on this machine, and no local model is loaded.';
+
+const TRUE = new Set(['true', 'yes', 'on']);
+const FALSE = new Set(['false', 'no', 'off']);
+
+/** `stays_local` as the frontmatter spells it; `null` when it says nothing usable. */
+function staysLocalOf(fm: Record<string, string>): boolean | null {
+  const raw = (fm['stays_local'] ?? fm['stays-local'] ?? '').trim().toLowerCase();
+  if (TRUE.has(raw)) return true;
+  if (FALSE.has(raw)) return false;
+  return null;
+}
+
+/**
+ * The matter file that governs a vault path, or `null` when the path is not
+ * under the matters directory. A flat matter is its own file
+ * (`matters/acme.md`); a folder matter is `matters/acme/matter.md` and
+ * governs everything in `matters/acme/`. A document inside a folder whose
+ * `matter.md` does not exist falls back to the flat file of the same name
+ * (`matters/acme.md`), the way intake pairs folders with flat matters.
+ */
+export async function matterFor(path: string, cfg: VaultConfig, read: ReadText): Promise<string | null> {
+  const dir = cfg.mattersPath.replace(/\/+$/, '');
+  if (!path.startsWith(`${dir}/`)) return null;
+  const rest = path.slice(dir.length + 1);
+  const cut = rest.indexOf('/');
+  if (cut === -1) {
+    // A file directly under matters/: a flat matter, or a stray document.
+    return rest.endsWith('.md') ? path : null;
+  }
+  const folder = rest.slice(0, cut);
+  const inFolder = `${dir}/${folder}/matter.md`;
+  if ((await read(inFolder)) !== null) return inFolder;
+  const flat = `${dir}/${folder}.md`;
+  if ((await read(flat)) !== null) return flat;
+  return null;
+}
+
+/** The policy one matter file declares, with the vault default beneath it. */
+export async function matterPolicy(matterPath: string | null, cfg: VaultConfig, read: ReadText): Promise<StepPolicy> {
+  if (matterPath !== null) {
+    const text = await read(matterPath);
+    if (text !== null) {
+      const said = staysLocalOf(parseFrontmatter(text).frontmatter);
+      if (said !== null) return { localOnly: said, source: 'matter', matter: matterPath };
+    }
+  }
+  if (cfg.defaultLocality === 'local') return { localOnly: true, source: 'vault' };
+  return { localOnly: false, source: 'none' };
+}
+
+/**
+ * The vault paths a message carries as attachment chips: the trailing line
+ * of backticked paths `withAttachments` writes (Home's "attach from vault",
+ * a dropped document). Anything else in the message is prose.
+ */
+export function attachmentPaths(message: string): string[] {
+  const lines = message.replace(/\s+$/, '').split('\n');
+  const last = (lines[lines.length - 1] ?? '').trim();
+  if (!/^`[^`\n]+`(\s+`[^`\n]+`)*$/.test(last)) return [];
+  return Array.from(last.matchAll(/`([^`]+)`/g), m => m[1]!);
+}
+
+/**
+ * The policy for one step, decided before the model is chosen: the thread's
+ * explicit matter first; else the first attached path that belongs to a
+ * matter; else the vault default. Read once per step, never cached across
+ * steps — a matter can be marked between two messages.
+ */
+export async function policyForStep(
+  input: { matter?: string | undefined; message: string },
+  cfg: VaultConfig,
+  read: ReadText,
+): Promise<StepPolicy> {
+  if (input.matter !== undefined && input.matter !== '') {
+    return matterPolicy(input.matter, cfg, read);
+  }
+  for (const path of attachmentPaths(input.message)) {
+    let governing: string | null;
+    try {
+      governing = await matterFor(path, cfg, read);
+    } catch {
+      continue; // A malformed chip is prose, not a policy.
+    }
+    if (governing !== null) return matterPolicy(governing, cfg, read);
+  }
+  return matterPolicy(null, cfg, read);
+}
+
+/** A `ReadText` over a vault store: missing or unreadable → `null`. */
+export function readerOver(store: { read(tenant: string, path: string): Promise<string> }, tenant: string): ReadText {
+  return async path => {
+    try {
+      return await store.read(tenant, path);
+    } catch {
+      return null;
+    }
+  };
+}

--- a/runtime/src/vault/resolve-root.test.ts
+++ b/runtime/src/vault/resolve-root.test.ts
@@ -206,3 +206,15 @@ describe('readVaultConfig law flags', () => {
     expect(cfg.lawManagement).toBe('plugin');
   });
 });
+
+describe('readVaultConfig default_locality (providers spec §7)', () => {
+  test('local is read; anything else is absent', () => {
+    const root = mkdtempSync(join(tmpdir(), 'cfg-'));
+    writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: x\ndefault_locality: local\n', 'utf8');
+    expect(readVaultConfig(root).defaultLocality).toBe('local');
+    writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: x\ndefault_locality: any\n', 'utf8');
+    expect(readVaultConfig(root).defaultLocality).toBeUndefined();
+    writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: x\n', 'utf8');
+    expect(readVaultConfig(root).defaultLocality).toBeUndefined();
+  });
+});

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -33,6 +33,10 @@ export interface VaultConfig {
    * → the retro module's default (quarterly). Optional so the many literal
    * `VaultConfig`s in tests stay as they are. */
   retroCadenceDays?: number;
+  /** `default_locality: local` — every matter stays on this machine unless
+   * its own frontmatter says `stays_local: false` (providers spec §7).
+   * Absent → `any`. Optional so the literal `VaultConfig`s in tests stay. */
+  defaultLocality?: 'local' | 'any';
 }
 
 const CWD_WALK_MAX_DEPTH = 3;
@@ -242,5 +246,6 @@ export function readVaultConfig(root: string): VaultConfig {
     autoApplyLawUpdates: flag(findOverride('auto_apply_law_updates')) === 'true',
     lawManagement: flag(findOverride('law_management')) === 'user' ? 'user' : 'plugin',
     ...(Number.isInteger(cadence) && cadence > 0 ? { retroCadenceDays: cadence } : {}),
+    ...(flag(findOverride('default_locality')) === 'local' ? { defaultLocality: 'local' as const } : {}),
   };
 }

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -89,9 +89,19 @@ export interface ThreadHeader {
   sessions: Record<string, string>;
 }
 
+/** The privacy policy a thread's EXPLICIT matter (or the vault default)
+ * implies (providers spec §7). COPIED from `runtime/src/vault/policy.ts`'s
+ * `StepPolicy` minus the matter path. */
+export interface ThreadPolicy {
+  localOnly: boolean;
+  source: 'matter' | 'vault' | 'none';
+}
+
 export interface Thread {
   header: ThreadHeader;
   events: ThreadEvent[];
+  /** Present on `GET /threads/:id`; absent on older runtimes. */
+  policy?: ThreadPolicy;
 }
 
 export interface ToolCallLog {
@@ -369,6 +379,9 @@ export interface SetupPlanBody {
   sampleMatter: boolean;
   defaultProvider?: string;
   git: boolean;
+  /** "Keep every matter on this machine unless I say otherwise" →
+   * `default_locality: local` (providers spec §7). */
+  staysLocalDefault?: boolean;
 }
 
 /** `POST /setup` — 200. `result.groups` mirrors `SetupResult` in

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -971,3 +971,12 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-retro { margin-top: 22px; }
 .v2-retro-line { margin: 6px 0 10px; font-size: 13px; color: var(--fg-muted); }
 .v2-retro-due-word { color: var(--warn, var(--accent)); font-style: italic; }
+
+/* The matter's privacy policy (providers spec §7): set text beside the
+   matter line, the offer to link an inferred stays-local matter, and the
+   switcher's cloud rows greyed while such a thread is on screen. */
+.v2-thread-local { font: italic 500 12.5px var(--serif); color: var(--fg-muted); }
+.v2-thread-linkit { font-size: 12px; }
+.v2-policy-notice { color: var(--fg-muted); }
+.v2-switch-off { opacity: 0.45; cursor: default; }
+.v2-setup-local { margin-top: 10px; }

--- a/runtime/ui/src/v2/ModelSwitcher.tsx
+++ b/runtime/ui/src/v2/ModelSwitcher.tsx
@@ -19,7 +19,12 @@ export interface ModelSwitcherProps {
   /** Make this loaded provider the saved default (the settings round-trip
    * lives in the Shell — the rail stays presentational). */
   onSetDefault(id: string): void;
+  /** The open thread's matter stays on this machine (providers spec §7):
+   * cloud rows are shown but cannot be picked, with the reason on hover. */
+  localOnly?: boolean;
 }
+
+export const STAYS_LOCAL_NOTE = 'This matter stays on this machine';
 
 interface Row {
   id: string;
@@ -40,7 +45,7 @@ interface Row {
  * AMBER when the saved default did not load and the runtime fell back —
  * the title carries the explanation, the plate itself stays calm.
  */
-export function ModelSwitcher({ health, collapsed, onSetDefault }: ModelSwitcherProps): JSX.Element {
+export function ModelSwitcher({ health, collapsed, onSetDefault, localOnly = false }: ModelSwitcherProps): JSX.Element {
   const state = useMenuTriggerState({});
   const triggerRef = useRef<HTMLButtonElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
@@ -76,6 +81,7 @@ export function ModelSwitcher({ health, collapsed, onSetDefault }: ModelSwitcher
     health === null ? null : plateFor(effective, health.providers.find(p => p.id === effective)?.auth);
 
   const rows: Row[] = [...(health?.providers ?? []).map(p => ({ id: p.id })), { id: SETTINGS_KEY }];
+  const disabledKeys = new Set(localOnly ? (health?.providers ?? []).filter(p => p.auth !== 'local').map(p => p.id) : []);
   const children = (row: Row): JSX.Element => {
     if (row.id === SETTINGS_KEY) {
       return (
@@ -126,7 +132,7 @@ export function ModelSwitcher({ health, collapsed, onSetDefault }: ModelSwitcher
             }
           }}
         >
-          <SwitchMenu {...menuProps} items={rows} autoFocus={state.focusStrategy || true} onAction={act} onClose={state.close}>
+          <SwitchMenu {...menuProps} items={rows} disabledKeys={disabledKeys} autoFocus={state.focusStrategy || true} onAction={act} onClose={state.close}>
             {children}
           </SwitchMenu>
         </div>
@@ -181,9 +187,15 @@ function SwitchMenu(props: AriaMenuProps<Row> & { onClose(): void }): JSX.Elemen
 
 function SwitchRow({ item, state }: { item: Node<Row>; state: TreeState<Row> }): JSX.Element {
   const ref = useRef<HTMLLIElement | null>(null);
-  const { menuItemProps, isFocused } = useMenuItem({ key: item.key }, state, ref);
+  const { menuItemProps, isFocused, isDisabled } = useMenuItem({ key: item.key }, state, ref);
   return (
-    <li {...menuItemProps} ref={ref} className="v2-switch-item" data-focused={isFocused ? true : undefined}>
+    <li
+      {...menuItemProps}
+      ref={ref}
+      className={isDisabled ? 'v2-switch-item v2-switch-off' : 'v2-switch-item'}
+      data-focused={isFocused ? true : undefined}
+      title={isDisabled ? STAYS_LOCAL_NOTE : undefined}
+    >
       {item.rendered}
     </li>
   );

--- a/runtime/ui/src/v2/ProviderNotice.tsx
+++ b/runtime/ui/src/v2/ProviderNotice.tsx
@@ -1,5 +1,5 @@
-import type { Health } from '../api/types';
-import { swapPlates } from './plate';
+import type { Health, ThreadPolicy } from '../api/types';
+import { localPlate, swapPlates } from './plate';
 
 /**
  * The swap, said where the lawyer is about to act (cou-95): the saved
@@ -17,6 +17,25 @@ export function ProviderNotice({ health }: { health: Health | null | undefined }
         ? `${saved} is not available, and no other model is loaded.`
         : `${saved} is not available. Counsel will answer on ${swap.effective.vendor} (${swap.effective.model}).`}
       <a href="#/settings">change</a>
+    </p>
+  );
+}
+
+/**
+ * The matter's privacy policy, said where the lawyer is about to send
+ * (providers spec §7): which local model answers, or that none is loaded —
+ * the runtime refuses the step in that case, and this line says so first.
+ * Set text, no box, no pill; nothing at all when the matter is not local.
+ */
+export function PolicyNotice({ health, policy }: { health: Health | null | undefined; policy: ThreadPolicy | null | undefined }): JSX.Element | null {
+  if (policy === null || policy === undefined || !policy.localOnly) return null;
+  const local = localPlate(health ?? null);
+  return (
+    <p className="v2-swap-notice v2-policy-notice" role="status">
+      {local === null
+        ? 'This matter stays on this machine, and no local model is loaded.'
+        : `This matter stays on this machine · answering on ${local.vendor} (${local.model})`}
+      {local === null ? <a href="#/settings">add one</a> : null}
     </p>
   );
 }

--- a/runtime/ui/src/v2/Rail.test.tsx
+++ b/runtime/ui/src/v2/Rail.test.tsx
@@ -304,3 +304,20 @@ describe('Rail', () => {
     expect(document.querySelector('.v2-thread-sub')?.textContent).toBe('Acme nda');
   });
 });
+
+describe('Rail switcher under a stays-local thread (providers spec §7)', () => {
+  test('cloud rows are shown, greyed, and cannot be picked; the local row can', async () => {
+    const picked: string[] = [];
+    mount({ health: { ...health, providers: [fake, claude] }, localOnly: true, onSetDefault: id => picked.push(id) });
+    await userEvent.click(screen.getByRole('button', { name: /fake\/fake/ }));
+    const menu = screen.getByRole('menu', { name: 'Switch model' }) as HTMLElement;
+    const rows = Array.from(menu.querySelectorAll<HTMLElement>('li'));
+    const claudeRow = rows.find(li => li.textContent?.includes('Claude'))!;
+    expect(claudeRow.className).toContain('v2-switch-off');
+    expect(claudeRow.getAttribute('aria-disabled')).toBe('true');
+    expect(claudeRow.getAttribute('title')).toBe('This matter stays on this machine');
+    await userEvent.click(claudeRow);
+    expect(picked).toEqual([]);
+    expect(rows.find(li => li.textContent?.includes('fake/fake'))!.className).not.toContain('v2-switch-off');
+  });
+});

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -30,6 +30,9 @@ export interface RailProps {
   /** The footer switcher picked a loaded provider: save it as the default
    * (the settings round-trip lives in the Shell). */
   onSetDefault: (id: string) => void;
+  /** The open thread's matter stays local (providers spec §7): the
+   * switcher greys its cloud rows. */
+  localOnly?: boolean;
   /** Matter path → title (from `/vault/overview`), for the faint second
    * line under a thread with an EXPLICIT matter link. Absent or missing a
    * path, the row falls back to the prettified filename. */
@@ -64,6 +67,7 @@ export function Rail({
   onDelete,
   onSetDefault,
   matterTitles,
+  localOnly = false,
 }: RailProps): JSX.Element {
   /** The row whose × was clicked: it reads "Delete this? ·
    * Delete · Keep" in set text until answered — no `window.confirm`, no
@@ -180,7 +184,7 @@ export function Rail({
               empty on its own. */}
         </>
       )}
-      <ModelSwitcher health={health} collapsed={collapsed} onSetDefault={onSetDefault} />
+      <ModelSwitcher health={health} collapsed={collapsed} onSetDefault={onSetDefault} localOnly={localOnly} />
     </aside>
   );
 }

--- a/runtime/ui/src/v2/SetupPage.test.tsx
+++ b/runtime/ui/src/v2/SetupPage.test.tsx
@@ -97,7 +97,7 @@ describe('SetupPage', () => {
     expect(screen.getByRole('radio', { name: /Documents\/Counsel OS/ }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByRole('radio', { name: /^solo$/ }).getAttribute('aria-checked')).toBe('true');
     expect((screen.getByRole('radio', { name: /ChatGPT/ }) as HTMLButtonElement).disabled).toBe(true);
-    expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+    expect((screen.getByRole('checkbox', { name: /sample matter/ }) as HTMLInputElement).checked).toBe(true);
     expect(screen.getByText(/Writes 26 law areas, your standards, methods and clause library/)).toBeTruthy();
     expect(document.querySelector('.v2-rail')).toBeNull();
     expect(screen.getByText('bun runtime/src/cli.ts init')).toBeTruthy();
@@ -112,7 +112,7 @@ describe('SetupPage', () => {
     await userEvent.type(screen.getByLabelText('Jurisdiction'), 'Massachusetts');
     await userEvent.type(screen.getByLabelText('Your practice'), 'Commercial contracts');
     await userEvent.click(screen.getByRole('radio', { name: /Ollama/ }));
-    await userEvent.click(screen.getByRole('checkbox'));
+    await userEvent.click(screen.getByRole('checkbox', { name: /sample matter/ }));
     await userEvent.click(screen.getByRole('button', { name: 'Create' }));
     await waitFor(() => expect(posts).toHaveLength(1));
     expect(posts[0]).toEqual({
@@ -122,6 +122,7 @@ describe('SetupPage', () => {
       sampleMatter: false,
       defaultProvider: 'ollama/gemma4:e4b',
       git: true,
+      staysLocalDefault: false,
     });
   });
 
@@ -212,5 +213,16 @@ describe('SetupPage', () => {
     await userEvent.type(screen.getByLabelText('Name'), 'J');
     await userEvent.click(screen.getByRole('button', { name: 'Create' }));
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('counsel-os did not answer'));
+  });
+});
+
+describe('SetupPage, keep every matter on this machine (providers spec §7)', () => {
+  test('the checkbox writes staysLocalDefault into the plan', async () => {
+    await mounted();
+    await userEvent.type(screen.getByLabelText('Name'), 'Jack Wang');
+    await userEvent.click(screen.getByRole('checkbox', { name: /Keep every matter on this machine/ }));
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+    await waitFor(() => expect(posts).toHaveLength(1));
+    expect(posts[0]!.staysLocalDefault).toBe(true);
   });
 });

--- a/runtime/ui/src/v2/SetupPage.tsx
+++ b/runtime/ui/src/v2/SetupPage.tsx
@@ -120,6 +120,7 @@ export function SetupPage({ onDone }: SetupPageProps): JSX.Element {
   const [practice, setPractice] = useState('');
   const [provider, setProvider] = useState<string | null>(null);
   const [sample, setSample] = useState(true);
+  const [staysLocal, setStaysLocal] = useState(false);
 
   const [phase, setPhase] = useState<Phase>({ kind: 'form' });
   const [errors, setErrors] = useState<FieldErrors>({});
@@ -163,6 +164,7 @@ export function SetupPage({ onDone }: SetupPageProps): JSX.Element {
       sampleMatter: sample,
       ...(provider === null ? {} : { defaultProvider: provider }),
       git: true,
+      staysLocalDefault: staysLocal,
     };
     setPhase({ kind: 'creating', vault, done: false });
     try {
@@ -326,6 +328,12 @@ export function SetupPage({ onDone }: SetupPageProps): JSX.Element {
             <h2 className="runin">What you practice</h2>
             <p className="v2-setup-why">One sentence. It tunes your practice profile — the positions counsel opens from and when it escalates to you. You can rewrite the profile later.</p>
             <Field id="v2-setup-practice" label="Your practice" value={practice} onChange={setPractice} error={errors.practice} placeholder="e.g. in-house GC at a B2B SaaS company" />
+            {/* The vault-wide privacy default (providers spec §7): one checkbox,
+                written to config.md as `default_locality: local`. */}
+            <label className="v2-setup-sample v2-setup-local">
+              <input type="checkbox" checked={staysLocal} onChange={event => setStaysLocal(event.target.checked)} />
+              <span>Keep every matter on this machine unless I say otherwise — counsel then answers only on a local model.</span>
+            </label>
           </section>
 
           <section className="v2-setup-group rule-double">

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import { bootstrapToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
-import type { Health, RetroStart, SettingsView, ThreadHeader, VaultOverview } from '../api/types';
+import type { Health, RetroStart, SettingsView, ThreadHeader, ThreadPolicy, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
 import { VAULT_CHANGED_EVENT } from './intake';
@@ -95,6 +95,9 @@ export function Shell(): JSX.Element {
    * text, which is exactly what they were before.
    */
   const [vaultPaths, setVaultPaths] = useState<ReadonlySet<string>>(() => new Set());
+  /** The open thread's privacy policy, for the rail's switcher (providers
+   * spec §7): cloud rows grey out while a stays-local thread is on screen. */
+  const [threadPolicy, setThreadPolicy] = useState<ThreadPolicy | null>(null);
   const loadIndex = useCallback(async (): Promise<void> => {
     try {
       const paths = await fetchJson<unknown>('/vault/index');
@@ -427,6 +430,7 @@ export function Shell(): JSX.Element {
         onDelete={id => void deleteThread(id)}
         onSetDefault={id => void setDefaultProvider(id)}
         matterTitles={matterTitles}
+        localOnly={route === 'chat' && threadPolicy?.localOnly === true}
       />
       <div className="v2-main-col">
         {error === null ? null : (
@@ -477,6 +481,7 @@ export function Shell(): JSX.Element {
                 onFileDecided={fileDecided}
                 onOpenFile={openDrawer}
                 vaultPaths={vaultPaths}
+                onPolicy={setThreadPolicy}
               />
             )}
           </main>

--- a/runtime/ui/src/v2/chat/Chat.test.tsx
+++ b/runtime/ui/src/v2/chat/Chat.test.tsx
@@ -564,3 +564,74 @@ describe('v2 Chat, rename and matter link', () => {
     await waitFor(() => expect(screen.getByText('inferred')).toBeTruthy());
   });
 });
+
+describe('v2 Chat, the matter privacy policy (providers spec §7)', () => {
+  const localHealth: Health = {
+    ...health,
+    default: 'ollama/gemma4',
+    providers: [
+      { id: 'ollama/gemma4', kind: 'direct', auth: 'local', capabilities: { tools: true, caching: false, thinking: false, contextTokens: 32_000, auth: 'local' } },
+      ...health.providers,
+    ],
+  };
+  const events: ThreadEvent[] = [
+    { t: 'user', at, content: 'check it' },
+    { t: 'step', at, runId: 'r-1', provider: 'fake/fake' },
+    { type: 'tool_call', at, id: 'c2', name: 'vault_read', input: { path: 'matters/acme-nda.md' } },
+    { type: 'done', at, output: null, usage: { inputTokens: 1, outputTokens: 1 } },
+  ];
+
+  function installPolicy(thread: Thread & { policy?: { localOnly: boolean; source: 'matter' | 'vault' | 'none' } }, opts: { matterContent?: string; steps?: () => Response } = {}): void {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({ method, url, body: init?.body === undefined ? undefined : JSON.parse(String(init.body)) });
+      if (url.startsWith('/runs')) return json([]);
+      if (url.startsWith('/vault/read')) return json({ path: 'matters/acme-nda.md', content: opts.matterContent ?? '---\ntitle: Acme NDA\nstays_local: true\n---\n# Acme\n', version: 'v1', mtimeMs: 1 });
+      if (method === 'PATCH' && url.startsWith('/threads/')) return json({ ...thread.header, matter: (JSON.parse(String(init?.body)) as { matter: string }).matter });
+      if (url.endsWith('/steps')) return opts.steps === undefined ? stream(SSE) : opts.steps();
+      if (url.startsWith('/threads/')) return json(thread);
+      throw new Error(`unexpected fetch: ${method} ${url}`);
+    }) as unknown as typeof fetch;
+  }
+
+  test('an explicit stays-local matter reads beside the MATTER line, and the shell hears the policy', async () => {
+    const heard: unknown[] = [];
+    installPolicy({ header: { id: 't-1', matter: 'matters/acme-nda.md', createdAt: at, updatedAt: at, sessions: {} }, events, policy: { localOnly: true, source: 'matter' } });
+    render(<Chat threadId="t-1" health={localHealth} onPolicy={p => heard.push(p)} />);
+    await waitFor(() => expect(document.querySelector('.v2-thread-local')?.textContent).toBe('· stays local'));
+    expect(heard).toContainEqual({ localOnly: true, source: 'matter' });
+    // The composer says which local model answers — before the reader sends.
+    expect(document.querySelector('.v2-policy-notice')?.textContent).toContain('answering on Ollama (gemma4)');
+  });
+
+  test('an INFERRED stays-local matter offers the link and never takes it', async () => {
+    installPolicy({ header: { id: 't-1', createdAt: at, updatedAt: at, sessions: {} }, events, policy: { localOnly: false, source: 'none' } });
+    render(<Chat threadId="t-1" health={localHealth} />);
+    await waitFor(() => expect(screen.getByRole('button', { name: 'stays local — link it' })).toBeTruthy());
+    expect(document.querySelector('.v2-thread-local')).toBeNull();
+    expect(document.querySelector('.v2-policy-notice')).toBeNull();
+    await userEvent.click(screen.getByRole('button', { name: 'stays local — link it' }));
+    await waitFor(() => expect(calls.some(c => c.method === 'PATCH' && c.url === '/threads/t-1' && (c.body as { matter: string }).matter === 'matters/acme-nda.md')).toBe(true));
+  });
+
+  test('a matter that does not stay local offers nothing', async () => {
+    installPolicy({ header: { id: 't-1', createdAt: at, updatedAt: at, sessions: {} }, events, policy: { localOnly: false, source: 'none' } }, { matterContent: '---\ntitle: Open\n---\n# Open\n' });
+    render(<Chat threadId="t-1" health={localHealth} />);
+    await waitFor(() => expect(document.querySelector('.v2-thread-matter-name')?.textContent).toBe('Open'));
+    expect(screen.queryByRole('button', { name: 'stays local — link it' })).toBeNull();
+  });
+
+  test('a refused step (409 matter-stays-local) is the sentence, with no Retry into cloud', async () => {
+    installPolicy(
+      { header: { id: 't-1', matter: 'matters/acme-nda.md', createdAt: at, updatedAt: at, sessions: {} }, events, policy: { localOnly: true, source: 'matter' } },
+      { steps: () => json({ error: 'matter-stays-local', message: 'This matter stays on this machine, and no local model is loaded.' }, 409) },
+    );
+    render(<Chat threadId="t-1" health={health} />);
+    await waitFor(() => expect(document.querySelector('.v2-thread-local')).toBeTruthy());
+    await ask();
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('no local model is loaded'));
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
+    composerIsUsable();
+  });
+});

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, streamStep } from '../../api/client';
-import type { Health, RunRecord, Thread, ThreadEvent, ThreadHeader, VaultFile } from '../../api/types';
+import type { Health, RunRecord, Thread, ThreadEvent, ThreadHeader, ThreadPolicy, VaultFile } from '../../api/types';
 import { proposalFromHash } from '../../app';
 import { applyStepEvent, buildTurns, emptyAssistantTurn, type AssistantTurn, type Turn } from '../../chat/turns';
 import { createThread, defaultProviderId, titleFor } from '../threads';
@@ -41,6 +41,10 @@ export interface ChatProps {
   /** Every file path the vault holds (`GET /vault/index`): a path the model
    * writes in an answer becomes a click target only when it is in here. */
   vaultPaths?: ReadonlySet<string>;
+  /** The thread's privacy policy as `GET /threads/:id` reports it — the
+   * shell passes it to the rail so the switcher greys cloud rows for this
+   * thread (providers spec §7). Fires with `null` for a draft. */
+  onPolicy?: (policy: ThreadPolicy | null) => void;
 }
 
 function detail(err: unknown): string {
@@ -100,6 +104,7 @@ export function Chat({
   initialAsk,
   onAskUsed,
   vaultPaths,
+  onPolicy,
 }: ChatProps): JSX.Element {
   /** The thread this pane is about. A ref, not only state: `load` and
    * `send` read it outside a render, and it changes exactly once — from
@@ -161,8 +166,9 @@ export function Chat({
   const load = useCallback(async (): Promise<void> => {
     // Cleared before the draft guard: a load that finds nothing to fetch
     // must still dismiss whatever is on screen, or the button that called it
-    // does nothing at all.
-    setError(null);
+    // does nothing at all. A policy refusal is the exception: the send's own
+    // `finally` reloads, and the sentence must survive that reload.
+    if (!refusedRef.current) setError(null);
     const id = idRef.current;
     if (id === null) {
       setLoading(false);
@@ -240,6 +246,8 @@ export function Chat({
     retry.current = null;
     setLiveMs({});
     setError(null);
+    setRefused(false);
+    refusedRef.current = false;
     showPending(message);
     showLive(emptyAssistantTurn());
 
@@ -295,6 +303,18 @@ export function Chat({
       );
     } catch (err) {
       if (!controller.signal.aborted) {
+        // The runtime refused the step for the matter's privacy policy
+        // (409 matter-stays-local): nothing ran, nothing to retry into —
+        // the sentence is the whole answer, without a Retry into cloud.
+        const body = err instanceof ApiError && err.status === 409 ? (err.body as { error?: string; message?: string } | null) : null;
+        if (body !== null && body?.error === 'matter-stays-local') {
+          showLive(null);
+          showPending(null);
+          setError(body.message ?? 'This matter stays on this machine.');
+          setRefused(true);
+          refusedRef.current = true;
+          return;
+        }
         showLive(applyStepEvent(liveRef.current ?? emptyAssistantTurn(), { type: 'error', message: detail(err) }));
         setError(detail(err));
       }
@@ -428,26 +448,43 @@ export function Chat({
    * model the reader uses; until it lands — or if it cannot — the prettified
    * filename stands in, so the line never flashes empty.
    */
-  const [matterTitles, setMatterTitles] = useState<Record<string, string>>({});
+  const [matterTitles, setMatterTitles] = useState<Record<string, { title: string; staysLocal: boolean }>>({});
   useEffect(() => {
     if (matterPath === null || matterTitles[matterPath] !== undefined) return;
     let cancelled = false;
     void (async () => {
       let title = matterFallbackTitle(matterPath);
+      let staysLocal = false;
       try {
         const file = await fetchJson<VaultFile>(`/vault/read?path=${encodeURIComponent(matterPath)}`);
-        if (typeof file.content === 'string') title = readerModel(file.content, matterPath).title;
+        if (typeof file.content === 'string') {
+          const model = readerModel(file.content, matterPath);
+          title = model.title;
+          // The matter's own word (providers spec §7), so an INFERRED matter
+          // that stays local can offer the link — never take it.
+          staysLocal = model.rows.some(r => r.key === 'stays local' && /^(yes|true)$/i.test(r.value));
+        }
       } catch {
         // A matter file that moved or cannot be read keeps the fallback —
         // the header is a courtesy, not a record.
       }
-      if (!cancelled) setMatterTitles(current => ({ ...current, [matterPath]: title }));
+      if (!cancelled) setMatterTitles(current => ({ ...current, [matterPath]: { title, staysLocal } }));
     })();
     return () => {
       cancelled = true;
     };
   }, [matterPath]);
-  const matterTitle = matterPath === null ? null : (matterTitles[matterPath] ?? matterFallbackTitle(matterPath));
+  const matterTitle = matterPath === null ? null : (matterTitles[matterPath]?.title ?? matterFallbackTitle(matterPath));
+  const inferredStaysLocal = matterInferred && inferredMatter !== null && matterTitles[inferredMatter]?.staysLocal === true;
+  /** The thread's policy as the runtime reports it; a draft has none. */
+  const policy: ThreadPolicy | null = thread?.policy ?? null;
+  const [refused, setRefused] = useState(false);
+  /** Mirrors `refused` for `load`, which runs in the send's `finally` and
+   * would otherwise wipe the refusal sentence the moment it appeared. */
+  const refusedRef = useRef(false);
+  useEffect(() => {
+    onPolicy?.(policy);
+  }, [policy?.localOnly, policy?.source]);
 
   return (
     <section className="v2-chat">
@@ -488,7 +525,18 @@ export function Chat({
               <span className="v2-thread-matter-name">{matterTitle}</span>
             </a>
           )}
+          {/* The policy in force reads beside the matter (providers spec §7):
+              set text, and only from an EXPLICIT link. An inferred matter
+              that stays local offers the link instead — never takes it. */}
+          {policy !== null && policy.localOnly && policy.source === 'matter' && explicitMatter !== null ? (
+            <span className="v2-thread-local">· stays local</span>
+          ) : null}
           {matterInferred ? <span className="v2-thread-inferred">inferred</span> : null}
+          {inferredStaysLocal && inferredMatter !== null ? (
+            <button type="button" className="v2-link v2-thread-linkit" onClick={() => void patchThread({ matter: inferredMatter })}>
+              stays local — link it
+            </button>
+          ) : null}
           <MatterPicker current={explicitMatter} label={matterPath === null ? 'link a matter' : 'change'} onPick={path => void patchThread({ matter: path })} />
           <span className="v2-thread-date">{relTime(thread.header.createdAt)}</span>
         </header>
@@ -525,15 +573,18 @@ export function Chat({
       {error === null ? null : (
         <div className="v2-notice v2-notice-error v2-chat-error" role="alert">
           <span>{error}</span>
-          <button type="button" onClick={retryNow}>
-            Retry
-          </button>
+          {refused ? null : (
+            <button type="button" onClick={retryNow}>
+              Retry
+            </button>
+          )}
         </div>
       )}
 
       <Composer
         streaming={streaming}
         health={health}
+        policy={policy}
         matter={explicitMatter === null || matterTitle === null ? null : { path: explicitMatter, title: matterTitle }}
         {...(explicitMatter === null ? {} : { dropDest: matterFolderOf(explicitMatter) })}
         seed={seed}

--- a/runtime/ui/src/v2/chat/Composer.test.tsx
+++ b/runtime/ui/src/v2/chat/Composer.test.tsx
@@ -152,3 +152,23 @@ describe('v2 Composer document intake (docx spec §6)', () => {
     expect(screen.getByRole('alert').textContent).toContain('only Word documents (.docx) can be added for now');
   });
 });
+
+describe('v2 Composer, the matter privacy policy (providers spec §7)', () => {
+  test('a stays-local matter names the local model that answers', () => {
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={fine} policy={{ localOnly: true, source: 'matter' }} />);
+    const notice = screen.getByRole('status');
+    expect(notice.className).toContain('v2-policy-notice');
+    expect(notice.textContent).toBe('This matter stays on this machine · answering on Ollama (gemma4:e4b)');
+  });
+
+  test('with no local model loaded it says so and points at Settings', () => {
+    const cloudOnly: Health = { ...fine, default: 'claude-sub/claude-opus-5', providers: [{ id: 'claude-sub/claude-opus-5', kind: 'harness', auth: 'subscription', capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' } }] };
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={cloudOnly} policy={{ localOnly: true, source: 'vault' }} />);
+    expect(screen.getByRole('status').textContent).toBe('This matter stays on this machine, and no local model is loaded.add one');
+  });
+
+  test('no policy, no line', () => {
+    render(<Composer streaming={false} onSend={noop} onStop={noop} health={fine} policy={{ localOnly: false, source: 'none' }} />);
+    expect(document.querySelector('.v2-policy-notice')).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/chat/Composer.tsx
+++ b/runtime/ui/src/v2/chat/Composer.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react';
-import type { Health } from '../../api/types';
+import type { ThreadPolicy, Health } from '../../api/types';
 import { withAttachments } from '../home/home';
 import { carriesFiles, droppedFiles, intake, type IntakeStatus } from '../intake';
-import { ProviderNotice } from '../ProviderNotice';
+import { PolicyNotice, ProviderNotice } from '../ProviderNotice';
 
 /** A prefill pushed in from outside — the vault's "Ask counsel about this
  * file" (spec §3.4). The nonce distinguishes two asks about the same file. */
@@ -27,6 +27,9 @@ export interface ComposerProps {
    * default is not loaded, so the reader learns which model will answer
    * BEFORE sending. Absent = no notice. */
   health?: Health | null;
+  /** The thread's privacy policy (providers spec §7): when the matter stays
+   * local, the line above the box names the local model that answers. */
+  policy?: ThreadPolicy | null;
   /** The thread's EXPLICIT matter, for the line above the box and for where
    * a dropped document lands. Absent or `null`: drops go to the inbox. */
   matter?: { path: string; title: string } | null;
@@ -44,7 +47,7 @@ export interface ComposerProps {
  * picker under every message asked the reader to make a choice they had
  * already made once, in the one place that remembers it.
  */
-export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed, health, matter = null, dropDest }: ComposerProps): JSX.Element {
+export function Composer({ streaming, disabled = false, onSend, onStop, seed, onSeedUsed, health, policy = null, matter = null, dropDest }: ComposerProps): JSX.Element {
   const [message, setMessage] = useState('');
   /** Vault paths riding along with the message — a dropped document lands
    * here as a chip, the way Home's "attach from vault" chips do. */
@@ -96,6 +99,7 @@ export function Composer({ streaming, disabled = false, onSend, onStop, seed, on
         send();
       }}
     >
+      <PolicyNotice health={health} policy={policy} />
       <ProviderNotice health={health} />
       {matter === null ? null : (
         <p className="v2-composer-matter">

--- a/runtime/ui/src/v2/plate.test.ts
+++ b/runtime/ui/src/v2/plate.test.ts
@@ -135,3 +135,24 @@ describe('swapPlates (cou-95)', () => {
     });
   });
 });
+
+import { localPlate } from './plate';
+
+describe('localPlate (providers spec §7)', () => {
+  const local = (id: string, tools = true, contextTokens = 32_000): Health['providers'][number] => ({
+    id, kind: 'direct', auth: 'local', capabilities: { tools, caching: false, thinking: false, contextTokens, auth: 'local' },
+  });
+  const cloud: Health['providers'][number] = { id: 'claude-sub/claude-opus-5', kind: 'harness', auth: 'subscription', capabilities: { tools: true, caching: true, thinking: true, contextTokens: 200_000, auth: 'subscription' } };
+  const base: Health = { vault: '/v', tenant: 'default', default: 'claude-sub/claude-opus-5', stepTimeoutMs: 1, providers: [] };
+
+  test('the saved default when it is local; else tools first, then the largest context', () => {
+    expect(localPlate({ ...base, default: 'ollama/small', providers: [cloud, local('ollama/small'), local('ollama/big', true, 128_000)] })?.model).toBe('small');
+    expect(localPlate({ ...base, providers: [cloud, local('ollama/notools', false, 999_999), local('ollama/big', true, 128_000), local('ollama/small')] })?.model).toBe('big');
+    expect(localPlate({ ...base, providers: [cloud, local('ollama/notools', false, 999_999)] })?.model).toBe('notools');
+  });
+
+  test('nothing local → null', () => {
+    expect(localPlate({ ...base, providers: [cloud] })).toBeNull();
+    expect(localPlate(null)).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/plate.ts
+++ b/runtime/ui/src/v2/plate.ts
@@ -118,3 +118,23 @@ export function swapPlates(health: Health | null): { saved: Plate; effective: (P
   const model = plate.known ? plate.detail.split(' · ')[0]! : effectiveId;
   return { saved, effective: { ...plate, model } };
 }
+
+/**
+ * The provider a stays-local step will run on (providers spec §7): the
+ * saved default when it is local, else the best local one the way the
+ * router ranks them — tools first, then the largest context. `null` when
+ * nothing local is loaded, which the notice says in so many words.
+ */
+export function localPlate(health: Health | null): (Plate & { model: string }) | null {
+  if (health === null) return null;
+  const local = health.providers.filter(p => p.auth === 'local');
+  if (local.length === 0) return null;
+  const preferred = local.find(p => p.id === health.default);
+  const pick =
+    preferred ??
+    [...local].sort((a, b) => {
+      if (a.capabilities.tools !== b.capabilities.tools) return a.capabilities.tools ? -1 : 1;
+      return b.capabilities.contextTokens - a.capabilities.contextTokens;
+    })[0]!;
+  return { ...plateFor(pick.id, 'local'), model: modelName(pick.id.slice(pick.id.indexOf('/') + 1)) };
+}

--- a/runtime/ui/src/v2/vault/frontmatter.test.ts
+++ b/runtime/ui/src/v2/vault/frontmatter.test.ts
@@ -72,3 +72,13 @@ describe('frontmatter cleanup (founder feedback 2026-08-31)', () => {
     ]);
   });
 });
+
+describe('the privacy flag in the facts block (providers spec §7)', () => {
+  test('stays_local reads as yes / no, never true / false', () => {
+    expect(splitFrontmatter('---\nstays_local: true\nstage: working\n---\nbody\n').rows).toEqual([
+      { key: 'stays local', value: 'yes' },
+      { key: 'stage', value: 'working' },
+    ]);
+    expect(splitFrontmatter('---\nstays-local: FALSE\n---\n').rows).toEqual([{ key: 'stays local', value: 'no' }]);
+  });
+});

--- a/runtime/ui/src/v2/vault/frontmatter.ts
+++ b/runtime/ui/src/v2/vault/frontmatter.ts
@@ -24,7 +24,13 @@ export function splitFrontmatter(source: string): { rows: FmRow[]; body: string 
   const rows: FmRow[] = [];
   for (const line of lines.slice(1, end)) {
     const m = /^([A-Za-z0-9_-]+):\s*(.+)$/.exec(line);
-    if (m !== null && !m[1]!.startsWith('counsel-os')) rows.push({ key: m[1]!.replace(/[-_]/g, ' '), value: m[2]!.trim() });
+    if (m !== null && !m[1]!.startsWith('counsel-os')) {
+      const key = m[1]!.replace(/[-_]/g, ' ');
+      let value = m[2]!.trim();
+      // The privacy flag reads as a fact, not a boolean (providers spec §7).
+      if (key === 'stays local') value = /^(true|yes|on)$/i.test(value) ? 'yes' : /^(false|no|off)$/i.test(value) ? 'no' : value;
+      rows.push({ key, value });
+    }
   }
   return { rows, body: lines.slice(end + 1).join('\n') };
 }


### PR DESCRIPTION
Providers spec §7, step 4 of the track.

**Declaration.** `stays_local: true` on a matter (a folder matter's `matter.md` governs its folder); vault-wide `default_locality: local` in `config.md`; a matter's own `stays_local: false` beats the vault default. First-run gains one checkbox that writes the vault default. `CONFIGURATION.md` documents both.

**Decided before the first call.** From the thread's explicit matter link, else a matter document attached to the message (the chip line), else the vault default. An inferred matter never sets policy.

**Enforced by the runtime.** `router.resolve(task, { localOnly })` picks the best local provider (tools first, then context) and throws a typed `MatterStaysLocalError` when none is loaded; the loop reads the header, evaluates the policy, and resolves the provider *before* appending the user turn; a named cloud provider is refused. `POST /threads/:id/steps` pre-flights and answers `409 { error: 'matter-stays-local', message }` without streaming. `GET /threads/:id` carries the policy. Run records carry `policy: 'stays-local'`. Never a silent downgrade.

**UI.** `· stays local` beside the MATTER line; "stays local — link it" for an inferred matter; the composer's line names the local model that answers (or says none is loaded); the 409 is shown as the sentence with no Retry; the switcher greys cloud rows for that thread; the reader's facts block reads `stays local · yes`.

**Order change worth knowing:** provider resolution now happens before the user turn is written for every step, so a router hard error or an unknown provider id no longer leaves a question nobody answered in the transcript (two loop tests updated accordingly).

Tests: `bun run test` 948 · `bun run ui:test` 491 · typechecks clean.