### PR TITLE
providers: model discovery — the vendor's model list on every row, curated where none exists (step 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+Model discovery (providers spec §4, step 3)
+
+- `GET /providers/:id/models` lists what a vendor can answer with — from the vendor's own list where one exists (OpenAI, Google, Mistral, Groq, DeepSeek, Cohere, Together AI, Fireworks, Cerebras, OpenRouter, Ollama, and every OpenAI-compatible preset and local runner), from a curated list where none does (Anthropic, xAI, Perplexity, DeepInfra) — with context sizes where the vendor reports them and OpenRouter's per-million prices kept for the scoreboard. A keyed vendor is never called without a key; a failure is one sentence, never an empty picker; listings are remembered for ten minutes (`?refresh=1` asks again).
+- Settings: each provider row gains a Model picker over that list (context size beside each model, custom ids still typed) with the runtime's sentence and a `refresh` link under it; a local runner lists from the row's base URL.
+- First run: a usable Ollama row lists its models in the same picker; picking one is the model counsel starts on.
+
 More providers and models, step 1 — the vendor catalog (providers spec §3, §6)
 
 - One vendor catalog (`runtime/src/providers/vendors.ts`) in two layers replaces the hand-kept allowlist. SDK-native: Google Gemini, Mistral, Groq, xAI, DeepSeek, Cohere, Perplexity, Together AI, Fireworks, DeepInfra, Cerebras and OpenRouter join Anthropic, OpenAI, Ollama and the OpenAI-compatible shape. Presets (data rows over the OpenAI-compatible shape, base URL built in): Kimi/Moonshot, GLM/Z.ai, Qwen/Alibaba Model Studio, SambaNova, Baseten, Hugging Face, Cloudflare Workers AI, Replicate, and the local runners LM Studio, llama.cpp, vLLM, MLX, Jan, GPT4All. An unknown prefix in `providers.yaml` now names the known ones. Settings adds a provider through one grouped picker (Subscriptions · Local runners · Hosted API); the first-run screen names the hosted vendors a key unlocks and open models worth starting with on Ollama.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -143,6 +143,8 @@ An API key is pasted once in Settings, on the provider's row, and kept in the pl
 
 The runtime reports only whether a key is set (`keySet: true | false | 'env'` on `/settings` and `/health`), never the value. `PUT /providers/<id>/key` and `DELETE /providers/<id>/key` are the only routes that touch keys.
 
+**Picking a model.** The model part of an id (`gpt-5.6` in `openai/gpt-5.6`) can be picked from the vendor's own list in Settings — the runtime asks the vendor (`GET /providers/<prefix>/models`) and shows each model's context size where the vendor reports it; vendors without a listing endpoint (Anthropic, xAI, Perplexity, DeepInfra) offer a curated list, and any id can still be typed. A local runner (Ollama, LM Studio, …) lists from the row's base URL; a keyed vendor is only asked once its key is set.
+
 ## Plugin-internal constants
 
 These aren't user-configurable; they're baked into the plugin:

--- a/docs/superpowers/plans/2026-09-01-model-discovery.md
+++ b/docs/superpowers/plans/2026-09-01-model-discovery.md
@@ -1,0 +1,39 @@
+# Providers step 3 — model discovery — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** a provider row's model is picked from the vendor's own list (with context size beside it), not typed from memory; the first-run Ollama row offers its models the same way; a vendor with no list endpoint offers a curated list; a failed listing is a sentence on the row, never an empty picker.
+
+**Architecture:** each catalog record gains a `discovery` descriptor (`shape` + optional `url`); `runtime/src/providers/discovery.ts` turns a descriptor plus credentials into `{ models, source, error? }` through one lister per response shape (OpenAI `/models`, Google `models.list`, OpenRouter, Ollama `/api/tags`, Cohere, Together). `GET /providers/:id/models` resolves the key the way the registry does (entry's `apiKeyEnv`, else the vendor's default variable), refuses to call a keyed vendor without a key, caches per vendor for ten minutes, and never throws. The UI's `ModelCombo` (react-aria combobox, same markup as `ProviderCombo`) feeds from that route on the Settings row and on the first-run Ollama row.
+
+**Tech Stack:** Bun `fetch` with `AbortSignal.timeout`, react-aria combobox hooks, zod for the route's query.
+
+**Spec:** `docs/superpowers/specs/2026-09-01-providers-design.md` §4, §9, §10, §11 step 3.
+
+## Global Constraints
+- No network in tests: every lister runs against recorded fixtures through an injected `fetch`.
+- 3-second timeout per vendor call; a failure is `{ error: 'Could not list models: <reason>' }`.
+- A keyed vendor is never called without a key: `{ models: [], error: 'No key for <Vendor> yet.' }`.
+- Keys come from the environment this step (the secret store is step 2; another builder owns it).
+- The Settings change is the MODEL field and its sentence; the switcher and task-route pickers are unchanged.
+- No Co-Authored-By / Claude-Session trailers.
+
+---
+
+### Task 1: discovery descriptors on the catalog + the listers
+**Files:** modify `runtime/src/providers/vendors.ts`; create `runtime/src/providers/discovery.ts`, `runtime/src/providers/discovery.test.ts`.
+- [ ] Test: each shape parses its fixture (`openai` → ids; `google` → `models/`-stripped ids filtered to `generateContent`, `inputTokenLimit`; `openrouter` → `context_length` + pricing per 1M; `ollama` → names; `cohere` → chat models with `context_length`; `together` → array with `context_length`); a slow server → the timeout error; a non-2xx → the status in the error; a curated vendor returns `source: 'curated'` without calling fetch; a `models: 'none'` vendor returns an explanatory error.
+- [ ] Implement `Discovery` on `Vendor` (`{ shape, url? }`), `discoverModels(vendor, { apiKey, baseURL, fetch, timeoutMs })`.
+
+### Task 2: the route
+**Files:** modify `runtime/src/server/routes.ts` (`API_PREFIXES` + `providers`), `runtime/src/server/routes.test.ts`.
+- [ ] Test: `GET /providers/openai/models` with no key → `{ models: [], source: 'list', error: 'No key for OpenAI yet.' }`; with `OPENAI_API_KEY` in the injected env → the fixture's ids; a full id `openai/gpt-5.6` resolves the vendor; a registry entry's `apiKeyEnv` wins; `?baseURL=` (loopback or https only) reaches a local runner; the second call hits the cache (fetch called once) and `?refresh=1` calls again; unknown prefix → 404.
+- [ ] Implement with `deps.discovery?: { fetch?, env?, now? }`.
+
+### Task 3: the UI picker
+**Files:** create `runtime/ui/src/settings/ModelCombo.tsx`, `ModelCombo.test.tsx`; modify `runtime/ui/src/v2/settings/SettingsPage.tsx`, `SettingsPage.test.tsx`, `runtime/ui/src/v2/SetupPage.tsx`, `SetupPage.test.tsx`, `runtime/ui/src/api/types.ts`, `runtime/ui/src/styles.css`.
+- [ ] Test: the Settings row shows a Model picker beside Id when the id has a known prefix; it lists the route's models with context sizes, picking sets the id to `<prefix>/<model>`, a custom id is accepted, the route's error shows as the row's sentence with a `refresh` link; the first-run Ollama row lists its models in the picker and picking sets the provider id.
+- [ ] Implement.
+
+### Task 4: docs
+- [ ] CHANGELOG Unreleased, CONFIGURATION.md note.

--- a/runtime/src/providers/discovery.test.ts
+++ b/runtime/src/providers/discovery.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, test } from 'bun:test';
+import { DiscoveryCache, discoverModels, listingURL, parseListing } from './discovery';
+import { vendorFor } from './vendors';
+
+function reply(body: unknown, status = 200): typeof fetch {
+  return (async () => new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+}
+
+function recording(body: unknown): { fetch: typeof fetch; calls: Array<{ url: string; auth: string | null }> } {
+  const calls: Array<{ url: string; auth: string | null }> = [];
+  const f = (async (input: string | URL | Request, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    calls.push({ url: String(input), auth: headers.get('authorization') });
+    return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+  }) as unknown as typeof fetch;
+  return { fetch: f, calls };
+}
+
+describe('parseListing — one parser per response shape (spec §4)', () => {
+  test('openai: ids, with a context size when the vendor adds one (Mistral, Groq)', () => {
+    const models = parseListing('openai', { object: 'list', data: [{ id: 'gpt-5.6', object: 'model' }, { id: 'mistral-large-latest', max_context_length: 131072 }, { id: 'llama-3.3-70b', context_window: 128000 }, { nope: true }] });
+    expect(models).toEqual([{ id: 'gpt-5.6' }, { id: 'llama-3.3-70b', contextTokens: 128000 }, { id: 'mistral-large-latest', contextTokens: 131072 }]);
+  });
+
+  test('google: models/ prefix stripped, only generateContent, inputTokenLimit', () => {
+    const models = parseListing('google', {
+      models: [
+        { name: 'models/gemini-2.5-pro', supportedGenerationMethods: ['generateContent', 'countTokens'], inputTokenLimit: 1048576 },
+        { name: 'models/embedding-001', supportedGenerationMethods: ['embedContent'], inputTokenLimit: 2048 },
+      ],
+    });
+    expect(models).toEqual([{ id: 'gemini-2.5-pro', contextTokens: 1048576 }]);
+  });
+
+  test('openrouter: context_length and per-token prices become per-million', () => {
+    const models = parseListing('openrouter', { data: [{ id: 'anthropic/claude-opus-5', context_length: 200000, pricing: { prompt: '0.000015', completion: '0.000075' } }, { id: 'free/x', context_length: 8192, pricing: { prompt: '0', completion: '0' } }] });
+    expect(models[0]).toEqual({ id: 'anthropic/claude-opus-5', contextTokens: 200000, pricing: { prompt: 15, completion: 75 } });
+    // A zero price is not a price; the model is still listed.
+    expect(models[1]).toEqual({ id: 'free/x', contextTokens: 8192 });
+  });
+
+  test('ollama: the tag names', () => {
+    expect(parseListing('ollama', { models: [{ name: 'gemma4:e4b' }, { name: 'qwen3:32b' }, {}] })).toEqual([{ id: 'gemma4:e4b' }, { id: 'qwen3:32b' }]);
+  });
+
+  test('cohere: chat models with their context length', () => {
+    expect(parseListing('cohere', { models: [{ name: 'command-a-03-2025', endpoints: ['chat'], context_length: 256000 }, { name: 'embed-v4', endpoints: ['embed'] }] })).toEqual([{ id: 'command-a-03-2025', contextTokens: 256000 }]);
+  });
+
+  test('together: a bare array, chat and language types only', () => {
+    expect(parseListing('together', [{ id: 'meta-llama/Llama-4-Scout', type: 'chat', context_length: 1048576 }, { id: 'some/embedding', type: 'embedding' }])).toEqual([{ id: 'meta-llama/Llama-4-Scout', contextTokens: 1048576 }]);
+  });
+
+  test('a body of the wrong shape is an empty list, never a throw', () => {
+    expect(parseListing('openai', null)).toEqual([]);
+    expect(parseListing('google', 'nonsense')).toEqual([]);
+    expect(parseListing('together', { data: [] })).toEqual([]);
+  });
+});
+
+describe('listingURL', () => {
+  test('the vendor root by shape, or the entry base URL when there is one', () => {
+    expect(listingURL(vendorFor('openai')!, undefined)).toBe('https://api.openai.com/v1/models');
+    expect(listingURL(vendorFor('groq')!, undefined)).toBe('https://api.groq.com/openai/v1/models');
+    expect(listingURL(vendorFor('cohere')!, undefined)).toBe('https://api.cohere.com/v1/models?endpoint=chat');
+    expect(listingURL(vendorFor('ollama')!, undefined)).toBe('http://127.0.0.1:11434/api/tags');
+    expect(listingURL(vendorFor('ollama')!, 'http://127.0.0.1:11435/')).toBe('http://127.0.0.1:11435/api/tags');
+    expect(listingURL(vendorFor('lmstudio')!, undefined)).toBe('http://127.0.0.1:1234/v1/models');
+    expect(listingURL(vendorFor('openai-compatible')!, 'http://localhost:8080/v1')).toBe('http://localhost:8080/v1/models');
+    expect(listingURL(vendorFor('openai-compatible')!, undefined)).toBeNull();
+  });
+});
+
+describe('discoverModels', () => {
+  test('a curated vendor answers from the catalog without a request', async () => {
+    let called = false;
+    const r = await discoverModels(vendorFor('anthropic')!, { fetch: (async () => { called = true; return new Response('{}'); }) as unknown as typeof fetch });
+    expect(r.source).toBe('curated');
+    expect(r.models.map(m => m.id)).toContain('claude-opus-5');
+    expect(called).toBe(false);
+  });
+
+  test('a keyed vendor is not called without a key', async () => {
+    let called = false;
+    const r = await discoverModels(vendorFor('openai')!, { fetch: (async () => { called = true; return new Response('{}'); }) as unknown as typeof fetch });
+    expect(r).toEqual({ models: [], source: 'list', error: 'No key for OpenAI yet.' });
+    expect(called).toBe(false);
+  });
+
+  test('a listed vendor is asked with the bearer, and answers sorted', async () => {
+    const rec = recording({ data: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }] });
+    const r = await discoverModels(vendorFor('openai')!, { apiKey: 'sk-test', fetch: rec.fetch });
+    expect(r).toEqual({ models: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }], source: 'list' });
+    expect(rec.calls).toEqual([{ url: 'https://api.openai.com/v1/models', auth: 'Bearer sk-test' }]);
+  });
+
+  test('google takes the key as a query parameter, never as a bearer', async () => {
+    const rec = recording({ models: [{ name: 'models/gemini-2.5-pro', supportedGenerationMethods: ['generateContent'], inputTokenLimit: 1048576 }] });
+    const r = await discoverModels(vendorFor('google')!, { apiKey: 'g-key', fetch: rec.fetch });
+    expect(r.models).toEqual([{ id: 'gemini-2.5-pro', contextTokens: 1048576 }]);
+    expect(rec.calls[0]!.url).toBe('https://generativelanguage.googleapis.com/v1beta/models?key=g-key');
+    expect(rec.calls[0]!.auth).toBeNull();
+  });
+
+  test('a local runner needs no key', async () => {
+    const rec = recording({ models: [{ name: 'gemma4:e4b' }] });
+    const r = await discoverModels(vendorFor('ollama')!, { fetch: rec.fetch });
+    expect(r).toEqual({ models: [{ id: 'gemma4:e4b' }], source: 'list' });
+    expect(rec.calls[0]!.auth).toBeNull();
+  });
+
+  test('a refused key, a server error, an empty list, and a timeout are sentences', async () => {
+    expect((await discoverModels(vendorFor('openai')!, { apiKey: 'k', fetch: reply({ error: 'bad key' }, 401) })).error).toBe('Could not list models: the key was refused by OpenAI.');
+    expect((await discoverModels(vendorFor('openai')!, { apiKey: 'k', fetch: reply({}, 503) })).error).toBe('Could not list models: OpenAI answered 503.');
+    expect((await discoverModels(vendorFor('openai')!, { apiKey: 'k', fetch: reply({ data: [] }) })).error).toBe('Could not list models: OpenAI returned none.');
+    const slow = ((_: unknown, init?: RequestInit) => new Promise<Response>((_resolve, reject) => { init?.signal?.addEventListener('abort', () => reject(Object.assign(new Error('timed out'), { name: 'TimeoutError' }))); })) as unknown as typeof fetch;
+    const r = await discoverModels(vendorFor('openai')!, { apiKey: 'k', fetch: slow, timeoutMs: 10 });
+    expect(r.error).toBe('Could not list models: OpenAI did not answer in time.');
+    expect(r.models).toEqual([]);
+  });
+
+  test('a vendor with no list and no curated ids says to type the id', async () => {
+    const r = await discoverModels(vendorFor('claude-sub')!, {});
+    expect(r.models).toEqual([]);
+    expect(r.error).toContain('type the model id');
+  });
+
+  test('the bare OpenAI-compatible shape needs a base URL first', async () => {
+    const r = await discoverModels(vendorFor('openai-compatible')!, { fetch: reply({ data: [{ id: 'x' }] }) });
+    expect(r.error).toContain('needs a base URL');
+    const ok = await discoverModels(vendorFor('openai-compatible')!, { baseURL: 'http://127.0.0.1:1234/v1', fetch: reply({ data: [{ id: 'x' }] }) });
+    expect(ok.models).toEqual([{ id: 'x' }]);
+  });
+});
+
+describe('DiscoveryCache', () => {
+  test('remembers a good listing for the ttl, never a failure', () => {
+    let t = 0;
+    const cache = new DiscoveryCache(1000, () => t);
+    const k = cache.key('openai', undefined);
+    cache.set(k, { models: [], source: 'list', error: 'nope' });
+    expect(cache.get(k)).toBeNull();
+    cache.set(k, { models: [{ id: 'a' }], source: 'list' });
+    expect(cache.get(k)?.models).toEqual([{ id: 'a' }]);
+    t = 1001;
+    expect(cache.get(k)).toBeNull();
+    expect(cache.key('ollama', 'http://127.0.0.1:11434')).not.toBe(cache.key('ollama', undefined));
+  });
+});

--- a/runtime/src/providers/discovery.ts
+++ b/runtime/src/providers/discovery.ts
@@ -1,0 +1,244 @@
+/**
+ * Model discovery (providers spec §4): what a vendor can answer with, from
+ * the vendor's own list where one exists, from the catalog's curated list
+ * where none does.
+ *
+ * One lister per RESPONSE SHAPE, not per vendor: most hosted APIs answer
+ * `GET …/models` in OpenAI's `{ data: [{ id }] }`; Google, OpenRouter, Ollama,
+ * Cohere and Together have their own. The catalog record says which shape
+ * and, when the vendor's API lives somewhere other than the entry's base
+ * URL, where.
+ *
+ * Nothing here throws to a caller: a vendor that is down, slow, or refusing
+ * the key becomes one sentence in `error`, and the picker still takes a
+ * typed id.
+ */
+import type { Vendor } from './vendors';
+
+export type DiscoveryShape = 'openai' | 'google' | 'openrouter' | 'ollama' | 'cohere' | 'together';
+
+export interface Discovery {
+  shape: DiscoveryShape;
+  /** The listing URL. Absent → derived from the base URL by shape
+   * (`<baseURL>/models`, `<ollama>/api/tags`). */
+  url?: string;
+  /** The listing was not confirmed against the vendor's docs when written. */
+  unverified?: boolean;
+}
+
+export interface DiscoveredModel {
+  id: string;
+  contextTokens?: number;
+  /** USD per million tokens, when the vendor says (OpenRouter). Kept for the
+   * scoreboard (phase 2); the picker does not show it yet. */
+  pricing?: { prompt: number; completion: number };
+}
+
+export interface DiscoveryResult {
+  models: DiscoveredModel[];
+  source: 'list' | 'curated';
+  error?: string;
+}
+
+export interface DiscoveryOptions {
+  apiKey?: string;
+  /** The entry's base URL (a local runner, a preset, or an override). */
+  baseURL?: string;
+  fetch?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export const DISCOVERY_TIMEOUT_MS = 3_000;
+
+/** The vendor's own API root, for a vendor whose entry names no base URL. */
+export const API_ROOTS: Readonly<Record<string, string>> = {
+  openai: 'https://api.openai.com/v1',
+  mistral: 'https://api.mistral.ai/v1',
+  groq: 'https://api.groq.com/openai/v1',
+  deepseek: 'https://api.deepseek.com',
+  togetherai: 'https://api.together.xyz/v1',
+  fireworks: 'https://api.fireworks.ai/inference/v1',
+  cerebras: 'https://api.cerebras.ai/v1',
+  cohere: 'https://api.cohere.com/v1',
+  openrouter: 'https://openrouter.ai/api/v1',
+  google: 'https://generativelanguage.googleapis.com/v1beta',
+  ollama: 'http://127.0.0.1:11434',
+};
+
+function trimSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/** Where to ask. The entry's base URL wins (a local runner, a preset, a
+ * proxy); otherwise the vendor's root; the shape adds its path. */
+export function listingURL(vendor: Vendor, baseURL: string | undefined): string | null {
+  const d = vendor.discovery;
+  if (d === undefined) return null;
+  if (d.url !== undefined && baseURL === undefined) return d.url;
+  const root = baseURL ?? vendor.defaultBaseURL ?? API_ROOTS[vendor.prefix];
+  if (root === undefined) return d.url ?? null;
+  const base = trimSlash(root);
+  switch (d.shape) {
+    case 'ollama':
+      return `${base}/api/tags`;
+    case 'google':
+      return `${base}/models`;
+    case 'cohere':
+      return `${base}/models?endpoint=chat`;
+    default:
+      return `${base}/models`;
+  }
+}
+
+function asNumber(v: unknown): number | undefined {
+  if (typeof v === 'number' && Number.isFinite(v) && v > 0) return v;
+  if (typeof v === 'string' && v.trim() !== '' && Number.isFinite(Number(v))) return Number(v) > 0 ? Number(v) : undefined;
+  return undefined;
+}
+
+/** OpenRouter prices per token as strings; the picker wants per million. */
+function perMillion(v: unknown): number | undefined {
+  const n = asNumber(v);
+  return n === undefined ? undefined : Math.round(n * 1_000_000 * 1000) / 1000;
+}
+
+function model(id: string, contextTokens?: number, pricing?: DiscoveredModel['pricing']): DiscoveredModel {
+  return { id, ...(contextTokens === undefined ? {} : { contextTokens }), ...(pricing === undefined ? {} : { pricing }) };
+}
+
+/** Each shape's body → models. Exported for the fixture tests. */
+export function parseListing(shape: DiscoveryShape, body: unknown): DiscoveredModel[] {
+  const out: DiscoveredModel[] = [];
+  const obj = (body ?? {}) as Record<string, unknown>;
+  switch (shape) {
+    case 'openai': {
+      const data = Array.isArray(obj['data']) ? (obj['data'] as Array<Record<string, unknown>>) : [];
+      for (const m of data) {
+        if (typeof m['id'] !== 'string') continue;
+        // Mistral: max_context_length; Groq: context_window; both optional.
+        out.push(model(m['id'], asNumber(m['max_context_length']) ?? asNumber(m['context_window']) ?? asNumber(m['context_length'])));
+      }
+      break;
+    }
+    case 'google': {
+      const models = Array.isArray(obj['models']) ? (obj['models'] as Array<Record<string, unknown>>) : [];
+      for (const m of models) {
+        const name = typeof m['name'] === 'string' ? m['name'] : '';
+        const methods = Array.isArray(m['supportedGenerationMethods']) ? (m['supportedGenerationMethods'] as unknown[]) : [];
+        if (name === '' || !methods.includes('generateContent')) continue;
+        out.push(model(name.replace(/^models\//, ''), asNumber(m['inputTokenLimit'])));
+      }
+      break;
+    }
+    case 'openrouter': {
+      const data = Array.isArray(obj['data']) ? (obj['data'] as Array<Record<string, unknown>>) : [];
+      for (const m of data) {
+        if (typeof m['id'] !== 'string') continue;
+        const p = (m['pricing'] ?? {}) as Record<string, unknown>;
+        const prompt = perMillion(p['prompt']);
+        const completion = perMillion(p['completion']);
+        out.push(model(m['id'], asNumber(m['context_length']), prompt !== undefined && completion !== undefined ? { prompt, completion } : undefined));
+      }
+      break;
+    }
+    case 'ollama': {
+      const models = Array.isArray(obj['models']) ? (obj['models'] as Array<Record<string, unknown>>) : [];
+      for (const m of models) if (typeof m['name'] === 'string' && m['name'] !== '') out.push(model(m['name']));
+      break;
+    }
+    case 'cohere': {
+      const models = Array.isArray(obj['models']) ? (obj['models'] as Array<Record<string, unknown>>) : [];
+      for (const m of models) {
+        if (typeof m['name'] !== 'string') continue;
+        const endpoints = Array.isArray(m['endpoints']) ? (m['endpoints'] as unknown[]) : ['chat'];
+        if (!endpoints.includes('chat')) continue;
+        out.push(model(m['name'], asNumber(m['context_length'])));
+      }
+      break;
+    }
+    case 'together': {
+      const arr = Array.isArray(body) ? (body as Array<Record<string, unknown>>) : [];
+      for (const m of arr) {
+        if (typeof m['id'] !== 'string') continue;
+        if (typeof m['type'] === 'string' && m['type'] !== 'chat' && m['type'] !== 'language') continue;
+        out.push(model(m['id'], asNumber(m['context_length'])));
+      }
+      break;
+    }
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+function authHeaders(vendor: Vendor, apiKey: string | undefined, url: string): Record<string, string> {
+  if (apiKey === undefined || apiKey === '') return {};
+  // Google takes the key as a query parameter (handled by the caller);
+  // everything else is a bearer.
+  if (vendor.discovery?.shape === 'google') return {};
+  void url;
+  return { authorization: `Bearer ${apiKey}` };
+}
+
+/**
+ * The models for one vendor. Curated vendors answer from the catalog
+ * without a request; keyed vendors are not called without a key; every
+ * failure is a sentence, never a throw.
+ */
+export async function discoverModels(vendor: Vendor, opts: DiscoveryOptions = {}): Promise<DiscoveryResult> {
+  if (vendor.models === 'curated') {
+    return { models: (vendor.curated ?? []).map(m => model(m.id, m.contextTokens)), source: 'curated' };
+  }
+  if (vendor.models === 'none' || vendor.discovery === undefined) {
+    return { models: [], source: 'list', error: `${vendor.name} does not publish a model list; type the model id.` };
+  }
+  const needsKey = vendor.auth === 'apikey' && vendor.locality !== 'local' && vendor.prefix !== 'openai-compatible';
+  if (needsKey && (opts.apiKey === undefined || opts.apiKey === '')) {
+    return { models: [], source: 'list', error: `No key for ${vendor.name} yet.` };
+  }
+  const url0 = listingURL(vendor, opts.baseURL);
+  if (url0 === null) return { models: [], source: 'list', error: `${vendor.name} needs a base URL before its models can be listed.` };
+  const url = vendor.discovery.shape === 'google' && opts.apiKey !== undefined ? `${url0}${url0.includes('?') ? '&' : '?'}key=${encodeURIComponent(opts.apiKey)}` : url0;
+  const doFetch = opts.fetch ?? fetch;
+  try {
+    const res = await doFetch(url, { headers: { accept: 'application/json', ...authHeaders(vendor, opts.apiKey, url) }, signal: AbortSignal.timeout(opts.timeoutMs ?? DISCOVERY_TIMEOUT_MS) });
+    if (!res.ok) {
+      const why = res.status === 401 || res.status === 403 ? `the key was refused by ${vendor.name}` : `${vendor.name} answered ${res.status}`;
+      return { models: [], source: 'list', error: `Could not list models: ${why}.` };
+    }
+    const bodyJson: unknown = await res.json();
+    const models = parseListing(vendor.discovery.shape, bodyJson);
+    if (models.length === 0) return { models, source: 'list', error: `Could not list models: ${vendor.name} returned none.` };
+    return { models, source: 'list' };
+  } catch (err) {
+    const timedOut = err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
+    const reason = timedOut ? `${vendor.name} did not answer in time` : err instanceof Error ? err.message : String(err);
+    return { models: [], source: 'list', error: `Could not list models: ${reason}.` };
+  }
+}
+
+/** A ten-minute memory of listings, keyed by vendor and base URL, so a
+ * Settings page that re-renders does not re-ask the vendor. */
+export class DiscoveryCache {
+  private readonly entries = new Map<string, { at: number; result: DiscoveryResult }>();
+  constructor(private readonly ttlMs = 10 * 60_000, private readonly now: () => number = () => Date.now()) {}
+
+  key(vendorPrefix: string, baseURL: string | undefined): string {
+    return `${vendorPrefix}|${baseURL ?? ''}`;
+  }
+
+  get(key: string): DiscoveryResult | null {
+    const hit = this.entries.get(key);
+    if (hit === undefined) return null;
+    if (this.now() - hit.at > this.ttlMs) {
+      this.entries.delete(key);
+      return null;
+    }
+    return hit.result;
+  }
+
+  set(key: string, result: DiscoveryResult): void {
+    // A failure is not worth remembering: the next look should try again.
+    if (result.error !== undefined) return;
+    this.entries.set(key, { at: this.now(), result });
+  }
+}

--- a/runtime/src/providers/vendors.ts
+++ b/runtime/src/providers/vendors.ts
@@ -38,6 +38,7 @@ import { createXai } from '@ai-sdk/xai';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { createOllama } from 'ai-sdk-ollama';
 import type { Capabilities, Locality } from '../core/types';
+import type { Discovery } from './discovery';
 
 /** Who receives the text when a cloud vendor answers, and where they say
  * what they do with it. `null` for anything that stays on this machine. */
@@ -84,9 +85,12 @@ export interface Vendor {
   keyEnv?: string;
   keyLabel?: string;
   help: { getKey?: string; install?: string; note?: string };
-  /** How models are discovered (step 3); `curated` ships a list here. */
+  /** How models are discovered (step 3): `list` asks the vendor (see
+   * `discovery`), `curated` ships a list here, `none` means type the id. */
   models: 'list' | 'curated' | 'none';
   curated?: VendorModel[];
+  /** The listing's shape and, when it is not at the base URL, its URL. */
+  discovery?: Discovery;
   /** Open models worth starting with (Ollama). */
   openModels?: OpenModel[];
   /** Capability defaults for the prefix; an entry may refine them. */
@@ -129,6 +133,30 @@ const ANTHROPIC_MODELS: VendorModel[] = [
   { id: 'claude-haiku-4-5-20251001', contextTokens: 200_000 },
 ];
 
+/** xAI documents no listing endpoint; the ids from its models page. */
+const XAI_MODELS: VendorModel[] = [
+  { id: 'grok-4', contextTokens: 256_000 },
+  { id: 'grok-4-fast', contextTokens: 2_000_000 },
+  { id: 'grok-3', contextTokens: 131_072 },
+  { id: 'grok-3-mini', contextTokens: 131_072 },
+];
+
+/** Perplexity has no listing endpoint; the Sonar family. */
+const PERPLEXITY_MODELS: VendorModel[] = [
+  { id: 'sonar', contextTokens: 128_000 },
+  { id: 'sonar-pro', contextTokens: 200_000 },
+  { id: 'sonar-reasoning-pro', contextTokens: 128_000 },
+  { id: 'sonar-deep-research', contextTokens: 128_000 },
+];
+
+/** DeepInfra documents no OpenAI-shaped listing; a few open models it hosts. */
+const DEEPINFRA_MODELS: VendorModel[] = [
+  { id: 'meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8', contextTokens: 1_000_000 },
+  { id: 'Qwen/Qwen3-235B-A22B-Instruct-2507', contextTokens: 262_144 },
+  { id: 'deepseek-ai/DeepSeek-V3.1', contextTokens: 163_840 },
+  { id: 'openai/gpt-oss-120b', contextTokens: 131_072 },
+];
+
 /** Good starting points for a local model; the scoreboard (phase 2) ranks
  * them for the practice's own work. Tool use and a long context are what
  * counsel's loop needs. */
@@ -169,84 +197,84 @@ const SDK_VENDORS: Vendor[] = [
     prefix: 'openai', name: 'OpenAI', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'OpenAI', termsUrl: 'https://openai.com/policies/business-terms' },
     keyEnv: 'OPENAI_API_KEY', keyLabel: 'API key', help: { getKey: 'https://platform.openai.com/api-keys' },
-    models: 'list', capabilities: CLOUD_CAPS,
+    models: 'list', discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS,
     make: ({ model, apiKey, baseURL }) => createOpenAI(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'google', name: 'Google', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Google', termsUrl: 'https://ai.google.dev/gemini-api/terms' },
     keyEnv: 'GOOGLE_GENERATIVE_AI_API_KEY', keyLabel: 'API key', help: { getKey: 'https://aistudio.google.com/apikey' },
-    models: 'list', capabilities: { tools: true, caching: true, thinking: true, contextTokens: 1_000_000 },
+    models: 'list', discovery: { shape: 'google' }, capabilities: { tools: true, caching: true, thinking: true, contextTokens: 1_000_000 },
     make: ({ model, apiKey, baseURL }) => createGoogle(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'mistral', name: 'Mistral', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Mistral AI', termsUrl: 'https://mistral.ai/terms' },
     keyEnv: 'MISTRAL_API_KEY', keyLabel: 'API key', help: { getKey: 'https://console.mistral.ai/api-keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createMistral(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'groq', name: 'Groq', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Groq', termsUrl: 'https://groq.com/terms-of-use' },
     keyEnv: 'GROQ_API_KEY', keyLabel: 'API key', help: { getKey: 'https://console.groq.com/keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createGroq(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'xai', name: 'xAI', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'xAI', termsUrl: 'https://x.ai/legal/terms-of-service-enterprise' },
     keyEnv: 'XAI_API_KEY', keyLabel: 'API key', help: { getKey: 'https://console.x.ai' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'curated', curated: XAI_MODELS, discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createXai(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'deepseek', name: 'DeepSeek', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'DeepSeek', termsUrl: 'https://platform.deepseek.com/' },
     keyEnv: 'DEEPSEEK_API_KEY', keyLabel: 'API key', help: { getKey: 'https://platform.deepseek.com/api_keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createDeepSeek(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'cohere', name: 'Cohere', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Cohere', termsUrl: 'https://cohere.com/terms-of-use' },
     keyEnv: 'COHERE_API_KEY', keyLabel: 'API key', help: { getKey: 'https://dashboard.cohere.com/api-keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'cohere' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createCohere(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'perplexity', name: 'Perplexity', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Perplexity', termsUrl: 'https://www.perplexity.ai/hub/legal/terms-of-service' },
     keyEnv: 'PERPLEXITY_API_KEY', keyLabel: 'API key', help: { getKey: 'https://www.perplexity.ai/settings/api' },
-    models: 'none', capabilities: { tools: false, caching: false, thinking: false, contextTokens: 128_000 },
+    models: 'curated', curated: PERPLEXITY_MODELS, discovery: { shape: 'openai' }, capabilities: { tools: false, caching: false, thinking: false, contextTokens: 128_000 },
     make: ({ model, apiKey, baseURL }) => createPerplexity(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'togetherai', name: 'Together AI', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Together AI', termsUrl: 'https://www.together.ai/terms-of-service' },
     keyEnv: 'TOGETHER_AI_API_KEY', keyLabel: 'API key', help: { getKey: 'https://api.together.ai/settings/api-keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'together' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createTogetherAI(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'fireworks', name: 'Fireworks', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Fireworks AI', termsUrl: 'https://fireworks.ai/terms-of-service' },
     keyEnv: 'FIREWORKS_API_KEY', keyLabel: 'API key', help: { getKey: 'https://fireworks.ai/account/api-keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openai', unverified: true }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createFireworks(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'deepinfra', name: 'DeepInfra', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'DeepInfra', termsUrl: 'https://deepinfra.com/terms' },
     keyEnv: 'DEEPINFRA_API_KEY', keyLabel: 'API key', help: { getKey: 'https://deepinfra.com/dash/api_keys' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'curated', curated: DEEPINFRA_MODELS, discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createDeepInfra(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'cerebras', name: 'Cerebras', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',
     handles: { company: 'Cerebras', termsUrl: 'https://www.cerebras.ai/terms-of-service' },
     keyEnv: 'CEREBRAS_API_KEY', keyLabel: 'API key', help: { getKey: 'https://cloud.cerebras.ai/platform' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openai' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createCerebras(keyed(apiKey, baseURL))(model),
   },
   {
@@ -255,17 +283,17 @@ const SDK_VENDORS: Vendor[] = [
     // model. The label names the relay, since that is who holds the key.
     handles: { company: 'OpenRouter (and the model’s vendor)', termsUrl: 'https://openrouter.ai/terms' },
     keyEnv: 'OPENROUTER_API_KEY', keyLabel: 'API key', help: { getKey: 'https://openrouter.ai/keys', note: 'One key, many models.' },
-    models: 'list', capabilities: CLOUD_CAPS_NO_CACHE,
+    models: 'list', discovery: { shape: 'openrouter' }, capabilities: CLOUD_CAPS_NO_CACHE,
     make: ({ model, apiKey, baseURL }) => createOpenRouter(keyed(apiKey, baseURL))(model),
   },
   {
     prefix: 'ollama', name: 'Ollama', kind: 'direct', layer: 'sdk', group: 'local', auth: 'local', locality: 'local', handles: null,
-    help: { install: 'https://ollama.com/download' }, models: 'list', openModels: OPEN_MODELS, capabilities: LOCAL_CAPS,
+    help: { install: 'https://ollama.com/download' }, models: 'list', discovery: { shape: 'ollama' }, openModels: OPEN_MODELS, capabilities: LOCAL_CAPS,
     make: ({ model, baseURL }) => createOllama(baseURL === undefined ? {} : { baseURL })(model),
   },
   {
     prefix: 'openai-compatible', name: 'OpenAI-compatible', kind: 'direct', layer: 'sdk', group: 'local', auth: 'apikey', locality: 'by-baseURL', handles: null,
-    keyLabel: 'API key (if the server wants one)', help: {}, models: 'list', capabilities: LOCAL_CAPS, requiresBaseURL: true,
+    keyLabel: 'API key (if the server wants one)', help: {}, models: 'list', discovery: { shape: 'openai' }, capabilities: LOCAL_CAPS, requiresBaseURL: true,
     make: ({ model, apiKey, baseURL }) => createOpenAICompatible({ name: model, baseURL: baseURL ?? '', ...(apiKey === undefined ? {} : { apiKey }) })(model),
   },
 ];
@@ -329,6 +357,7 @@ function vendorFromPreset(p: Preset): Vendor {
     ...(p.keyLabel === undefined ? {} : { keyLabel: p.keyLabel }),
     help: { ...(p.getKey === undefined ? {} : { getKey: p.getKey }), ...(p.note === undefined ? {} : { note: p.note }) },
     models: 'list',
+    discovery: { shape: 'openai', ...(p.unverified === true ? { unverified: true } : {}) },
     capabilities: { ...(local ? LOCAL_CAPS : CLOUD_CAPS_NO_CACHE), ...p.capabilities },
     defaultBaseURL: p.baseURL,
     ...(p.baseURLFields === undefined ? {} : { baseURLFields: p.baseURLFields, requiresBaseURL: true }),

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1641,10 +1641,10 @@ describe('model discovery (providers spec §4)', () => {
 describe('model discovery reads the secret store first (providers spec §5)', () => {
   test('a key set only in the store makes the listing call the vendor instead of answering "No key … yet"', async () => {
     const urls: string[] = [];
-    let auth: string | null = null;
+    const seen: { auth: string | null } = { auth: null };
     const f = (async (input: string | URL | Request, init?: RequestInit) => {
       urls.push(String(input));
-      auth = new Headers(init?.headers).get('authorization');
+      seen.auth = new Headers(init?.headers).get('authorization');
       return new Response(JSON.stringify({ data: [{ id: 'gpt-5.6' }] }), { status: 200, headers: { 'content-type': 'application/json' } });
     }) as unknown as typeof fetch;
     const file = join(mkdtempSync(join(tmpdir(), 'routes-disc-key-')), 'providers.yaml');
@@ -1656,6 +1656,6 @@ describe('model discovery reads the secret store first (providers spec §5)', ()
     const res = await (await call(app, 'GET', '/providers/openai/models')).json();
     expect(res).toEqual({ models: [{ id: 'gpt-5.6' }], source: 'list' });
     expect(urls).toEqual(['https://api.openai.com/v1/models']);
-    expect(auth).toBe('Bearer sk-from-store');
+    expect(seen.auth).toBe('Bearer sk-from-store');
   });
 });

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -9,6 +9,7 @@ import { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
 import { fsSearch } from '../vault/search';
+import { memoryStore } from '../providers/secrets';
 import { buildDocx } from '../docx/test/builder';
 import { API_PREFIXES, createApp, safeBasename, suffixed, TRUNCATED_HEADER, UPLOAD_MAX_BYTES, type App, type ServerDeps } from './routes';
 import type { RuntimeState } from './settings';
@@ -1566,5 +1567,95 @@ describe('providers carry their locality and handles (providers spec §6)', () =
     }
     const settings = (await (await call(app, 'GET', '/settings')).json()) as { effective: { providers: Array<{ id: string; locality: string }> } };
     expect(settings.effective.providers.find(p => p.id === 'fake/fake')?.locality).toBe('local');
+  });
+});
+
+describe('model discovery (providers spec §4)', () => {
+  const listing = { object: 'list', data: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }] };
+  function recording(body: unknown = listing): { fetch: typeof fetch; urls: string[] } {
+    const urls: string[] = [];
+    const f = (async (input: string | URL | Request) => {
+      urls.push(String(input));
+      return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    return { fetch: f, urls };
+  }
+
+  test('a keyed vendor with no key is a sentence, and the vendor is never called', async () => {
+    const rec = recording();
+    // An empty environment on purpose: the developer's own OPENAI_API_KEY
+    // must never turn a route test into a real request.
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { discovery: { fetch: rec.fetch, env: {} } });
+    const res = await call(app, 'GET', '/providers/openai/models');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ models: [], source: 'list', error: 'No key for OpenAI yet.' });
+    expect(rec.urls).toEqual([]);
+  });
+
+  test('with a key in the environment: the vendor lists; a full id resolves its vendor; the cache holds until ?refresh=1', async () => {
+    const rec = recording();
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { discovery: { fetch: rec.fetch, env: { OPENAI_API_KEY: 'sk-t' } } });
+    const first = await (await call(app, 'GET', '/providers/openai/models')).json();
+    expect(first).toEqual({ models: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }], source: 'list' });
+    // A full id (with its own slash) names the same vendor and hits the cache.
+    const byId = await (await call(app, 'GET', '/providers/openai%2Fgpt-5.6/models')).json();
+    expect(byId).toEqual(first);
+    const again = await (await call(app, 'GET', '/providers/openai/gpt-5.6/models')).json();
+    expect(again).toEqual(first);
+    expect(rec.urls).toEqual(['https://api.openai.com/v1/models']);
+    await call(app, 'GET', '/providers/openai/models?refresh=1');
+    expect(rec.urls).toHaveLength(2);
+  });
+
+  test("a registry entry's apiKeyEnv and baseURL win over the vendor's defaults", async () => {
+    const rec = recording({ data: [{ id: 'local-model' }] });
+    const file = join(mkdtempSync(join(tmpdir(), 'routes-disc-')), 'providers.yaml');
+    writeFileSync(file, 'providers:\n  - id: openai-compatible/mine\n    baseURL: http://127.0.0.1:1234/v1\n    apiKeyEnv: MY_KEY\n');
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { settings: { file, reload: () => {} }, discovery: { fetch: rec.fetch, env: { MY_KEY: 'k' } } });
+    const res = await (await call(app, 'GET', '/providers/openai-compatible%2Fmine/models')).json();
+    expect(res).toEqual({ models: [{ id: 'local-model' }], source: 'list' });
+    expect(rec.urls).toEqual(['http://127.0.0.1:1234/v1/models']);
+  });
+
+  test('?baseURL= reaches a local runner and is held to the base-URL rule', async () => {
+    const rec = recording({ models: [{ name: 'gemma4:e4b' }] });
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { discovery: { fetch: rec.fetch, env: {} } });
+    const ok = await (await call(app, 'GET', '/providers/ollama/models?baseURL=http%3A%2F%2F127.0.0.1%3A11435')).json();
+    expect(ok).toEqual({ models: [{ id: 'gemma4:e4b' }], source: 'list' });
+    expect(rec.urls).toEqual(['http://127.0.0.1:11435/api/tags']);
+    expect((await call(app, 'GET', '/providers/ollama/models?baseURL=http%3A%2F%2Fevil.example%2Fv1')).status).toBe(400);
+  });
+
+  test('a curated vendor answers from the catalog; an unknown prefix is 404; no token is 401', async () => {
+    const rec = recording();
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { discovery: { fetch: rec.fetch, env: {} } });
+    const curated = (await (await call(app, 'GET', '/providers/anthropic/models')).json()) as { source: string; models: Array<{ id: string }> };
+    expect(curated.source).toBe('curated');
+    expect(curated.models.map((m: { id: string }) => m.id)).toContain('claude-opus-5');
+    expect(rec.urls).toEqual([]);
+    expect((await call(app, 'GET', '/providers/nope/models')).status).toBe(404);
+    expect((await call(app, 'GET', '/providers/openai/models', { token: null })).status).toBe(401);
+  });
+});
+
+describe('model discovery reads the secret store first (providers spec §5)', () => {
+  test('a key set only in the store makes the listing call the vendor instead of answering "No key … yet"', async () => {
+    const urls: string[] = [];
+    let auth: string | null = null;
+    const f = (async (input: string | URL | Request, init?: RequestInit) => {
+      urls.push(String(input));
+      auth = new Headers(init?.headers).get('authorization');
+      return new Response(JSON.stringify({ data: [{ id: 'gpt-5.6' }] }), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    const file = join(mkdtempSync(join(tmpdir(), 'routes-disc-key-')), 'providers.yaml');
+    writeFileSync(file, 'providers:\n  - id: openai/gpt-5.6\n');
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], {
+      settings: { file, reload: () => {}, secrets: memoryStore({ 'openai/gpt-5.6': 'sk-from-store' }) },
+      discovery: { fetch: f, env: {} },
+    });
+    const res = await (await call(app, 'GET', '/providers/openai/models')).json();
+    expect(res).toEqual({ models: [{ id: 'gpt-5.6' }], source: 'list' });
+    expect(urls).toEqual(['https://api.openai.com/v1/models']);
+    expect(auth).toBe('Bearer sk-from-store');
   });
 });

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -6,7 +6,9 @@ import { applyProposal } from '../loop/proposals';
 import { listRuns, readRun, type RunRecord } from '../loop/run-record';
 import { DOCX_CONTENT_TYPE, docxToMarkdown, isDocxPath, NotADocxError, openDocx, UnsafeXmlError } from '../docx';
 import { assertSafeXml } from '../docx/safety';
-import { RegistryFile } from '../providers/registry';
+import { BASE_URL_RULE, isAllowedBaseURL, readRegistry, RegistryFile } from '../providers/registry';
+import { DiscoveryCache, discoverModels } from '../providers/discovery';
+import { prefixOf, vendorFor } from '../providers/vendors';
 import type { ThreadEvent, ThreadHeader } from '../threads/store';
 import { vaultDocket } from '../vault/docket';
 import { normalizeVaultPath } from '../vault/knowledge-paths';
@@ -52,6 +54,10 @@ export interface ServerDeps extends Omit<CounselLoopDeps, 'providers' | 'router'
   /** The doctor's git runner (spec 2026-09-01 §7). Default: real git when
    * on PATH; `null` reports "git is not installed". */
   git?: GitRunner | null;
+  /** Model discovery (providers spec §4): the fetch the vendor listings go
+   * through, the environment the keys are read from, and the ten-minute
+   * cache — all injectable so the route tests never touch the network. */
+  discovery?: { fetch?: typeof fetch; env?: NodeJS.ProcessEnv; cache?: DiscoveryCache };
 }
 
 export type App = (req: Request) => Promise<Response>;
@@ -441,6 +447,53 @@ export function createApp(deps: ServerDeps): App {
     } finally {
       release();
     }
+  };
+
+  /**
+   * `GET /providers/:id/models` (providers spec §4): the vendor's own list,
+   * or the catalog's curated one. `:id` is a prefix (`openai`) or a full
+   * provider id (`openai/gpt-5.6`, which may itself contain slashes). The
+   * key is resolved the way the registry resolves it — the secret store,
+   * else the entry's `apiKeyEnv`, else the vendor's usual variable — and a keyed vendor is
+   * never called without one. Cached per vendor and base URL for ten
+   * minutes; `?refresh=1` asks again. Never a throw: a vendor that is down
+   * is a sentence in `error`.
+   */
+  const discoveryCache = deps.discovery?.cache ?? new DiscoveryCache();
+  const modelsRoute = async (id: string, url: URL): Promise<Response> => {
+    const prefix = prefixOf(id);
+    const vendor = vendorFor(prefix);
+    if (vendor === undefined) return fail(404, `unknown provider: ${prefix}`);
+    const env = deps.discovery?.env ?? process.env;
+    let entry: { id: string; baseURL?: string; apiKeyEnv?: string } | undefined;
+    try {
+      const rows = readRegistry(deps.settings.file).providers ?? [];
+      entry = rows.find(e => e.id === id) ?? rows.find(e => prefixOf(e.id) === prefix);
+    } catch {
+      entry = undefined; // a file that does not parse is /settings' problem, not this listing's
+    }
+    const queryBase = url.searchParams.get('baseURL');
+    if (queryBase !== null && !isAllowedBaseURL(queryBase)) return fail(400, BASE_URL_RULE);
+    const baseURL = queryBase ?? entry?.baseURL;
+    // The key, the way the registry resolves it (providers spec §5): the
+    // secret store for the entry's id first, then the entry's variable,
+    // then the vendor's usual one.
+    const keyEnv = entry?.apiKeyEnv ?? vendor.keyEnv;
+    const secretId = entry?.id ?? (id === prefix ? undefined : id);
+    const stored = secretId === undefined ? null : (deps.settings.secrets?.get(secretId) ?? null);
+    const apiKey = stored ?? (keyEnv === undefined ? undefined : env[keyEnv]);
+    const cacheKey = discoveryCache.key(prefix, baseURL);
+    if (url.searchParams.get('refresh') !== '1') {
+      const hit = discoveryCache.get(cacheKey);
+      if (hit !== null) return json(hit);
+    }
+    const result = await discoverModels(vendor, {
+      ...(apiKey === undefined ? {} : { apiKey }),
+      ...(baseURL === undefined ? {} : { baseURL }),
+      ...(deps.discovery?.fetch === undefined ? {} : { fetch: deps.discovery.fetch }),
+    });
+    discoveryCache.set(cacheKey, result);
+    return json(result);
   };
 
   const runProviderTest = async (req: Request): Promise<Response> =>
@@ -970,6 +1023,10 @@ export function createApp(deps: ServerDeps): App {
       }
 
       if (segments.length === 1 && first === 'doctor' && method === 'GET') return doctorRoute();
+
+      if (first === 'providers' && segments.length >= 3 && segments[segments.length - 1] === 'models' && method === 'GET') {
+        return await modelsRoute(decodeURIComponent(segments.slice(1, -1).join('/')), url);
+      }
 
       if (segments.length === 1 && first === 'retro') {
         if (method === 'GET') return await retroStatusRoute();

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -382,6 +382,22 @@ export interface SetupLocation {
 
 /** One row of `GET /setup/providers`. COPIED from `ProviderProbe` in
  * `runtime/src/setup/detect.ts`; a change there is a change here. */
+/** `GET /providers/:id/models` (providers spec §4). COPIED from
+ * `runtime/src/providers/discovery.ts`; a change there is a change here. */
+export interface DiscoveredModel {
+  id: string;
+  contextTokens?: number;
+  /** USD per million tokens, when the vendor says. */
+  pricing?: { prompt: number; completion: number };
+}
+
+export interface DiscoveryResult {
+  models: DiscoveredModel[];
+  source: 'list' | 'curated';
+  /** One sentence when the list could not be had; the picker still types. */
+  error?: string;
+}
+
 export interface SetupProvider {
   id: string;
   vendor: 'Claude' | 'ChatGPT' | 'Ollama';

--- a/runtime/ui/src/settings/ModelCombo.test.tsx
+++ b/runtime/ui/src/settings/ModelCombo.test.tsx
@@ -1,0 +1,47 @@
+import { cleanup, render, screen, userEvent } from '../test/dom';
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { useState } from 'react';
+import type { DiscoveredModel } from '../api/types';
+import { contextLabel, ModelCombo } from './ModelCombo';
+
+function Harness({ models }: { models: DiscoveredModel[] }): JSX.Element {
+  const [value, setValue] = useState('gpt-5.6');
+  return <ModelCombo id="m" label="Model" value={value} models={models} onChange={setValue} />;
+}
+
+afterEach(cleanup);
+
+describe('ModelCombo (providers spec §4)', () => {
+  test('lists the vendor models with their context size as set text; a click fills the field', async () => {
+    render(<Harness models={[{ id: 'gpt-5.6', contextTokens: 400_000 }, { id: 'gpt-5.6-mini', contextTokens: 128_000 }, { id: 'o-something' }]} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Show models' }));
+    const rows = Array.from(document.querySelectorAll('.v2-combo-item-model'), el => el.textContent);
+    expect(rows).toEqual(['gpt-5.6400k', 'gpt-5.6-mini128k', 'o-something']);
+    await userEvent.click(screen.getByText('gpt-5.6-mini'));
+    expect((screen.getByLabelText('Model') as HTMLInputElement).value).toBe('gpt-5.6-mini');
+  });
+
+  test('a model the list does not carry is still typeable', async () => {
+    render(<Harness models={[{ id: 'gpt-5.6' }]} />);
+    const user = userEvent.setup({ document });
+    const input = screen.getByLabelText('Model') as HTMLInputElement;
+    await user.clear(input);
+    await user.type(input, 'gpt-7-preview');
+    expect(input.value).toBe('gpt-7-preview');
+  });
+
+  test('with nothing listed the toggle opens no empty box', async () => {
+    render(<Harness models={[]} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Show models' }));
+    expect(document.querySelector('.v2-combo-pop')).toBeNull();
+  });
+
+  test('contextLabel', () => {
+    expect(contextLabel(1_048_576)).toBe('1M');
+    expect(contextLabel(2_000_000)).toBe('2M');
+    expect(contextLabel(131_072)).toBe('131k');
+    expect(contextLabel(512)).toBe('512');
+    expect(contextLabel(undefined)).toBeNull();
+  });
+});

--- a/runtime/ui/src/settings/ModelCombo.tsx
+++ b/runtime/ui/src/settings/ModelCombo.tsx
@@ -1,0 +1,91 @@
+import { useRef } from 'react';
+import { useButton, useComboBox, useFilter, useListBox, useOption, type AriaListBoxOptions } from 'react-aria';
+import { Item, useComboBoxState, type ComboBoxState } from 'react-stately';
+import type { Node } from '@react-types/shared';
+import type { DiscoveredModel } from '../api/types';
+import { Chevron } from '../v2/icons';
+
+export interface ModelComboProps {
+  id: string;
+  label: string;
+  /** The model part of the id — `gpt-5.6`, `gemma4:e4b`. */
+  value: string;
+  /** What the vendor lists (providers spec §4) — suggestions, never a
+   * constraint: a model the list does not carry yet is still typeable. */
+  models: DiscoveredModel[];
+  placeholder?: string;
+  onChange(value: string): void;
+}
+
+/** `1,048,576` → `1M`; `131072` → `131k`: the context size as set text. */
+export function contextLabel(tokens: number | undefined): string | null {
+  if (tokens === undefined) return null;
+  if (tokens >= 1_000_000) return `${Math.round(tokens / 100_000) / 10}M`;
+  if (tokens >= 1_000) return `${Math.round(tokens / 1_000)}k`;
+  return String(tokens);
+}
+
+/**
+ * The model picker (providers spec §4): the same headless combobox as the
+ * provider picker, over the vendor's own list, each row with its context
+ * size in set text. The typed text is the value; the list is a shortcut.
+ */
+export function ModelCombo({ id, label, value, models, placeholder, onChange }: ModelComboProps): JSX.Element {
+  const { contains } = useFilter({ sensitivity: 'base' });
+  const items = models.map(m => ({ id: m.id, context: contextLabel(m.contextTokens) }));
+  const children = (item: { id: string; context: string | null }): JSX.Element => (
+    <Item textValue={item.id}>
+      <span className="v2-combo-model">{item.id}</span>
+      {item.context === null ? null : <span className="v2-combo-ctx">{item.context}</span>}
+    </Item>
+  );
+  const props = { id, label, inputValue: value, onInputChange: onChange, allowsCustomValue: true, menuTrigger: 'focus' as const, items, children };
+  const state = useComboBoxState({ ...props, defaultFilter: contains });
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const listBoxRef = useRef<HTMLUListElement | null>(null);
+  const popoverRef = useRef<HTMLDivElement | null>(null);
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const { inputProps, listBoxProps, labelProps, buttonProps } = useComboBox({ ...props, inputRef, listBoxRef, popoverRef, buttonRef }, state);
+  const { buttonProps: toggleProps } = useButton(buttonProps, buttonRef);
+
+  return (
+    <>
+      <label {...labelProps}>{label}</label>
+      <div className="v2-combo">
+        <input {...inputProps} ref={inputRef} placeholder={placeholder} />
+        <button {...toggleProps} ref={buttonRef} type="button" className="v2-combo-toggle" aria-label="Show models" aria-labelledby={undefined}>
+          <Chevron />
+        </button>
+        {state.isOpen && items.length > 0 ? (
+          <div className="v2-combo-pop" ref={popoverRef}>
+            <ModelList listBoxProps={listBoxProps} listBoxRef={listBoxRef} state={state} />
+          </div>
+        ) : null}
+      </div>
+    </>
+  );
+}
+
+type Row = { id: string; context: string | null };
+
+function ModelList({ listBoxProps, listBoxRef, state }: { listBoxProps: AriaListBoxOptions<Row>; listBoxRef: React.RefObject<HTMLUListElement>; state: ComboBoxState<Row> }): JSX.Element {
+  const { listBoxProps: props } = useListBox(listBoxProps, state, listBoxRef);
+  return (
+    <ul {...props} ref={listBoxRef} className="v2-combo-list">
+      {[...state.collection].map(item => (
+        <ModelOption key={item.key} item={item} state={state} />
+      ))}
+    </ul>
+  );
+}
+
+function ModelOption({ item, state }: { item: Node<Row>; state: ComboBoxState<Row> }): JSX.Element {
+  const ref = useRef<HTMLLIElement | null>(null);
+  const { optionProps, isFocused } = useOption({ key: item.key }, state, ref);
+  return (
+    <li {...optionProps} ref={ref} className="v2-combo-item v2-combo-item-model" data-focused={isFocused ? true : undefined}>
+      {item.rendered}
+    </li>
+  );
+}

--- a/runtime/ui/src/settings/useModels.ts
+++ b/runtime/ui/src/settings/useModels.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ApiError, fetchJson } from '../api/client';
+import type { DiscoveryResult } from '../api/types';
+
+export interface ModelsState {
+  result: DiscoveryResult | null;
+  loading: boolean;
+  /** Ask the vendor again, past the runtime's ten-minute memory. */
+  refresh(): void;
+}
+
+/** The listing path for a vendor prefix, with the row's base URL when it
+ * has one (a local runner, a preset, a proxy). */
+export function modelsPath(prefix: string, baseURL: string | undefined, refresh = false): string {
+  const q = new URLSearchParams();
+  if (baseURL !== undefined && baseURL.trim() !== '') q.set('baseURL', baseURL.trim());
+  if (refresh) q.set('refresh', '1');
+  const qs = q.toString();
+  return `/providers/${encodeURIComponent(prefix)}/models${qs === '' ? '' : `?${qs}`}`;
+}
+
+/**
+ * `GET /providers/:prefix/models` for a row (providers spec §4). Re-reads
+ * when the prefix or base URL changes; a 401 is the shell's to announce and
+ * is silent here; any other failure becomes the row's sentence.
+ */
+export function useModels(prefix: string | null, baseURL: string | undefined): ModelsState {
+  const [result, setResult] = useState<DiscoveryResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const seq = useRef(0);
+
+  const load = useCallback(
+    (refresh: boolean): void => {
+      if (prefix === null) {
+        setResult(null);
+        return;
+      }
+      const ticket = ++seq.current;
+      setLoading(true);
+      void (async () => {
+        try {
+          const next = await fetchJson<DiscoveryResult>(modelsPath(prefix, baseURL, refresh));
+          if (ticket === seq.current) setResult(next);
+        } catch (err) {
+          if (err instanceof ApiError && err.status === 401) return;
+          if (ticket === seq.current) setResult({ models: [], source: 'list', error: `Could not list models: ${err instanceof Error ? err.message : String(err)}` });
+        } finally {
+          if (ticket === seq.current) setLoading(false);
+        }
+      })();
+    },
+    [prefix, baseURL],
+  );
+
+  useEffect(() => load(false), [load]);
+
+  return { result, loading, refresh: () => load(true) };
+}

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1007,3 +1007,13 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-key-form input { flex: 1 1 24ch; min-width: 0; font: 13px var(--mono); padding: 4px 8px; border: 1px solid var(--border-strong); border-radius: 6px; background: var(--bg-raised); color: var(--fg); }
 .v2-key-where { font-size: 11.5px; flex-basis: 100%; }
 .v2-key-error { margin: 4px 0 0; font-size: 12.5px; color: var(--error); }
+
+/* The model picker (providers spec §4): the model id, then its context size
+   as set text at the right of the row. */
+.v2-combo-item-model { display: flex; align-items: baseline; gap: 10px; }
+.v2-combo-model { flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.v2-combo-ctx { font: 11px var(--sans); color: var(--fg-faint); flex-shrink: 0; }
+.v2-model-note { font-size: 12px; color: var(--fg-faint); margin: 2px 0 0; }
+.v2-model-note.v2-model-note-error { color: var(--error); }
+.v2-model-note .v2-link { margin-left: 6px; }
+.v2-setup-models { margin: 4px 0 8px 2px; max-width: 28rem; }

--- a/runtime/ui/src/v2/SetupPage.test.tsx
+++ b/runtime/ui/src/v2/SetupPage.test.tsx
@@ -240,3 +240,20 @@ describe('SetupPage, the keyed vendors (providers spec §12)', () => {
     expect(models.textContent).toContain('good starting points');
   });
 });
+
+describe('SetupPage, the Ollama row lists its models (providers spec §4)', () => {
+  test('picking the row shows its models in the picker; picking a model changes the provider sent', async () => {
+    await mounted();
+    await waitFor(() => expect(screen.getByRole('radio', { name: /Ollama/ })).toBeTruthy());
+    expect(screen.queryByLabelText('Ollama model')).toBeNull();
+    await userEvent.click(screen.getByRole('radio', { name: /Ollama/ }));
+    await waitFor(() => expect(screen.getByLabelText('Ollama model')).toBeTruthy());
+    expect((screen.getByLabelText('Ollama model') as HTMLInputElement).value).toBe('gemma4:e4b');
+    await userEvent.click(screen.getByRole('button', { name: 'Show models' }));
+    expect(Array.from(document.querySelectorAll('.v2-combo-item-model'), el => el.textContent)).toEqual(['a', 'b', 'c']);
+    await userEvent.click(screen.getByText('b'));
+    // The row keeps reading as selected, with the chosen model.
+    expect(screen.getByRole('radio', { name: /Ollama/ }).textContent).toContain('b · local');
+    expect((screen.getByLabelText('Ollama model') as HTMLInputElement).value).toBe('b');
+  });
+});

--- a/runtime/ui/src/v2/SetupPage.tsx
+++ b/runtime/ui/src/v2/SetupPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import { ModelCombo } from '../settings/ModelCombo';
 import { keyedHints, OPEN_MODELS } from './vendors';
 import { ApiError, fetchJson } from '../api/client';
 import type { SetupLocation, SetupPlanBody, SetupProvider, SetupResponse } from '../api/types';
@@ -347,17 +348,32 @@ export function SetupPage({ onDone }: SetupPageProps): JSX.Element {
             ) : (
               <div role="radiogroup" aria-label="Which model answers">
                 {providers.map(p => {
-                  const on = provider === p.id;
+                  // A row's id is `<prefix>/<model>`; the picked model may
+                  // have replaced the probe's suggestion.
+                  const prefix = p.id.slice(0, p.id.indexOf('/'));
+                  const on = provider !== null && provider.startsWith(`${prefix}/`);
+                  const chosen = on ? provider!.slice(prefix.length + 1) : p.model;
                   const pick = on ? 'selected' : p.usable ? 'use this' : p.installed ? 'sign in' : 'install';
+                  const listed = p.usable && (p.models?.length ?? 0) > 0;
                   return (
-                    <button type="button" key={p.id} role="radio" aria-checked={on} className="v2-setup-prov" disabled={!p.usable} onClick={() => setProvider(p.id)}>
-                      <span className="v2-setup-vendor">{p.vendor}</span>
-                      <span className="v2-setup-model">
-                        {p.model} · {p.connection}
-                      </span>
-                      <span className={p.usable ? 'v2-setup-state v2-setup-state-in' : 'v2-setup-state'}>{p.state}</span>
-                      <span className={on ? 'v2-setup-pick v2-setup-pick-on' : 'v2-setup-pick'}>{pick}</span>
-                    </button>
+                    <div key={p.id}>
+                      <button type="button" role="radio" aria-checked={on} className="v2-setup-prov" disabled={!p.usable} onClick={() => setProvider(on ? provider : p.id)}>
+                        <span className="v2-setup-vendor">{p.vendor}</span>
+                        <span className="v2-setup-model">
+                          {listed ? chosen : p.model} · {p.connection}
+                        </span>
+                        <span className={p.usable ? 'v2-setup-state v2-setup-state-in' : 'v2-setup-state'}>{p.state}</span>
+                        <span className={on ? 'v2-setup-pick v2-setup-pick-on' : 'v2-setup-pick'}>{pick}</span>
+                      </button>
+                      {/* The runner's own models, in the same picker Settings
+                          uses (providers spec §4): pick one and this row is
+                          the answer. */}
+                      {listed && on ? (
+                        <div className="field v2-setup-models">
+                          <ModelCombo id={`v2-setup-${prefix}-model`} label={`${p.vendor} model`} value={chosen} models={(p.models ?? []).map(id => ({ id }))} onChange={model => setProvider(`${prefix}/${model}`)} />
+                        </div>
+                      ) : null}
+                    </div>
                   );
                 })}
               </div>

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -353,3 +353,65 @@ describe('SettingsPage, provider keys (providers spec §5)', () => {
     expect(screen.queryByRole('button', { name: 'paste a key' })).toBeNull();
   });
 });
+
+describe('SettingsPage, the model picker on a provider row (providers spec §4)', () => {
+  const withRow: SettingsView = {
+    ...view,
+    registry: { ...view.registry, providers: [{ id: 'openai/gpt-5.6', apiKeyEnv: 'OPENAI_API_KEY' }] },
+  };
+
+  function installWithModels(answer: (url: string) => Response | null): { listed: string[] } {
+    const listed: string[] = [];
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/settings' && (init?.method ?? 'GET') === 'GET') return json(withRow);
+      if (url === '/content/status') return json({ shippedVersion: '0.0.0', vaultVersion: '0.0.0', receivedAt: null, lawManagement: 'plugin', autoApplyLawUpdates: false, items: [], counts: { current: 0, 'update-available': 0, 'user-modified': 0, 'vault-only': 0, missing: 0, 'upstream-changed': 0 } });
+      if (url.startsWith('/providers/')) {
+        listed.push(url);
+        const r = answer(url);
+        if (r !== null) return r;
+      }
+      throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
+    }) as unknown as typeof fetch;
+    return { listed };
+  }
+
+  test("the row lists the vendor's models with context sizes; a pick rewrites the id; refresh asks again", async () => {
+    const { listed } = installWithModels(() => json({ models: [{ id: 'gpt-5.6', contextTokens: 400000 }, { id: 'gpt-5.6-mini', contextTokens: 128000 }], source: 'list' }));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Model')).toBeTruthy());
+    expect((screen.getByLabelText('Model') as HTMLInputElement).value).toBe('gpt-5.6');
+    await waitFor(() => expect(screen.getByText(/2 models listed/)).toBeTruthy());
+    expect(listed).toEqual(['/providers/openai/models']);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show models' }));
+    await userEvent.click(screen.getByText('gpt-5.6-mini'));
+    expect((screen.getByLabelText('Id') as HTMLInputElement).value).toBe('openai/gpt-5.6-mini');
+
+    await userEvent.click(screen.getByRole('button', { name: 'refresh' }));
+    await waitFor(() => expect(listed).toHaveLength(2));
+    expect(listed[1]).toBe('/providers/openai/models?refresh=1');
+  });
+
+  test('a listing that failed is the runtime\'s sentence under the field, and the id is still typeable', async () => {
+    installWithModels(() => json({ models: [], source: 'list', error: 'No key for OpenAI yet.' }));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByText('No key for OpenAI yet.')).toBeTruthy());
+    const user = userEvent.setup({ document });
+    const model = screen.getByLabelText('Model') as HTMLInputElement;
+    await user.clear(model);
+    await user.type(model, 'gpt-7');
+    expect((screen.getByLabelText('Id') as HTMLInputElement).value).toBe('openai/gpt-7');
+  });
+
+  test('a local runner row lists from its base URL', async () => {
+    const { listed } = installWithModels(() => json({ models: [{ id: 'qwen3:32b' }], source: 'list' }));
+    const local: SettingsView = { ...view, registry: { ...view.registry, providers: [{ id: 'lmstudio/qwen3:32b', baseURL: 'http://127.0.0.1:1234/v1' }] } };
+    globalThis.fetch = ((orig: typeof fetch) => (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/settings' && (init?.method ?? 'GET') === 'GET') return json(local);
+      return orig(input, init);
+    }) as unknown as typeof fetch)(globalThis.fetch);
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(listed).toEqual(['/providers/lmstudio/models?baseURL=http%3A%2F%2F127.0.0.1%3A1234%2Fv1']));
+  });
+});

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -2,7 +2,9 @@ import { useEffect, useState } from 'react';
 import { ApiError, fetchJson } from '../../api/client';
 import type { Health as HealthData, SettingsErrorBody, SettingsView } from '../../api/types';
 import { Health } from '../../settings/Health';
+import { ModelCombo } from '../../settings/ModelCombo';
 import { ProviderCombo } from '../../settings/ProviderCombo';
+import { useModels } from '../../settings/useModels';
 import { ProviderTest } from '../../settings/ProviderTest';
 import { addableVendors, dataLineFor, pickerLabel, prefixOf, vendorByPickerLabel, vendorFor } from '../vendors';
 import { KeyControl } from './KeyControl';
@@ -227,6 +229,7 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
                 <input id={`v2-${row.key}-id`} value={row.id} placeholder="openai/gpt-5.6" onChange={e => patchRow(index, { id: e.target.value })} />
                 <FieldError message={errors[`providers.${index}.id`]} />
               </div>
+              <ModelField rowKey={row.key} id={row.id} baseURL={row.baseURL} onPick={model => patchRow(index, { id: `${prefixOf(row.id.trim())}/${model}` })} />
               <div className="field">
                 <label htmlFor={`v2-${row.key}-baseurl`}>baseURL</label>
                 <input id={`v2-${row.key}-baseurl`} value={row.baseURL} placeholder="https://…" onChange={e => patchRow(index, { baseURL: e.target.value })} />
@@ -566,6 +569,43 @@ function TriField({ id, label, value, error, onChange }: { id: string; label: st
         ))}
       </select>
       <FieldError message={error} />
+    </div>
+  );
+}
+
+/**
+ * The row's Model picker (providers spec §4): the vendor's own list for the
+ * id's prefix, the row's base URL considered (a local runner lists from
+ * there), a custom id still typeable, the runtime's sentence under the
+ * field when the list could not be had, and "refresh" as a quiet link.
+ * Nothing shows until the id names a vendor that has models to list.
+ */
+function ModelField({ rowKey, id, baseURL, onPick }: { rowKey: string; id: string; baseURL: string; onPick(model: string): void }): JSX.Element | null {
+  const trimmed = id.trim();
+  const prefix = trimmed === '' ? null : prefixOf(trimmed);
+  const vendor = prefix === null ? undefined : vendorFor(prefix);
+  const listable = vendor !== undefined && vendor.group !== 'subscription';
+  const { result, loading, refresh } = useModels(listable ? prefix : null, baseURL.trim() === '' ? undefined : baseURL);
+  if (!listable || prefix === null) return null;
+  const model = trimmed.slice(prefix.length + 1);
+  return (
+    <div className="field v2-model-field">
+      <ModelCombo id={`v2-${rowKey}-model`} label="Model" value={model} models={result?.models ?? []} placeholder={loading ? 'listing…' : 'pick or type a model'} onChange={onPick} />
+      {result === null ? null : result.error !== undefined ? (
+        <p className="v2-model-note v2-model-note-error" role="status">
+          {result.error}
+          <button type="button" className="v2-link" onClick={refresh}>
+            refresh
+          </button>
+        </p>
+      ) : (
+        <p className="v2-model-note" role="note">
+          {result.models.length} model{result.models.length === 1 ? '' : 's'} {result.source === 'curated' ? 'known' : 'listed'}
+          <button type="button" className="v2-link" onClick={refresh}>
+            refresh
+          </button>
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Providers spec §4 (step 3). Branched from `providers-catalog` (#63): its commits show here until it merges; the pair rebases after.

**Runtime**
- `runtime/src/providers/discovery.ts`: one lister per response shape — OpenAI-style `/models` (OpenAI, Mistral, Groq, DeepSeek, Fireworks, Cerebras, every OpenAI-compatible preset and local runner), Google `models.list` (generateContent-capable, `inputTokenLimit`), OpenRouter (`context_length` + prices per million, kept for the scoreboard), Ollama `/api/tags`, Cohere (`?endpoint=chat`, `context_length`), Together (bare array, chat/language). 3-second timeout; every failure is `Could not list models: <reason>.`; a keyed vendor is never called without a key (`No key for <Vendor> yet.`).
- The catalog records carry a `discovery` descriptor; curated lists for Anthropic, xAI, Perplexity, DeepInfra (no listing endpoint documented).
- `GET /providers/:id/models` (prefix or full id, slashes allowed), key from the registry entry's `apiKeyEnv` else the vendor's variable, `?baseURL=` under the base-URL rule, ten-minute cache per vendor+baseURL, `?refresh=1`.

**UI**
- `ModelCombo` (react-aria, same markup as the provider picker) with the context size as set text per row; on every Settings provider row beside Id (a pick rewrites the id; the runtime's sentence + `refresh` under it; a local runner lists from the row's base URL); on the first-run Ollama row when it is usable.

**Verified against docs:** Together, Cerebras, Cohere, Google, Groq, DeepSeek. **Unverified:** Fireworks' OpenAI-compatible `/inference/v1/models` (their documented listing is the control-plane API with an account id) — marked `unverified` on the record; a failure there is the sentence.

**Tests:** `bun run test` 984 · `bun run ui:test` 509 · typechecks clean · `ui:build` ok. No network in tests (recorded fixtures through an injected fetch; the route tests run with an empty environment so a developer's own key never turns into a real request).