### PR TITLE
Routing and evals, step 1: task taxonomy, classification, and the outcomes record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Counsel OS are documented in this file. The format follow
 reconstructed from git history. New entries are prepended automatically by
 `scripts/release.sh`.
 
+## [Unreleased]
+
+Routing and evals, step 1 — every step has a task, and the vault keeps what you did with the answer (routing-and-evals spec §3, §7)
+
+- A closed legal task taxonomy — `review`, `redline`, `draft`, `research`, `extract`, `summarize`, `compare`, `remember`, `docket`, `retro`, `chat` — and where a step's task came from: named on the request, set on the conversation, a rule over the message and its attachments, an optional model call (`classify: model` in `config.md`, off by default), else `chat`. The task and its source sit on the step event and the run record; the turn's record shows `task · by rule · change`, and the picker corrects it (`PATCH /threads/:id/steps/:runId/task`).
+- The outcomes record: `.counsel/outcomes.jsonl`, one line per thing you did — a proposal approved or rejected (with an optional reason from the slip's new *add a reason*), an answer marked *useful* or *not right* (two words under the turn's strip; `POST /threads/:id/turns/:runId/mark`), a task corrected, a document produced by a redline or a compare, a conversation deleted. Local only, never sent to a model. `GET /outcomes?since=` reads it; `outcomes: off` in `config.md` (or Settings → Runtime → *Decisions and marks* → `turn off`, which writes it) stops every write; `/health` reports the switch.
+- The retro's evidence gains a *Decisions and marks* section with the period's counts.
+- Settings: a task route's Task field offers the taxonomy (a custom name still goes through).
+
 ## [0.13.0] — 2026-09-02
 
 Providers phase 1, retro, the binary — any model, keys in the Keychain, matters that stay local

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -51,6 +51,8 @@ matters_path: matters
 auto_apply_law_updates: false
 law_management: plugin
 default_locality: any
+outcomes: on
+classify: rules
 entity_properties:
   type_field: counsel-os-type
   values: [counterparty, vendor, customer, prospect, matter]
@@ -75,6 +77,26 @@ decided before the first model call — from the conversation's linked matter,
 else a matter document attached to the message, else this default — and is
 never downgraded silently: with no local model loaded the step does not run
 and the app says so.
+
+`outcomes: off` stops the vault's own record of what you did with counsel's
+work. By default the runtime appends one line per event to
+`.counsel/outcomes.jsonl` — a proposal approved or rejected (with the reason
+you gave, if any), an answer marked *useful* or *not right*, a step's task
+corrected, a document produced, a conversation deleted. The record never leaves
+this machine and is never sent to a model; the retro reads it, and the
+scoreboard will. The switch is also in Settings → Runtime (*Decisions and
+marks*), which writes this line for you.
+
+`classify: model` lets the runtime spend one small structured model call on a
+message that no rule can name — "so where does this leave us?" — to decide
+which kind of work it is (`review`, `redline`, `draft`, `research`, `extract`,
+`summarize`, `compare`, `remember`, `docket`, `retro`, else `chat`). The call
+goes to the smallest local model when one is loaded, else the default
+provider; it sees the one message and nothing else, and times out after ten
+seconds into `chat`. The default, `rules`, classifies by the words in the
+message alone and costs nothing. A task named on the request, or set on the
+conversation, always wins; the record shows where each step's task came from
+and lets you correct it.
 
 ## Documents in matters
 

--- a/docs/superpowers/plans/2026-09-02-routing-1.md
+++ b/docs/superpowers/plans/2026-09-02-routing-1.md
@@ -1,0 +1,30 @@
+# Routing and evals, step 1 — implementation plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:test-driven-development. Steps use checkbox (`- [x]`) syntax.
+
+**Goal:** every step carries a task from a closed legal taxonomy (from the caller, the thread, a rule, or one small model call), and the runtime keeps a local, append-only record of what the lawyer did with counsel's work — decisions, marks, task corrections, documents produced, deletions — switchable in `config.md`.
+
+**Architecture:** `runtime/src/tasks/` (taxonomy + classifier, pure with an injectable model classifier); `runtime/src/outcomes/store.ts` (append-only JSONL under `.counsel/`, gated by `VaultConfig.outcomes`); the loop stamps `task` + `taskSource` on the step event and the run record; routes record decisions, marks, corrections and deletions; retro evidence counts them; the UI shows the task with a picker, the two marks, a reject reason, a task picker on routes, and the Runtime switch.
+
+**Tech stack:** Bun/TypeScript runtime, React UI, bun test + happy-dom.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-routing-and-evals-design.md` §3, §7, §11 step 1, §12.
+
+## Global constraints
+- The closed set is the only vocabulary; a custom task route name is still allowed in Settings (spec §3 keeps route shape).
+- DECIDED while building: the model classifier is OPT-IN (`classify: model` in config.md; default rules-only). Wired always, it consumed a scripted fake-provider turn in every route/serve test and would spend a metered turn before every chat message unasked.
+- Rules run in the loop always; the MODEL classifier is an injected dependency (`deps.classifier`), wired by serve — the loop's tests never spend a fake-provider script step on it.
+- Nothing in the outcomes record leaves the machine; `outcomes: off` in config.md stops every write.
+- No pills, no modals: set-text links and the existing menu/combobox primitives.
+
+## Tasks
+1. [x] `tasks/taxonomy.ts` — `TASKS`, `TASK_IDS`, `isTask`, default scorer per task — test.
+2. [x] `tasks/classify.ts` — `classifyByRules`, `classifyTask` (caller > thread > rules > model > `chat`), `modelClassifier(providers, router)` with a 10 s timeout — tests with a fake provider.
+3. [x] `VaultConfig.outcomes` (`outcomes: off`) + `writeVaultConfigOverride` — tests.
+4. [x] `outcomes/store.ts` — `appendOutcome`, `readOutcomes`, kinds — tests (append, switch off, since filter).
+5. [x] Loop: classification + `taskSource` on the step event / run record; `thread.outcome` hook for artifacts — tests.
+6. [x] Store: `taskSource` on the step event; `updateStep` — test.
+7. [x] Routes: reason on approve; `proposal.decided`, `thread.deleted`; `POST /threads/:id/turns/:runId/mark`; `PATCH /threads/:id/steps/:runId/task`; `GET /outcomes?since=`; `PATCH /settings/vault`; `outcomes` on `/health` — tests.
+8. [x] Retro evidence: outcome counts in the evidence and the rendered section — test.
+9. [x] UI: types + client; Strip task line with picker and the two marks; ProposalCard reject reason; Settings task-route picker; Runtime switch — tests.
+10. [x] CONFIGURATION.md, CHANGELOG.

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -1661,3 +1661,53 @@ describe('the matter privacy policy (providers spec §7)', () => {
     expect((log.find(e => 't' in e && e.t === 'step') as { provider: string }).provider).toBe('ollama/local');
   });
 });
+
+describe('the task on a step (routing-and-evals spec §3)', () => {
+  test('a rule names the task when the caller does not, and the source is stamped on the event and the record', async () => {
+    const fake = new FakeModelProvider([{ text: 'marked up' }]);
+    const { id } = await store.create('default', {});
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'Redline this for us.' }));
+    const runId = events[0]!.runId;
+
+    const { events: log } = await store.get('default', id);
+    const stepEv = log.find((e): e is Extract<ThreadEvent, { t: 'step' }> => 't' in e && e.t === 'step')!;
+    expect(stepEv.task).toBe('redline');
+    expect(stepEv.taskSource).toBe('rule');
+    const record = readRun(vaultRoot, 'default', runId)!;
+    expect(record.task).toBe('redline');
+    expect(record.taskSource).toBe('rule');
+  });
+
+  test("the caller's task is kept as given (a custom route name too) and is never re-classified", async () => {
+    const fake = new FakeModelProvider([{ text: 'ok' }]);
+    let asked = 0;
+    const classifier = async (): Promise<'research'> => {
+      asked += 1;
+      return 'research';
+    };
+    const { id } = await store.create('default', {});
+    const events = await collect(runStep({ ...deps([fake]), classifier }, { threadId: id, message: 'redline this', task: 'classify' }));
+    const record = readRun(vaultRoot, 'default', events[0]!.runId)!;
+    expect(record.task).toBe('classify');
+    expect(record.taskSource).toBe('caller');
+    expect(asked).toBe(0);
+  });
+
+  test('no rule → the injected classifier decides, and its failure leaves a chat step', async () => {
+    const fake = new FakeModelProvider([{ text: 'one' }, { text: 'two' }]);
+    const answers: Array<'research' | null> = ['research', null];
+    const classifier = async (): Promise<'research' | null> => {
+      const next = answers.shift();
+      if (next === undefined) throw new Error('classifier down');
+      return next;
+    };
+    const { id } = await store.create('default', {});
+    const first = await collect(runStep({ ...deps([fake]), classifier }, { threadId: id, message: 'hmm, what about Delaware' }));
+    expect(readRun(vaultRoot, 'default', first[0]!.runId)).toMatchObject({ task: 'research', taskSource: 'model' });
+
+    const second = await collect(runStep({ ...deps([fake]), classifier }, { threadId: id, message: 'and then?' }));
+    expect(readRun(vaultRoot, 'default', second[0]!.runId)).toMatchObject({ task: 'chat', taskSource: 'default' });
+    // The provider saw both turns: the classifier never spent a script step.
+    expect(fake.lastRequest!.messages.filter(m => m.role === 'user')).toHaveLength(2);
+  });
+});

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -19,6 +19,9 @@ import { proposeUpdateTool } from './proposals';
 import { writeRunLog, type RunLogEntry, type ToolCallLog } from './run-log';
 import { finishRun, startRun, type RunPatch, type RunRecord } from './run-record';
 import { RETRO_TASK, retroSections } from '../retro/index';
+import { classifyTask, type ModelClassifier } from '../tasks/classify';
+import type { TaskSource } from '../tasks/taxonomy';
+import { appendOutcome } from '../outcomes/store';
 
 /**
  * Headroom left in the context window for the model's own reply and for the
@@ -66,6 +69,10 @@ export interface CounselLoopDeps {
   platform?: Platform;
   /** The per-step deadline, in milliseconds. Default `DEFAULT_STEP_TIMEOUT_MS`. */
   stepTimeoutMs?: number;
+  /** The model-backed task classifier (routing-and-evals spec §3), used only
+   * when neither the caller nor the thread named a task and no rule fired.
+   * Absent → rules then `chat`; serve wires `modelClassifier`. */
+  classifier?: ModelClassifier;
 }
 
 export interface RunStepOptions {
@@ -207,7 +214,12 @@ export async function* runStep(
     yield { type: 'error', message: `unknown thread: ${threadId}`, runId };
     return;
   }
-  if (opts.task === undefined && early.task !== undefined) opts = { ...opts, task: early.task };
+  // The task and where it came from (spec §3): caller, thread, rule, one
+  // small model call, else `chat`. Decided before the run opens so the
+  // record and the step event carry the same answer.
+  const classified = await classifyTask({ message: opts.message, callerTask: opts.task, threadTask: early.task }, deps.classifier);
+  const taskSource: TaskSource = classified.source;
+  opts = { ...opts, task: classified.task };
   // The matter's privacy policy, from the header and the message — before
   // the run opens, before the user turn is appended, before any provider is
   // looked at (providers spec §7).
@@ -217,7 +229,7 @@ export async function* runStep(
   // everything that follows is visible to `/runs` while it is happening and
   // after it dies (spec §4.3). The unknown-thread return above is the one
   // exception: there was no run to record.
-  beginRun(deps, opts, runId, new Date(startedAt).toISOString());
+  beginRun(deps, opts, runId, new Date(startedAt).toISOString(), taskSource);
   // Tracks whether the record has reached a terminal status yet, so the
   // `finally` below can tell "the step ended" from "the caller walked away".
   const run: RunState = {
@@ -284,7 +296,7 @@ export async function* runStep(
         at: nowIso(),
         runId,
         provider: provider.id,
-        ...(opts.task ? { task: opts.task } : {}),
+        ...(opts.task ? { task: opts.task, taskSource } : {}),
       }),
     );
     if (stepFailed) {
@@ -307,7 +319,18 @@ export async function* runStep(
         vaultRoot: deps.vaultRoot,
         repoRoot: deps.pluginRoot,
         vault: deps.vault,
-        thread: { store: deps.store, threadId, tenant },
+        thread: {
+          store: deps.store,
+          threadId,
+          tenant,
+          outcome: line => {
+            try {
+              appendOutcome(deps.vaultRoot, cfg, { ...line, threadId, runId, ...(opts.task ? { task: opts.task } : {}), providerId: provider.id });
+            } catch (err) {
+              console.error(`counsel-loop: outcome write failed for ${runId}: ${message(err)}`);
+            }
+          },
+        },
       })) registry.register(t);
       const scriptTools = registry.available(platform);
 
@@ -1084,7 +1107,7 @@ function rememberPrimitive(into: string[], ev: Extract<StepEvent, { type: 'tool_
  * that dies choosing one still leaves the request behind (spec §4.3).
  * Failures go to stderr, never out of the loop: the record is telemetry.
  */
-function beginRun(deps: CounselLoopDeps, opts: RunStepOptions, runId: string, startedAt: string): void {
+function beginRun(deps: CounselLoopDeps, opts: RunStepOptions, runId: string, startedAt: string, taskSource?: TaskSource): void {
   const rec: RunRecord = {
     runId,
     threadId: opts.threadId,
@@ -1096,6 +1119,7 @@ function beginRun(deps: CounselLoopDeps, opts: RunStepOptions, runId: string, st
     // router (or the caller's `providerId`) names one.
     provider: '',
     ...(opts.task ? { task: opts.task } : {}),
+    ...(taskSource === undefined ? {} : { taskSource }),
     primitivesRead: [],
     toolCalls: [],
     proposals: [],

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -214,16 +214,18 @@ export async function* runStep(
     yield { type: 'error', message: `unknown thread: ${threadId}`, runId };
     return;
   }
-  // The task and where it came from (spec §3): caller, thread, rule, one
-  // small model call, else `chat`. Decided before the run opens so the
-  // record and the step event carry the same answer.
-  const classified = await classifyTask({ message: opts.message, callerTask: opts.task, threadTask: early.task }, deps.classifier);
-  const taskSource: TaskSource = classified.source;
-  opts = { ...opts, task: classified.task };
   // The matter's privacy policy, from the header and the message — before
   // the run opens, before the user turn is appended, before any provider is
-  // looked at (providers spec §7).
+  // looked at (providers spec §7) — and before the task classifier, which
+  // may itself call a model.
   const policy = await policyForOptions(deps, { ...(early.matter === undefined ? {} : { matter: early.matter }), message: opts.message });
+  // The task and where it came from (spec §3): caller, thread, rule, one
+  // small model call (local only under the policy), else `chat`. Decided
+  // before the run opens so the record and the step event carry the same
+  // answer.
+  const classified = await classifyTask({ message: opts.message, callerTask: opts.task, threadTask: early.task }, deps.classifier, { localOnly: policy.localOnly });
+  const taskSource: TaskSource = classified.source;
+  opts = { ...opts, task: classified.task };
 
   // The run record opens here — before the provider is even chosen — so
   // everything that follows is visible to `/runs` while it is happening and

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -32,6 +32,13 @@ export interface RunRecord {
   /** Empty until the router (or the caller's `providerId`) resolves one. */
   provider: string;
   task?: string;
+  /** Where the task came from (routing-and-evals spec §3): the caller, the
+   * thread, a rule, a model guess, the `chat` default, or a later
+   * correction by the lawyer. */
+  taskSource?: 'caller' | 'rule' | 'model' | 'default' | 'corrected';
+  /** The lawyer's mark on this answer (spec §7), kept here so the strip can
+   * show it on reload; the outcomes record has the full line. */
+  mark?: { mark: 'useful' | 'not-right'; reason?: string; at: string };
   /** Unique `read_primitive` names, in the order the step first read them. */
   primitivesRead: string[];
   toolCalls: ToolCallLog[];

--- a/runtime/src/outcomes/store.test.ts
+++ b/runtime/src/outcomes/store.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { appendOutcome, countOutcomes, outcomesEnabled, outcomesPath, readOutcomes } from './store';
+
+function root(): string {
+  return mkdtempSync(join(tmpdir(), 'outcomes-'));
+}
+
+describe('the outcomes record (routing-and-evals spec §7)', () => {
+  test('append writes one JSON line under .counsel, owner-only, stamped now when no `at` is given', () => {
+    const r = root();
+    expect(appendOutcome(r, {}, { kind: 'answer.marked', threadId: 't1', runId: 'r1', detail: { mark: 'useful' } })).toBe(true);
+    expect(appendOutcome(r, {}, { kind: 'thread.deleted', threadId: 't2', at: '2026-08-01T00:00:00.000Z', detail: {} })).toBe(true);
+    const lines = readFileSync(outcomesPath(r), 'utf8').trimEnd().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]!) as { at: string; kind: string; detail: { mark: string } };
+    expect(first.kind).toBe('answer.marked');
+    expect(Number.isNaN(Date.parse(first.at))).toBe(false);
+    expect(first.detail.mark).toBe('useful');
+    expect((JSON.parse(lines[1]!) as { at: string }).at).toBe('2026-08-01T00:00:00.000Z');
+    if (process.platform !== 'win32') {
+      expect(statSync(outcomesPath(r)).mode & 0o777).toBe(0o600);
+      expect(statSync(join(r, '.counsel')).mode & 0o777).toBe(0o700);
+    }
+  });
+
+  test('`outcomes: off` stops every write; absent means on', () => {
+    const r = root();
+    expect(outcomesEnabled({})).toBe(true);
+    expect(outcomesEnabled({ outcomes: false })).toBe(false);
+    expect(appendOutcome(r, { outcomes: false }, { kind: 'thread.deleted', detail: {} })).toBe(false);
+    expect(existsSync(outcomesPath(r))).toBe(false);
+  });
+
+  test('read returns oldest first, filters by since and kind, and skips a corrupt line', () => {
+    const r = root();
+    appendOutcome(r, {}, { kind: 'proposal.decided', at: '2026-07-01T00:00:00.000Z', detail: { decision: 'approved' } });
+    appendOutcome(r, {}, { kind: 'answer.marked', at: '2026-08-01T00:00:00.000Z', detail: { mark: 'not-right' } });
+    writeFileSync(outcomesPath(r), `${readFileSync(outcomesPath(r), 'utf8')}{not json\n`, 'utf8');
+    appendOutcome(r, {}, { kind: 'proposal.decided', at: '2026-09-01T00:00:00.000Z', detail: { decision: 'rejected', reason: 'too broad' } });
+
+    expect(readOutcomes(r).map(l => l.at)).toEqual(['2026-07-01T00:00:00.000Z', '2026-08-01T00:00:00.000Z', '2026-09-01T00:00:00.000Z']);
+    expect(readOutcomes(r, { since: '2026-07-15T00:00:00.000Z' })).toHaveLength(2);
+    expect(readOutcomes(r, { kind: 'proposal.decided' })).toHaveLength(2);
+    expect(readOutcomes(root())).toEqual([]);
+  });
+
+  test('countOutcomes tallies decisions, reasons, marks, corrections, documents and deletions', () => {
+    const counts = countOutcomes([
+      { at: 'a', kind: 'proposal.decided', detail: { decision: 'approved' } },
+      { at: 'a', kind: 'proposal.decided', detail: { decision: 'rejected', reason: 'no' } },
+      { at: 'a', kind: 'answer.marked', detail: { mark: 'useful' } },
+      { at: 'a', kind: 'answer.marked', detail: { mark: 'not-right' } },
+      { at: 'a', kind: 'answer.marked', detail: { mark: 'not-right' } },
+      { at: 'a', kind: 'task.corrected', detail: { from: 'chat', to: 'review' } },
+      { at: 'a', kind: 'artifact.produced', detail: {} },
+      { at: 'a', kind: 'thread.deleted', detail: {} },
+    ]);
+    expect(counts).toEqual({ decisions: { approved: 1, rejected: 1, withReason: 1 }, marks: { useful: 1, notRight: 2 }, corrections: 1, documents: 1, deletedThreads: 1 });
+  });
+});

--- a/runtime/src/outcomes/store.ts
+++ b/runtime/src/outcomes/store.ts
@@ -1,0 +1,102 @@
+/**
+ * The outcomes record (routing-and-evals spec §7): what the lawyer did with
+ * counsel's work, one JSON line each, appended under the vault's own
+ * `.counsel/` and never sent anywhere. Retro reads it; the scoreboard
+ * (step 3) will. `outcomes: off` in `config.md` stops every write — the
+ * switch is read on each append, so flipping it needs no restart.
+ *
+ * `node:fs` rather than `VaultStore`, which refuses `.counsel/` so no
+ * model-reachable tool can touch the runtime's bookkeeping.
+ */
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { VaultConfig } from '../vault/resolve-root';
+
+export type OutcomeKind =
+  | 'proposal.decided'
+  | 'artifact.produced'
+  | 'answer.marked'
+  | 'task.corrected'
+  | 'thread.deleted';
+
+export interface OutcomeLine {
+  at: string;
+  kind: OutcomeKind;
+  threadId?: string;
+  runId?: string;
+  task?: string;
+  providerId?: string;
+  matter?: string;
+  path?: string;
+  detail: Record<string, unknown>;
+}
+
+export function outcomesPath(vaultRoot: string): string {
+  return join(vaultRoot, '.counsel', 'outcomes.jsonl');
+}
+
+/** Whether the vault keeps the record. Absent → on (spec §7). */
+export function outcomesEnabled(cfg: Pick<VaultConfig, 'outcomes'>): boolean {
+  return cfg.outcomes !== false;
+}
+
+/**
+ * Appends one line, or nothing when the vault switched the record off.
+ * Returns whether a line was written. Failures are the caller's to swallow:
+ * the record is telemetry and must never fail a step.
+ */
+export function appendOutcome(vaultRoot: string, cfg: Pick<VaultConfig, 'outcomes'>, line: Omit<OutcomeLine, 'at'> & { at?: string }): boolean {
+  if (!outcomesEnabled(cfg)) return false;
+  const path = outcomesPath(vaultRoot);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const full: OutcomeLine = { at: line.at ?? new Date().toISOString(), ...line } as OutcomeLine;
+  appendFileSync(path, `${JSON.stringify(full)}\n`, { encoding: 'utf8', mode: 0o600 });
+  return true;
+}
+
+/** Every line, oldest first; a corrupt line is skipped, never fatal. */
+export function readOutcomes(vaultRoot: string, opts: { since?: string | null; kind?: OutcomeKind } = {}): OutcomeLine[] {
+  const path = outcomesPath(vaultRoot);
+  if (!existsSync(path)) return [];
+  const sinceMs = opts.since === undefined || opts.since === null ? 0 : Date.parse(opts.since);
+  const out: OutcomeLine[] = [];
+  for (const raw of readFileSync(path, 'utf8').split('\n')) {
+    if (raw.trim() === '') continue;
+    let line: OutcomeLine;
+    try {
+      line = JSON.parse(raw) as OutcomeLine;
+    } catch {
+      continue;
+    }
+    if (typeof line.at !== 'string' || typeof line.kind !== 'string') continue;
+    if (sinceMs > 0 && Date.parse(line.at) < sinceMs) continue;
+    if (opts.kind !== undefined && line.kind !== opts.kind) continue;
+    out.push(line);
+  }
+  return out;
+}
+
+export interface OutcomeCounts {
+  decisions: { approved: number; rejected: number; withReason: number };
+  marks: { useful: number; notRight: number };
+  corrections: number;
+  documents: number;
+  deletedThreads: number;
+}
+
+export function countOutcomes(lines: OutcomeLine[]): OutcomeCounts {
+  const c: OutcomeCounts = { decisions: { approved: 0, rejected: 0, withReason: 0 }, marks: { useful: 0, notRight: 0 }, corrections: 0, documents: 0, deletedThreads: 0 };
+  for (const l of lines) {
+    if (l.kind === 'proposal.decided') {
+      if (l.detail['decision'] === 'approved') c.decisions.approved += 1;
+      else if (l.detail['decision'] === 'rejected') c.decisions.rejected += 1;
+      if (typeof l.detail['reason'] === 'string' && l.detail['reason'] !== '') c.decisions.withReason += 1;
+    } else if (l.kind === 'answer.marked') {
+      if (l.detail['mark'] === 'useful') c.marks.useful += 1;
+      else if (l.detail['mark'] === 'not-right') c.marks.notRight += 1;
+    } else if (l.kind === 'task.corrected') c.corrections += 1;
+    else if (l.kind === 'artifact.produced') c.documents += 1;
+    else if (l.kind === 'thread.deleted') c.deletedThreads += 1;
+  }
+  return c;
+}

--- a/runtime/src/retro/__snapshots__/evidence.test.ts.snap
+++ b/runtime/src/retro/__snapshots__/evidence.test.ts.snap
@@ -30,6 +30,10 @@ exports[`gatherRetroEvidence renders the period as plain facts for the system pr
 - 1 documents (docx-redline 1); 5 edits applied, 1 skipped, 3 comments.
   - matters/acme/acme-nda-redline-2026-08-10.docx
 
+### Decisions and marks
+- Proposals decided: 0 approved, 0 rejected (0 with a reason).
+- Answers marked: 0 useful, 0 not right; 0 task corrections; 0 conversations deleted.
+
 ### Matters
 - 1 of 2 matters touched in the period:
   - matters/acme-nda.md — Acme — NDA · working · updated 2026-08-10

--- a/runtime/src/retro/evidence.test.ts
+++ b/runtime/src/retro/evidence.test.ts
@@ -8,6 +8,7 @@ import { ThreadStore } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
 import { readVaultConfig } from '../vault/resolve-root';
 import { gatherRetroEvidence, renderRetroEvidence } from './evidence';
+import { appendOutcome } from '../outcomes/store';
 
 const NOW = new Date('2026-09-01T12:00:00.000Z');
 const SINCE = '2026-07-01T00:00:00.000Z';
@@ -128,5 +129,28 @@ describe('gatherRetroEvidence', () => {
     const { vaultRoot, store, vault } = await seed();
     const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW, doctor: () => doctor });
     expect(renderRetroEvidence(e)).toMatchSnapshot();
+  });
+});
+
+describe('gatherRetroEvidence outcomes (routing-and-evals spec §7)', () => {
+  test('counts the period\'s decisions, marks, corrections and deletions, and renders them', async () => {
+    const { vaultRoot, store, vault } = await seed();
+    appendOutcome(vaultRoot, {}, { kind: 'proposal.decided', at: '2026-08-12T00:00:00.000Z', detail: { decision: 'approved' } });
+    appendOutcome(vaultRoot, {}, { kind: 'proposal.decided', at: '2026-08-12T00:00:00.000Z', detail: { decision: 'rejected', reason: 'too broad' } });
+    appendOutcome(vaultRoot, {}, { kind: 'answer.marked', at: '2026-08-13T00:00:00.000Z', detail: { mark: 'useful' } });
+    appendOutcome(vaultRoot, {}, { kind: 'task.corrected', at: '2026-08-13T00:00:00.000Z', detail: { from: 'chat', to: 'review' } });
+    appendOutcome(vaultRoot, {}, { kind: 'thread.deleted', at: '2026-08-14T00:00:00.000Z', detail: {} });
+    // Before the period: not counted.
+    appendOutcome(vaultRoot, {}, { kind: 'answer.marked', at: '2026-05-01T00:00:00.000Z', detail: { mark: 'not-right' } });
+
+    const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW });
+    expect(e.outcomes).toEqual({ decisions: { approved: 1, rejected: 1, withReason: 1 }, marks: { useful: 1, notRight: 0 }, corrections: 1, documents: 0, deletedThreads: 1 });
+    const text = renderRetroEvidence(e);
+    expect(text).toContain('### Decisions and marks');
+    expect(text).toContain('1 approved, 1 rejected (1 with a reason)');
+    expect(text).toContain('1 useful, 0 not right; 1 task corrections; 1 conversations deleted');
+
+    const all = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: null, now: NOW });
+    expect(all.outcomes.marks.notRight).toBe(1);
   });
 });

--- a/runtime/src/retro/evidence.ts
+++ b/runtime/src/retro/evidence.ts
@@ -6,6 +6,7 @@ import { listAllRuns, type RunRecord } from '../loop/run-record';
 import type { ThreadEvent, ThreadHeader, ThreadStore } from '../threads/store';
 import { vaultOverview, type MatterOverview } from '../vault/overview';
 import type { VaultConfig } from '../vault/resolve-root';
+import { countOutcomes, readOutcomes, type OutcomeCounts } from '../outcomes/store';
 
 /**
  * What the runtime knows about the period, gathered for the retro's system
@@ -64,6 +65,8 @@ export interface RetroEvidence {
     patternsEntries: number | null;
     previousRetros: string[];
   };
+  /** What the lawyer did with counsel's work in the period (spec §7). */
+  outcomes: OutcomeCounts;
   doctor: DoctorReport | null;
 }
 
@@ -180,6 +183,7 @@ export async function gatherRetroEvidence(deps: RetroEvidenceDeps): Promise<Retr
     runs,
     proposals,
     artifacts,
+    outcomes: countOutcomes(readOutcomes(deps.vaultRoot, { since }).filter(l => inPeriod(l.at, since, to))),
     matters,
     memory: readMemory(deps.vaultRoot),
     doctor: deps.doctor === undefined ? null : deps.doctor(),
@@ -257,6 +261,10 @@ export function renderRetroEvidence(e: RetroEvidence): string {
   lines.push('### Documents produced');
   lines.push(`- ${e.artifacts.count} documents (${counts(e.artifacts.byKind)}); ${e.artifacts.applied} edits applied, ${e.artifacts.skipped} skipped, ${e.artifacts.comments} comments.`);
   for (const p of e.artifacts.paths) lines.push(`  - ${p}`);
+  lines.push('');
+  lines.push('### Decisions and marks');
+  lines.push(`- Proposals decided: ${e.outcomes.decisions.approved} approved, ${e.outcomes.decisions.rejected} rejected (${e.outcomes.decisions.withReason} with a reason).`);
+  lines.push(`- Answers marked: ${e.outcomes.marks.useful} useful, ${e.outcomes.marks.notRight} not right; ${e.outcomes.corrections} task corrections; ${e.outcomes.deletedThreads} conversations deleted.`);
   lines.push('');
   lines.push('### Matters');
   lines.push(`- ${e.matters.touched.length} of ${e.matters.total} matters touched in the period:`);

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -10,6 +10,7 @@ import { ThreadStore, type ThreadEvent } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
 import { fsSearch } from '../vault/search';
 import { memoryStore } from '../providers/secrets';
+import { readOutcomes } from '../outcomes/store';
 import { buildDocx } from '../docx/test/builder';
 import { API_PREFIXES, createApp, safeBasename, suffixed, TRUNCATED_HEADER, UPLOAD_MAX_BYTES, type App, type ServerDeps } from './routes';
 import type { RuntimeState } from './settings';
@@ -1699,5 +1700,111 @@ describe('GET /providers/:id/models for an enterprise vendor (providers spec §3
     expect(listed).toEqual({ source: 'list', models: [{ id: 'gpt-5-prod' }] });
     expect(az.requests[0]?.url).toBe('https://firm.openai.azure.com/openai/deployments?api-version=2023-03-15-preview');
     expect(az.requests[0]?.headers.get('api-key')).toBe('az-route-key');
+  });
+});
+
+describe('the outcomes record (routing-and-evals spec §7)', () => {
+  const proposal = {
+    toolCalls: [{ name: 'propose_update', input: { path: 'practice/standards/x.md', content: 'NEW TEXT\n', rationale: 'because' } }],
+    text: 'proposed',
+  };
+
+  async function seedProposal(app: App): Promise<{ threadId: string; proposalId: string }> {
+    const threadId = await newThread(app);
+    await step(app, threadId, { message: 'remember this' });
+    const { events } = await store.get('default', threadId);
+    const ev = events.find((e): e is Extract<ThreadEvent, { t: 'proposal' }> => 't' in e && e.t === 'proposal')!;
+    return { threadId, proposalId: ev.id };
+  }
+
+  test('a decision is recorded with its optional reason; a conflict is not', async () => {
+    const app = appWithFake([proposal, proposal]);
+    const { threadId, proposalId } = await seedProposal(app);
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, { body: { proposalId, decision: 'reject', reason: 'Too broad for the standard.' } });
+    expect(res.status).toBe(200);
+
+    const lines = readOutcomes(vaultRoot);
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toMatchObject({ kind: 'proposal.decided', threadId, path: 'practice/standards/x.md', detail: { proposalId, decision: 'rejected', reason: 'Too broad for the standard.' } });
+
+    const second = await seedProposal(app);
+    await vault.write('default', 'practice/standards/x.md', 'SOMEONE ELSE\n');
+    const conflict = await call(app, 'POST', `/threads/${second.threadId}/approve`, { body: { proposalId: second.proposalId, decision: 'approve' } });
+    expect(conflict.status).toBe(409);
+    expect(readOutcomes(vaultRoot)).toHaveLength(1);
+  });
+
+  test('a mark lands on the run record and in the record; a foreign run is 404', async () => {
+    const app = appWithFake([{ text: 'answer' }, { text: 'other' }]);
+    const id = await newThread(app);
+    const { res: stepRes } = await step(app, id, { message: 'Summarize where we stand.' });
+    const runId = stepRes.headers.get('x-run-id')!;
+
+    const res = await call(app, 'POST', `/threads/${id}/turns/${runId}/mark`, { body: { mark: 'not-right', reason: 'missed the term' } });
+    expect(res.status).toBe(200);
+    expect(((await res.json()) as { mark: { mark: string } }).mark.mark).toBe('not-right');
+    const run = (await (await call(app, 'GET', `/runs/${runId}`)).json()) as { mark?: { mark: string; reason?: string } };
+    expect(run.mark).toMatchObject({ mark: 'not-right', reason: 'missed the term' });
+    expect(readOutcomes(vaultRoot, { kind: 'answer.marked' })[0]).toMatchObject({ threadId: id, runId, task: 'summarize', providerId: 'fake/fake', detail: { mark: 'not-right', reason: 'missed the term' } });
+
+    const other = await newThread(app);
+    expect((await call(app, 'POST', `/threads/${other}/turns/${runId}/mark`, { body: { mark: 'useful' } })).status).toBe(404);
+    expect((await call(app, 'POST', `/threads/${id}/turns/${runId}/mark`, { body: { mark: 'meh' } })).status).toBe(400);
+  });
+
+  test('a task correction rewrites the step event and the record, and is recorded; an unknown task is 400', async () => {
+    const app = appWithFake([{ text: 'answer' }]);
+    const id = await newThread(app);
+    const { res: stepRes } = await step(app, id, { message: 'hi' });
+    const runId = stepRes.headers.get('x-run-id')!;
+    expect(readRunTask()).toEqual(['chat', 'default']);
+
+    expect((await call(app, 'PATCH', `/threads/${id}/steps/${runId}/task`, { body: { task: 'classify' } })).status).toBe(400);
+    const res = await call(app, 'PATCH', `/threads/${id}/steps/${runId}/task`, { body: { task: 'review' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ task: 'review', taskSource: 'corrected' });
+    expect(readRunTask()).toEqual(['review', 'corrected']);
+    const { events } = await store.get('default', id);
+    const stepEv = events.find((e): e is Extract<ThreadEvent, { t: 'step' }> => 't' in e && e.t === 'step')!;
+    expect([stepEv.task, stepEv.taskSource]).toEqual(['review', 'corrected']);
+    expect(readOutcomes(vaultRoot, { kind: 'task.corrected' })[0]).toMatchObject({ threadId: id, runId, task: 'review', detail: { from: 'chat', to: 'review', was: 'default' } });
+
+    function readRunTask(): [string | undefined, string | undefined] {
+      const raw = JSON.parse(readFileSync(join(vaultRoot, '.counsel', 'runs', 'default', `${runId}.json`), 'utf8')) as { task?: string; taskSource?: string };
+      return [raw.task, raw.taskSource];
+    }
+  });
+
+  test('deleting a thread is recorded; GET /outcomes lists since a date; a bad date is 400', async () => {
+    const app = appWithFake([{ text: 'answer' }]);
+    const id = await newThread(app);
+    expect((await call(app, 'DELETE', `/threads/${id}`)).status).toBe(204);
+
+    const all = (await (await call(app, 'GET', '/outcomes')).json()) as Array<{ kind: string; threadId: string }>;
+    expect(all).toHaveLength(1);
+    expect(all[0]).toMatchObject({ kind: 'thread.deleted', threadId: id });
+    const later = (await (await call(app, 'GET', '/outcomes?since=2999-01-01T00:00:00.000Z')).json()) as unknown[];
+    expect(later).toEqual([]);
+    expect((await call(app, 'GET', '/outcomes?since=yesterday')).status).toBe(400);
+  });
+
+  test('PATCH /settings/vault flips the switch in config.md, /health shows it, and nothing is written while off', async () => {
+    writeFileSync(join(vaultRoot, 'config.md'), 'counsel-os-config: true\nlegal_root: x\n', 'utf8');
+    const app = appWithFake([{ text: 'answer' }]);
+    expect(((await (await call(app, 'GET', '/health')).json()) as { outcomes: boolean }).outcomes).toBe(true);
+
+    const off = await call(app, 'PATCH', '/settings/vault', { body: { outcomes: false } });
+    expect(off.status).toBe(200);
+    expect(await off.json()).toEqual({ outcomes: false });
+    expect(readFileSync(join(vaultRoot, 'config.md'), 'utf8')).toContain('outcomes: off');
+    expect(((await (await call(app, 'GET', '/health')).json()) as { outcomes: boolean }).outcomes).toBe(false);
+
+    const id = await newThread(app);
+    expect((await call(app, 'DELETE', `/threads/${id}`)).status).toBe(204);
+    expect(readOutcomes(vaultRoot)).toEqual([]);
+
+    const on = await call(app, 'PATCH', '/settings/vault', { body: { outcomes: true } });
+    expect(await on.json()).toEqual({ outcomes: true });
+    expect((await call(app, 'PATCH', '/settings/vault', { body: { outcomes: 'yes' } })).status).toBe(400);
   });
 });

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -3,7 +3,7 @@ import { MatterStaysLocalError, RouterError } from '../core/types';
 import { DEFAULT_STEP_TIMEOUT_MS, runStep, type CounselLoopDeps, policyForOptions, resolveStepProvider } from '../loop/counsel-loop';
 import { pendingProposals } from '../loop/pending-proposals';
 import { applyProposal } from '../loop/proposals';
-import { listRuns, readRun, type RunRecord } from '../loop/run-record';
+import { finishRun, listRuns, readRun, type RunRecord } from '../loop/run-record';
 import { DOCX_CONTENT_TYPE, docxToMarkdown, isDocxPath, NotADocxError, openDocx, UnsafeXmlError } from '../docx';
 import { assertSafeXml } from '../docx/safety';
 import { BASE_URL_RULE, isAllowedBaseURL, readRegistry, RegistryFile } from '../providers/registry';
@@ -14,7 +14,10 @@ import type { ThreadEvent, ThreadHeader } from '../threads/store';
 import { vaultDocket } from '../vault/docket';
 import { normalizeVaultPath } from '../vault/knowledge-paths';
 import { vaultOverview } from '../vault/overview';
-import { readVaultConfig } from '../vault/resolve-root';
+import { readVaultConfig, writeVaultConfigOverride } from '../vault/resolve-root';
+import { appendOutcome, readOutcomes, type OutcomeLine } from '../outcomes/store';
+import { isTask, TASK_IDS } from '../tasks/taxonomy';
+import { modelClassifier } from '../tasks/classify';
 import { applyUpdates, contentStatus, UpdateError } from '../content/update';
 import { repoContentSource } from '../content/repo';
 import { runDoctor } from '../doctor/index';
@@ -69,7 +72,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session', 'retro', 'providers'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session', 'retro', 'providers', 'outcomes'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -117,6 +120,21 @@ const StepBody = z.object({
 const ApproveBody = z.object({
   proposalId: z.string().min(1),
   decision: z.enum(['approve', 'reject']),
+  /** Why (spec §7) — optional, kept in the outcomes record, never required. */
+  reason: z.string().trim().max(500).optional(),
+});
+
+const MarkBody = z.object({
+  mark: z.enum(['useful', 'not-right']),
+  reason: z.string().trim().max(500).optional(),
+});
+
+const TaskBody = z.object({
+  task: z.string().trim().min(1).max(40),
+});
+
+const VaultSettingsBody = z.object({
+  outcomes: z.boolean(),
 });
 
 function text(err: unknown): string {
@@ -377,7 +395,19 @@ export function createApp(deps: ServerDeps): App {
       router: state.router,
       ...(deps.platform === undefined ? {} : { platform: deps.platform }),
       ...(state.stepTimeoutMs === undefined ? {} : { stepTimeoutMs: state.stepTimeoutMs }),
+      // The model classifier is opt-in (`classify: model` in config.md): a
+      // scripted or metered provider must not spend a turn on it unasked.
+      ...(readVaultConfig(deps.vaultRoot).classify === 'model' ? { classifier: modelClassifier(state.providers, state.router, deps.tenant) } : {}),
     };
+  };
+
+  /** Appends to the vault's outcomes record; never fails a request. */
+  const recordOutcome = (line: Omit<OutcomeLine, 'at'>): void => {
+    try {
+      appendOutcome(deps.vaultRoot, readVaultConfig(deps.vaultRoot), line);
+    } catch (err) {
+      console.error(`outcomes: write failed: ${text(err)}`);
+    }
   };
 
   /** Runs `fn` with this thread's lock held for its whole duration — for the
@@ -405,6 +435,9 @@ export function createApp(deps: ServerDeps): App {
       // What a step on this runtime actually gets, not what was configured:
       // an operator reading /health wants the effective number.
       stepTimeoutMs: state.stepTimeoutMs ?? DEFAULT_STEP_TIMEOUT_MS,
+      // Whether this vault keeps the local record of decisions and marks
+      // (routing-and-evals spec §7).
+      outcomes: readVaultConfig(deps.vaultRoot).outcomes !== false,
     });
   };
 
@@ -554,10 +587,55 @@ export function createApp(deps: ServerDeps): App {
   };
   const deleteThread = async (id: string): Promise<Response> =>
     withThreadLock(id, async () => {
-      await loadThread(deps, id);
+      const { header } = await loadThread(deps, id);
       await deps.store.remove(deps.tenant, id);
+      recordOutcome({ kind: 'thread.deleted', threadId: id, ...(header.matter === undefined ? {} : { matter: header.matter }), detail: { title: header.title ?? '' } });
       return new Response(null, { status: 204 });
     });
+
+  /** The lawyer's mark on an answer (spec §7): recorded, and kept on the run
+   * record so the strip shows it after a reload. */
+  const markTurn = async (req: Request, id: string, runId: string): Promise<Response> => {
+    const input = await body(req, MarkBody);
+    const { header } = await loadThread(deps, id);
+    const run = readRun(deps.vaultRoot, deps.tenant, runId);
+    if (run === null || run.threadId !== id) throw new HttpError(404, `unknown run: ${runId}`);
+    const at = new Date().toISOString();
+    const mark = { mark: input.mark, at, ...(input.reason === undefined || input.reason === '' ? {} : { reason: input.reason }) };
+    finishRun(deps.vaultRoot, deps.tenant, runId, { mark });
+    recordOutcome({ kind: 'answer.marked', threadId: id, runId, ...(run.task === undefined ? {} : { task: run.task }), providerId: run.provider, ...(header.matter === undefined ? {} : { matter: header.matter }), detail: { mark: input.mark, ...(input.reason === undefined || input.reason === '' ? {} : { reason: input.reason }) } });
+    return json({ mark });
+  };
+
+  /** The lawyer corrects a step's task (spec §3): the step event and the run
+   * record change, and the correction is an outcome. */
+  const correctTask = async (req: Request, id: string, runId: string): Promise<Response> =>
+    withThreadLock(id, async () => {
+      const input = await body(req, TaskBody);
+      const { header } = await loadThread(deps, id);
+      const run = readRun(deps.vaultRoot, deps.tenant, runId);
+      if (run === null || run.threadId !== id) throw new HttpError(404, `unknown run: ${runId}`);
+      if (!isTask(input.task)) return fail(400, `task must be one of ${TASK_IDS.join(', ')}`);
+      const from = run.task ?? 'chat';
+      if (from === input.task) return json({ task: input.task, taskSource: run.taskSource ?? 'caller' });
+      await deps.store.updateStep(deps.tenant, id, runId, { task: input.task, taskSource: 'corrected' });
+      finishRun(deps.vaultRoot, deps.tenant, runId, { task: input.task, taskSource: 'corrected' });
+      recordOutcome({ kind: 'task.corrected', threadId: id, runId, task: input.task, providerId: run.provider, ...(header.matter === undefined ? {} : { matter: header.matter }), detail: { from, to: input.task, was: run.taskSource ?? 'caller' } });
+      return json({ task: input.task, taskSource: 'corrected' });
+    });
+
+  const outcomes = (url: URL): Response => {
+    const since = url.searchParams.get('since');
+    if (since !== null && Number.isNaN(Date.parse(since))) return fail(400, 'since must be a date');
+    return json(readOutcomes(deps.vaultRoot, { since }));
+  };
+
+  /** The vault-level switches Settings edits in config.md (spec §7). */
+  const patchVaultSettings = async (req: Request): Promise<Response> => {
+    const input = await body(req, VaultSettingsBody);
+    writeVaultConfigOverride(deps.vaultRoot, 'outcomes', input.outcomes ? 'on' : 'off');
+    return json({ outcomes: readVaultConfig(deps.vaultRoot).outcomes !== false });
+  };
 
   const steps = async (req: Request, id: string): Promise<Response> => {
     const input = await body(req, StepBody);
@@ -625,6 +703,14 @@ export function createApp(deps: ServerDeps): App {
 
     if (result.status === 'conflict') {
       return fail(409, `vault conflict on ${await proposalPath(deps, id, input.proposalId)}`, { conflict: result.conflict });
+    }
+    if (!('error' in result) && (result.status === 'approved' || result.status === 'rejected')) {
+      recordOutcome({
+        kind: 'proposal.decided',
+        threadId: id,
+        path: await proposalPath(deps, id, input.proposalId),
+        detail: { proposalId: input.proposalId, decision: result.status, decidedAt: new Date().toISOString(), ...(input.reason === undefined || input.reason === '' ? {} : { reason: input.reason }) },
+      });
     }
     // The proposal had already been decided — the earlier decision stands
     // and nothing was written.
@@ -1002,6 +1088,15 @@ export function createApp(deps: ServerDeps): App {
         if (third === 'steps') return await steps(req, second);
         if (third === 'approve') return await approve(req, second);
       }
+
+      if (segments.length === 5 && first === 'threads' && second !== undefined && segments[3] !== undefined) {
+        if (third === 'turns' && segments[4] === 'mark' && method === 'POST') return await markTurn(req, second, segments[3]);
+        if (third === 'steps' && segments[4] === 'task' && method === 'PATCH') return await correctTask(req, second, segments[3]);
+      }
+
+      if (segments.length === 1 && first === 'outcomes' && method === 'GET') return outcomes(url);
+
+      if (segments.length === 2 && first === 'settings' && second === 'vault' && method === 'PATCH') return await patchVaultSettings(req);
 
       if (segments.length === 1 && first === 'runs' && method === 'GET') return await runs(url);
 

--- a/runtime/src/tasks/classify.test.ts
+++ b/runtime/src/tasks/classify.test.ts
@@ -97,4 +97,21 @@ describe('modelClassifier', () => {
     expect(await classify('x')).toBe('extract');
     expect(cloud.lastRequest).toBeUndefined();
   });
+
+  test('under a matter that stays local, only a local model may classify — with none loaded, nothing is called and the step is chat', async () => {
+    const cloud = new FakeModelProvider([{ output: { task: 'draft' } }]);
+    Object.assign(cloud, { id: 'cloud/big' });
+    (cloud as { capabilities: ModelProvider['capabilities'] }).capabilities = { tools: true, caching: false, thinking: false, contextTokens: 200_000, auth: 'apikey', locality: 'cloud' };
+    const classify = modelClassifier([cloud], new Router({ default: 'cloud/big' }, [cloud]));
+    expect(await classify('x', { localOnly: true })).toBeNull();
+    expect(cloud.lastRequest).toBeUndefined();
+    // And classifyTask carries the option through to the classifier.
+    const seen: Array<{ localOnly?: boolean } | undefined> = [];
+    const spy = async (_m: string, opts?: { localOnly?: boolean }): Promise<null> => {
+      seen.push(opts);
+      return null;
+    };
+    expect(await classifyTask({ message: 'hello there' }, spy, { localOnly: true })).toEqual({ task: 'chat', source: 'default' });
+    expect(seen).toEqual([{ localOnly: true }]);
+  });
 });

--- a/runtime/src/tasks/classify.test.ts
+++ b/runtime/src/tasks/classify.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, test } from 'bun:test';
+import { FakeModelProvider } from '../core/fake-provider';
+import type { ModelProvider } from '../core/types';
+import { Router } from '../router/router';
+import { classifyByRules, classifyTask, modelClassifier } from './classify';
+
+describe('classifyByRules (spec §3)', () => {
+  test.each([
+    ['Redline this for us.', 'redline'],
+    ['Please mark up the indemnity.', 'redline'],
+    ['Compare round 2 vs round 3 — what moved?', 'compare'],
+    ['List the parties and defined terms.', 'extract'],
+    ['Summarize where we stand on Acme.', 'summarize'],
+    ["What's due this week?", 'docket'],
+    ['Remember this: we never accept unlimited liability.', 'remember'],
+    ['What does the law in Delaware require for non-competes?', 'research'],
+    ['Draft a mutual NDA for Acme.', 'draft'],
+    ['Would we sign this?', 'review'],
+    ['Hello there', null],
+  ])('%s → %s', (message, task) => {
+    expect(classifyByRules(message) as string | null).toBe(task);
+  });
+
+  test('a review verb with a document attached is a review; a redline verb wins over review', () => {
+    expect(classifyByRules('Flag any issues with this.\n`matters/acme/nda.docx`')).toBe('review');
+    expect(classifyByRules('Review it and give me a redline.\n`matters/acme/nda.docx`')).toBe('redline');
+  });
+
+  test('"flag" and "assess" need a document; alone they are not a review', () => {
+    expect(classifyByRules('Flag anything odd.')).toBeNull();
+    expect(classifyByRules('Assess this.\n`matters/acme/nda.md`')).toBe('review');
+  });
+});
+
+describe('classifyTask precedence', () => {
+  test('the caller wins, then the thread, and a custom route name is kept as-is', async () => {
+    expect(await classifyTask({ message: 'redline this', callerTask: 'classify' })).toEqual({ task: 'classify', source: 'caller' });
+    expect(await classifyTask({ message: 'redline this', threadTask: 'retro' })).toEqual({ task: 'retro', source: 'caller' });
+    expect(await classifyTask({ message: 'redline this', callerTask: '' })).toEqual({ task: 'redline', source: 'rule' });
+  });
+
+  test('no rule → the injected model; no model or a null answer → chat by default', async () => {
+    let asked = 0;
+    const model = async (): Promise<'research'> => {
+      asked += 1;
+      return 'research';
+    };
+    expect(await classifyTask({ message: 'hi there' }, model)).toEqual({ task: 'research', source: 'model' });
+    expect(asked).toBe(1);
+    expect(await classifyTask({ message: 'hi there' })).toEqual({ task: 'chat', source: 'default' });
+    expect(await classifyTask({ message: 'hi there' }, async () => null)).toEqual({ task: 'chat', source: 'default' });
+  });
+
+  test('a rule hit never asks the model; a throwing model is a chat step, not a failure', async () => {
+    let asked = 0;
+    const model = async (): Promise<null> => {
+      asked += 1;
+      throw new Error('boom');
+    };
+    expect(await classifyTask({ message: 'draft a letter' }, model)).toEqual({ task: 'draft', source: 'rule' });
+    expect(asked).toBe(0);
+    expect(await classifyTask({ message: 'hi' }, model)).toEqual({ task: 'chat', source: 'default' });
+    expect(asked).toBe(1);
+  });
+});
+
+describe('modelClassifier', () => {
+  test('one structured turn: the taxonomy in the system prompt, the message alone, a task id back', async () => {
+    const fake = new FakeModelProvider([{ output: { task: 'summarize' } }]);
+    const classify = modelClassifier([fake], new Router({ default: fake.id }, [fake]));
+    expect(await classify('so where does this leave us')).toBe('summarize');
+    const req = fake.lastRequest!;
+    expect(req.system).toContain('- summarize:');
+    expect(req.messages).toEqual([{ role: 'user', content: 'so where does this leave us' }]);
+    expect(req.tools).toEqual([]);
+    expect(req.outputSchema).toBeDefined();
+    expect(req.maxToolCalls).toBe(0);
+  });
+
+  test('an answer outside the taxonomy, an error, or a null output is null — never a throw', async () => {
+    const answers = [{ output: { task: 'classify' } }, { error: 'exploded' }, { output: null }];
+    const fake = new FakeModelProvider(answers);
+    const classify = modelClassifier([fake], new Router({ default: fake.id }, [fake]));
+    expect(await classify('x')).toBeNull();
+    expect(await classify('x')).toBeNull();
+    expect(await classify('x')).toBeNull();
+  });
+
+  test('prefers the smallest local provider over the router default', async () => {
+    const cloud = new FakeModelProvider([{ output: { task: 'draft' } }]);
+    Object.assign(cloud, { id: 'cloud/big' });
+    (cloud as { capabilities: ModelProvider['capabilities'] }).capabilities = { tools: true, caching: false, thinking: false, contextTokens: 200_000, auth: 'local', locality: 'cloud' };
+    const local = new FakeModelProvider([{ output: { task: 'extract' } }]);
+    Object.assign(local, { id: 'ollama/small' });
+    (local as { capabilities: ModelProvider['capabilities'] }).capabilities = { tools: true, caching: false, thinking: false, contextTokens: 8_000, auth: 'local', locality: 'local' };
+    const classify = modelClassifier([cloud, local], new Router({ default: 'cloud/big' }, [cloud, local]));
+    expect(await classify('x')).toBe('extract');
+    expect(cloud.lastRequest).toBeUndefined();
+  });
+});

--- a/runtime/src/tasks/classify.ts
+++ b/runtime/src/tasks/classify.ts
@@ -29,7 +29,7 @@ export interface Classification {
 }
 
 /** One structured call: the message → a task id, or `null` when it cannot say. */
-export type ModelClassifier = (message: string) => Promise<TaskId | null>;
+export type ModelClassifier = (message: string, opts?: { localOnly?: boolean }) => Promise<TaskId | null>;
 
 const DOCUMENT_EXT = /\.(docx|md|txt|pdf)$/i;
 
@@ -75,14 +75,14 @@ export function classifyByRules(message: string): TaskId | null {
  * from Settings) — the taxonomy is the vocabulary the runtime SPEAKS, not a
  * gate on what it accepts.
  */
-export async function classifyTask(input: ClassifyInput, model?: ModelClassifier): Promise<{ task: string; source: TaskSource }> {
+export async function classifyTask(input: ClassifyInput, model?: ModelClassifier, opts: { localOnly?: boolean } = {}): Promise<{ task: string; source: TaskSource }> {
   if (input.callerTask !== undefined && input.callerTask !== '') return { task: input.callerTask, source: 'caller' };
   if (input.threadTask !== undefined && input.threadTask !== '') return { task: input.threadTask, source: 'caller' };
   const rule = classifyByRules(input.message);
   if (rule !== null) return { task: rule, source: 'rule' };
   if (model !== undefined) {
     try {
-      const guessed = await model(input.message);
+      const guessed = await model(input.message, opts);
       if (guessed !== null && isTask(guessed)) return { task: guessed, source: 'model' };
     } catch {
       // A classifier that fails is a `chat` step, never a failed step.
@@ -99,18 +99,22 @@ const TaskAnswer = z.object({ task: z.enum(TASK_IDS as [TaskId, ...TaskId[]]) })
  * The model-backed classifier (spec §3): the cheapest LOCAL provider when one
  * is loaded, else the router's default; one structured turn with the
  * taxonomy quoted; ten seconds, then `null`. The message is the only content
- * sent — no vault, no tools — so a cloud classifier sees one sentence, and a
- * matter that stays local has already been decided before this runs.
+ * sent — no vault, no tools — so a cloud classifier sees one sentence; under
+ * a matter that stays local (`localOnly`) only a local model may see it.
  */
 export function modelClassifier(providers: readonly ModelProvider[], router: Router, tenant = 'default'): ModelClassifier {
-  return async (message: string): Promise<TaskId | null> => {
+  return async (message: string, opts: { localOnly?: boolean } = {}): Promise<TaskId | null> => {
     const local = providers.filter(p => isLocal(p.capabilities)).sort((a, b) => a.capabilities.contextTokens - b.capabilities.contextTokens);
-    let provider: ModelProvider;
+    let provider: ModelProvider | undefined;
     try {
-      provider = local[0] ?? router.resolve();
+      // A matter that stays on this machine classifies on a local model or
+      // not at all (providers spec §7): the message never reaches the cloud,
+      // not even for one word back.
+      provider = opts.localOnly === true ? local[0] : (local[0] ?? router.resolve());
     } catch {
       return null;
     }
+    if (provider === undefined) return null;
     const cancel = new AbortController();
     const timer = setTimeout(() => cancel.abort(), CLASSIFY_TIMEOUT_MS);
     try {

--- a/runtime/src/tasks/classify.ts
+++ b/runtime/src/tasks/classify.ts
@@ -1,0 +1,144 @@
+/**
+ * Which task a step is (routing-and-evals spec §3): the caller's word wins,
+ * then the thread's, then a rule pass over the message and its attachments,
+ * then one small structured model call, else `chat`.
+ *
+ * The rules are deliberately narrow and literal — a lawyer who types
+ * "redline it" means redline — and the model call is an injected
+ * dependency, so the loop's tests never spend a scripted provider turn on
+ * classification and a runtime with no provider still classifies by rule.
+ */
+import { z } from 'zod';
+import type { ModelProvider, StepEvent } from '../core/types';
+import { isLocal } from '../router/router';
+import type { Router } from '../router/router';
+import { attachmentPaths } from '../vault/policy';
+import { isTask, TASK_IDS, TASKS, type TaskId, type TaskSource } from './taxonomy';
+
+export interface ClassifyInput {
+  message: string;
+  /** The caller's task (the step body). */
+  callerTask?: string | undefined;
+  /** The thread header's task (a retro thread). */
+  threadTask?: string | undefined;
+}
+
+export interface Classification {
+  task: TaskId;
+  source: TaskSource;
+}
+
+/** One structured call: the message → a task id, or `null` when it cannot say. */
+export type ModelClassifier = (message: string) => Promise<TaskId | null>;
+
+const DOCUMENT_EXT = /\.(docx|md|txt|pdf)$/i;
+
+interface Rule {
+  task: TaskId;
+  /** Every pattern is tried against the lower-cased message. */
+  any: RegExp[];
+  /** When set, the rule also needs a document attached. */
+  needsDocument?: boolean;
+}
+
+/** Order matters: the first rule whose pattern hits wins, so the more
+ * specific verbs (redline, compare) sit above the broader ones (review). */
+const RULES: readonly Rule[] = [
+  { task: 'redline', any: [/\bredline/, /tracked changes/, /\bmark(?:ed)? up\b/, /\bmarkup\b/] },
+  { task: 'compare', any: [/\bcompare\b/, /what moved/, /\bround(?:s)?\b.*\b(?:vs|versus|against)\b/, /\bdiff(?:erence)?s?\b.*\b(?:between|against)\b/] },
+  { task: 'extract', any: [/\bextract\b/, /list (?:the )?(?:parties|defined terms|definitions|dates|deadlines|obligations)/, /\bdefined terms\b/, /who are the parties/] },
+  { task: 'summarize', any: [/\bsummari[sz]e\b/, /\bsummary\b/, /\bbrief me\b/, /\bbrief (?:the|this)\b/, /\btl;?dr\b/, /where (?:are we|do we stand|does this stand)/] },
+  { task: 'docket', any: [/\bdeadline/, /\bdocket\b/, /what(?:'s| is) due/, /next actions?\b/, /\bcalendar\b/] },
+  { task: 'remember', any: [/\bremember (?:this|that)\b/, /\bsave this\b/, /\bupdate (?:our|the) standard/, /\badd (?:this )?to (?:our )?(?:standards|memory|playbook)/, /\bfrom now on\b/] },
+  { task: 'research', any: [/\bresearch\b/, /what does the law/, /\bcase law\b/, /\bstatute\b/, /\bcite\b/, /is it (?:legal|lawful|permitted)/, /what(?:'s| is) the law/, /\bjurisdiction\b.*\brequire/] },
+  { task: 'draft', any: [/\bdraft\b/, /\bwrite (?:a|an|the|me)\b/, /\bprepare (?:a|an|the)\b/] },
+  { task: 'review', any: [/\breview\b/, /\bevaluate\b/, /\bflag\b/, /would we (?:not )?sign/, /\bissues? with\b/, /\bred ?flags?\b/, /\bassess\b/, /\bgo through\b/], needsDocument: true },
+  // A bare "review" with nothing attached still reads as a review request
+  // (the document may already be in the thread); kept below the attached
+  // form so the attachment case matches first and reads the same.
+  { task: 'review', any: [/\breview\b/, /\bevaluate\b/, /would we (?:not )?sign/] },
+];
+
+export function classifyByRules(message: string): TaskId | null {
+  const lower = message.toLowerCase();
+  const hasDocument = attachmentPaths(message).some(p => DOCUMENT_EXT.test(p));
+  for (const rule of RULES) {
+    if (rule.needsDocument === true && !hasDocument) continue;
+    if (rule.any.some(re => re.test(lower))) return rule.task;
+  }
+  return null;
+}
+
+/**
+ * The step's task and where it came from. A caller's or a thread's task is
+ * taken as given even when it is not in the taxonomy (a custom route name
+ * from Settings) — the taxonomy is the vocabulary the runtime SPEAKS, not a
+ * gate on what it accepts.
+ */
+export async function classifyTask(input: ClassifyInput, model?: ModelClassifier): Promise<{ task: string; source: TaskSource }> {
+  if (input.callerTask !== undefined && input.callerTask !== '') return { task: input.callerTask, source: 'caller' };
+  if (input.threadTask !== undefined && input.threadTask !== '') return { task: input.threadTask, source: 'caller' };
+  const rule = classifyByRules(input.message);
+  if (rule !== null) return { task: rule, source: 'rule' };
+  if (model !== undefined) {
+    try {
+      const guessed = await model(input.message);
+      if (guessed !== null && isTask(guessed)) return { task: guessed, source: 'model' };
+    } catch {
+      // A classifier that fails is a `chat` step, never a failed step.
+    }
+  }
+  return { task: 'chat', source: 'default' };
+}
+
+const CLASSIFY_TIMEOUT_MS = 10_000;
+
+const TaskAnswer = z.object({ task: z.enum(TASK_IDS as [TaskId, ...TaskId[]]) });
+
+/**
+ * The model-backed classifier (spec §3): the cheapest LOCAL provider when one
+ * is loaded, else the router's default; one structured turn with the
+ * taxonomy quoted; ten seconds, then `null`. The message is the only content
+ * sent — no vault, no tools — so a cloud classifier sees one sentence, and a
+ * matter that stays local has already been decided before this runs.
+ */
+export function modelClassifier(providers: readonly ModelProvider[], router: Router, tenant = 'default'): ModelClassifier {
+  return async (message: string): Promise<TaskId | null> => {
+    const local = providers.filter(p => isLocal(p.capabilities)).sort((a, b) => a.capabilities.contextTokens - b.capabilities.contextTokens);
+    let provider: ModelProvider;
+    try {
+      provider = local[0] ?? router.resolve();
+    } catch {
+      return null;
+    }
+    const cancel = new AbortController();
+    const timer = setTimeout(() => cancel.abort(), CLASSIFY_TIMEOUT_MS);
+    try {
+      const system = [
+        'Classify a lawyer\'s request into exactly one task id. Answer with the id only.',
+        ...TASKS.map(t => `- ${t.id}: ${t.definition}`),
+      ].join('\n');
+      let output: unknown = null;
+      for await (const ev of provider.run({
+        tenant,
+        system,
+        messages: [{ role: 'user', content: message }],
+        tools: [],
+        outputSchema: TaskAnswer,
+        maxTokens: 30,
+        maxToolCalls: 0,
+        signal: cancel.signal,
+      })) {
+        const e = ev as StepEvent;
+        if (e.type === 'done') output = e.output;
+        if (e.type === 'error') return null;
+      }
+      const parsed = TaskAnswer.safeParse(output);
+      return parsed.success ? parsed.data.task : null;
+    } catch {
+      return null;
+    } finally {
+      clearTimeout(timer);
+    }
+  };
+}

--- a/runtime/src/tasks/taxonomy.test.ts
+++ b/runtime/src/tasks/taxonomy.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+import { isTask, TASK_IDS, TASKS, taskDefinition } from './taxonomy';
+
+describe('the task taxonomy (routing-and-evals spec §3)', () => {
+  test('is the closed set the spec names, chat last', () => {
+    expect(TASK_IDS).toEqual(['review', 'redline', 'draft', 'research', 'extract', 'summarize', 'compare', 'remember', 'docket', 'retro', 'chat']);
+  });
+
+  test('every task has a one-line definition and a default scorer', () => {
+    for (const t of TASKS) {
+      expect(t.definition.length).toBeGreaterThan(10);
+      expect(['findings', 'redline', 'rubric', 'extraction', 'classification', 'none']).toContain(t.scorer);
+    }
+    expect(taskDefinition('redline').scorer).toBe('redline');
+    expect(taskDefinition('chat').scorer).toBe('none');
+  });
+
+  test('isTask accepts only the closed set', () => {
+    expect(isTask('review')).toBe(true);
+    expect(isTask('classify')).toBe(false);
+    expect(isTask('')).toBe(false);
+    expect(isTask(undefined)).toBe(false);
+    expect(isTask(3)).toBe(false);
+  });
+});

--- a/runtime/src/tasks/taxonomy.ts
+++ b/runtime/src/tasks/taxonomy.ts
@@ -1,0 +1,57 @@
+/**
+ * The legal task taxonomy (routing-and-evals spec §3): the closed set every
+ * step is tagged with. A task decides which route the router consults, which
+ * scorer an eval uses, and how the scoreboard groups results — so it is a
+ * vocabulary, not a free string. `chat` is the honest catch-all.
+ */
+
+export type TaskId =
+  | 'review'
+  | 'redline'
+  | 'draft'
+  | 'research'
+  | 'extract'
+  | 'summarize'
+  | 'compare'
+  | 'remember'
+  | 'docket'
+  | 'retro'
+  | 'chat';
+
+export type ScorerKind = 'findings' | 'redline' | 'rubric' | 'extraction' | 'classification' | 'none';
+
+export interface TaskDefinition {
+  id: TaskId;
+  /** One line the prompt (and a picker) can quote. */
+  definition: string;
+  /** The scorer an eval of this task uses by default (spec §4). */
+  scorer: ScorerKind;
+}
+
+export const TASKS: readonly TaskDefinition[] = [
+  { id: 'review', definition: "evaluate a document against the practice's standards; findings with severity", scorer: 'findings' },
+  { id: 'redline', definition: 'produce edits (tracked changes) to a document', scorer: 'redline' },
+  { id: 'draft', definition: "write a new document or clause from the practice's positions", scorer: 'rubric' },
+  { id: 'research', definition: "answer a legal question from the vault's law and reference layers", scorer: 'findings' },
+  { id: 'extract', definition: 'pull structured facts: parties, terms, dates, defined terms, clauses', scorer: 'extraction' },
+  { id: 'summarize', definition: "brief a document or a matter's state", scorer: 'rubric' },
+  { id: 'compare', definition: 'two documents or rounds: what moved', scorer: 'extraction' },
+  { id: 'remember', definition: 'promote a learning into memory or the standards (proposals)', scorer: 'rubric' },
+  { id: 'docket', definition: 'deadlines and next actions', scorer: 'extraction' },
+  { id: 'retro', definition: 'the periodic review of the practice', scorer: 'rubric' },
+  { id: 'chat', definition: 'anything else', scorer: 'none' },
+];
+
+export const TASK_IDS: readonly TaskId[] = TASKS.map(t => t.id);
+
+export function isTask(value: unknown): value is TaskId {
+  return typeof value === 'string' && (TASK_IDS as readonly string[]).includes(value);
+}
+
+export function taskDefinition(id: TaskId): TaskDefinition {
+  return TASKS.find(t => t.id === id)!;
+}
+
+/** Where a step's task came from (spec §3): stamped beside the task so a
+ * scoreboard can weigh a guessed task differently from a stated one. */
+export type TaskSource = 'caller' | 'rule' | 'model' | 'default' | 'corrected';

--- a/runtime/src/threads/store.test.ts
+++ b/runtime/src/threads/store.test.ts
@@ -262,3 +262,20 @@ describe('artifact events', () => {
     expect(got.events).toEqual([ev]);
   });
 });
+
+describe('updateStep (routing-and-evals spec §3)', () => {
+  test('rewrites the matching step event with the corrected task and source; a miss is false', async () => {
+    const header = await store.create('default', {});
+    await store.append('default', header.id, { t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'hi' });
+    await store.append('default', header.id, { t: 'step', at: '2026-01-01T00:00:01.000Z', runId: 'run-1', provider: 'fake/fake', task: 'chat', taskSource: 'default' });
+    await store.append('default', header.id, { t: 'step', at: '2026-01-01T00:00:02.000Z', runId: 'run-2', provider: 'fake/fake', task: 'draft', taskSource: 'rule' });
+
+    expect(await store.updateStep('default', header.id, 'run-1', { task: 'review', taskSource: 'corrected' })).toBe(true);
+    const { events } = await store.get('default', header.id);
+    const steps = events.filter((e): e is Extract<ThreadEvent, { t: 'step' }> => 't' in e && e.t === 'step');
+    expect(steps.map(s => [s.runId, s.task, s.taskSource])).toEqual([['run-1', 'review', 'corrected'], ['run-2', 'draft', 'rule']]);
+    expect(events[0]).toEqual({ t: 'user', at: '2026-01-01T00:00:00.000Z', content: 'hi' });
+
+    expect(await store.updateStep('default', header.id, 'run-9', { task: 'review', taskSource: 'corrected' })).toBe(false);
+  });
+});

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -34,7 +34,7 @@ export interface ThreadHeader {
 
 export type ThreadEvent =
   | { t: 'user'; at: string; content: string }
-  | { t: 'step'; at: string; runId: string; provider: string; task?: string }
+  | { t: 'step'; at: string; runId: string; provider: string; task?: string; taskSource?: 'caller' | 'rule' | 'model' | 'default' | 'corrected' }
   // Spec §5's warning event: something the run recovered from, worth
   // showing in the transcript but not an `error` and not model output. The
   // resume-failure fallback is the first user — it records that the vendor
@@ -296,6 +296,27 @@ export class ThreadStore {
     const header = this.readHeader(tenant, id);
     header.updatedAt = new Date().toISOString();
     this.writeHeader(tenant, header);
+  }
+
+  /** Rewrites one step event's task (a correction by the lawyer, spec §7)
+   * the way `updateProposal` rewrites a proposal's status. */
+  async updateStep(tenant: Tenant, id: string, runId: string, patch: { task: string; taskSource: 'corrected' }): Promise<boolean> {
+    this.validateTenant(tenant);
+    this.validateId(id);
+    let found = false;
+    const events = this.readEvents(tenant, id).map(ev => {
+      if ('t' in ev && ev.t === 'step' && ev.runId === runId) {
+        found = true;
+        return { ...ev, ...patch };
+      }
+      return ev;
+    });
+    if (!found) return false;
+    const logPath = this.logPath(tenant, id);
+    const tmpPath = `${logPath}.tmp`;
+    writeFileSync(tmpPath, events.map(ev => JSON.stringify(ev) + '\n').join(''), 'utf8');
+    renameSync(tmpPath, logPath);
+    return true;
   }
 
   async remove(tenant: Tenant, id: string): Promise<void> {

--- a/runtime/src/tools/builtin.ts
+++ b/runtime/src/tools/builtin.ts
@@ -24,7 +24,7 @@ export interface BuiltinToolOptions {
   vault?: VaultStore;
   /** The thread a step runs in: `apply_redlines` records its `artifact`
    * event there. Absent outside a thread (the CLI's one-shot run). */
-  thread?: { store: ThreadStore; threadId: string; tenant: Tenant };
+  thread?: { store: ThreadStore; threadId: string; tenant: Tenant; outcome?: (line: { kind: 'artifact.produced'; path: string; detail: Record<string, unknown> }) => void };
   /** Tests: pretend to be (or not be) the compiled binary. */
   compiled?: boolean;
 }

--- a/runtime/src/tools/docx-tools.test.ts
+++ b/runtime/src/tools/docx-tools.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { buildDocx } from '../docx/test/builder';
@@ -151,6 +151,28 @@ describe('apply_redlines', () => {
     expect(artifact.kind).toBe('docx-redline');
     expect(artifact.tracked).toBe(true);
     expect(artifact.summary.applied).toBe(1);
+  });
+
+  test('inside a thread, a redline and a compare each report the document produced through the outcome hook (routing-and-evals spec §7)', async () => {
+    const { ThreadStore } = await import('../threads/store');
+    const threads = new ThreadStore(vault, { codexHomeRoot: mkdtempSync(join(tmpdir(), 'docx-tools-codex-')) });
+    const { id } = await threads.create('default', {});
+    const produced: Array<{ kind: string; path: string; detail: Record<string, unknown> }> = [];
+    const tools = docxTools({ vaultRoot: vault, thread: { store: threads, threadId: id, tenant: 'default', outcome: line => produced.push(line) } });
+    const redline = tools.find(x => x.name === 'apply_redlines')!;
+    const out = (await redline.execute({ original: 'matters/acme/nda.docx', items, track: true, author: 'Counsel OS' }, ctx)) as { output: string; artifactId: string };
+    // Its own pair of files: the vault is shared across this file's tests,
+    // and the compare below must not take the name the next test expects.
+    copyFileSync(join(vault, 'matters', 'acme', 'nda.docx'), join(vault, 'matters', 'acme', 'nda-b.docx'));
+    writeFileSync(join(vault, 'matters', 'acme', 'nda-b-v2.docx'), buildDocx({ blocks: [{ style: 'Heading1', runs: ['1. Term'] }, { runs: ['Lasts one year.'] }] }));
+    const compare = tools.find(x => x.name === 'docx_compare')!;
+    const cmp = (await compare.execute(compare.inputSchema.parse({ original: 'matters/acme/nda-b.docx', revised: 'matters/acme/nda-b-v2.docx' }), ctx)) as { output: string; artifactId: string };
+
+    expect(produced.map(p => [p.kind, p.path, p.detail['kind'], p.detail['artifactId']])).toEqual([
+      ['artifact.produced', out.output, 'docx-redline', out.artifactId],
+      ['artifact.produced', cmp.output, 'docx-compare', cmp.artifactId],
+    ]);
+    expect(typeof produced[0]!.detail['summary']).toBe('object');
   });
 });
 

--- a/runtime/src/tools/docx-tools.ts
+++ b/runtime/src/tools/docx-tools.ts
@@ -62,7 +62,7 @@ export interface DocxToolOptions {
    * `vaultRoot` with the same never-overwrite flag. */
   vault?: VaultStore;
   /** The thread the step runs in: the `artifact` event is recorded there. */
-  thread?: { store: ThreadStore; threadId: string; tenant: Tenant };
+  thread?: { store: ThreadStore; threadId: string; tenant: Tenant; outcome?: (line: { kind: 'artifact.produced'; path: string; detail: Record<string, unknown> }) => void };
 }
 
 /** The redline JSON item, as the primitives specify it. `match` is kept
@@ -187,6 +187,7 @@ export function docxTools(opts: DocxToolOptions): Tool[] {
           summary,
         });
         out.artifactId = artifactId;
+        opts.thread.outcome?.({ kind: 'artifact.produced', path: rel, detail: { artifactId, kind: 'docx-redline', summary } });
       }
       return out;
     },
@@ -282,6 +283,7 @@ export function docxTools(opts: DocxToolOptions): Tool[] {
           summary,
         });
         out.artifactId = artifactId;
+        opts.thread.outcome?.({ kind: 'artifact.produced', path: rel, detail: { artifactId, kind: 'docx-compare', summary } });
       }
       return out;
     },

--- a/runtime/src/vault/resolve-root.test.ts
+++ b/runtime/src/vault/resolve-root.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test';
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readVaultConfig, resolveLegalRoot } from './resolve-root';
+import { readVaultConfig, resolveLegalRoot, writeVaultConfigOverride } from './resolve-root';
 
 function tmpDir(prefix: string): string {
   return mkdtempSync(join(tmpdir(), prefix));
@@ -216,5 +216,46 @@ describe('readVaultConfig default_locality (providers spec §7)', () => {
     expect(readVaultConfig(root).defaultLocality).toBeUndefined();
     writeFileSync(join(root, 'config.md'), 'counsel-os-config: true\nlegal_root: x\n', 'utf8');
     expect(readVaultConfig(root).defaultLocality).toBeUndefined();
+  });
+});
+
+describe('readVaultConfig outcomes + classify (routing-and-evals spec §3, §7)', () => {
+  function withConfig(body: string): string {
+    const root = tmpDir('root-');
+    writeFileSync(join(root, 'config.md'), `counsel-os-config: true\nlegal_root: x\n${body}`, 'utf8');
+    return root;
+  }
+
+  test('outcomes is on unless the config says off/false/no', () => {
+    expect(readVaultConfig(withConfig('')).outcomes).toBeUndefined();
+    expect(readVaultConfig(withConfig('outcomes: on\n')).outcomes).toBeUndefined();
+    expect(readVaultConfig(withConfig('outcomes: off\n')).outcomes).toBe(false);
+    expect(readVaultConfig(withConfig('outcomes: no\n')).outcomes).toBe(false);
+    expect(readVaultConfig(withConfig('# outcomes: off\n')).outcomes).toBeUndefined();
+  });
+
+  test('classify is rules-only unless the config opts into the model', () => {
+    expect(readVaultConfig(withConfig('')).classify).toBeUndefined();
+    expect(readVaultConfig(withConfig('classify: rules\n')).classify).toBeUndefined();
+    expect(readVaultConfig(withConfig('classify: model\n')).classify).toBe('model');
+  });
+
+  test('writeVaultConfigOverride replaces a live line, uncomments a commented one, or appends', () => {
+    const root = withConfig('outcomes: on\n');
+    writeVaultConfigOverride(root, 'outcomes', 'off');
+    expect(readFileSync(join(root, 'config.md'), 'utf8')).toBe('counsel-os-config: true\nlegal_root: x\noutcomes: off\n');
+    expect(readVaultConfig(root).outcomes).toBe(false);
+
+    const commented = withConfig('# outcomes: off\n');
+    writeVaultConfigOverride(commented, 'outcomes', 'off');
+    expect(readFileSync(join(commented, 'config.md'), 'utf8')).toContain('\noutcomes: off\n');
+    expect(readFileSync(join(commented, 'config.md'), 'utf8')).not.toContain('# outcomes');
+
+    const bare = withConfig('');
+    writeVaultConfigOverride(bare, 'outcomes', 'off');
+    expect(readVaultConfig(bare).outcomes).toBe(false);
+    writeVaultConfigOverride(bare, 'outcomes', 'on');
+    expect(readVaultConfig(bare).outcomes).toBeUndefined();
+    expect(readFileSync(join(bare, 'config.md'), 'utf8').match(/^outcomes:/gm)).toHaveLength(1);
   });
 });

--- a/runtime/src/vault/resolve-root.ts
+++ b/runtime/src/vault/resolve-root.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, join } from 'node:path';
 
@@ -37,6 +37,14 @@ export interface VaultConfig {
    * its own frontmatter says `stays_local: false` (providers spec §7).
    * Absent → `any`. Optional so the literal `VaultConfig`s in tests stay. */
   defaultLocality?: 'local' | 'any';
+  /** `outcomes: off` — the vault keeps NO local record of decisions, marks
+   * and corrections (routing-and-evals spec §7). Absent → on. */
+  outcomes?: boolean;
+  /** `classify: model` — when no rule names a step's task, spend one small
+   * structured model call on it (routing-and-evals spec §3). Default: rules
+   * only, then `chat` — a model turn before every message is the lawyer's
+   * call, not the runtime's. */
+  classify?: 'rules' | 'model';
 }
 
 const CWD_WALK_MAX_DEPTH = 3;
@@ -247,5 +255,36 @@ export function readVaultConfig(root: string): VaultConfig {
     lawManagement: flag(findOverride('law_management')) === 'user' ? 'user' : 'plugin',
     ...(Number.isInteger(cadence) && cadence > 0 ? { retroCadenceDays: cadence } : {}),
     ...(flag(findOverride('default_locality')) === 'local' ? { defaultLocality: 'local' as const } : {}),
+    ...(['off', 'false', 'no'].includes(flag(findOverride('outcomes'))) ? { outcomes: false } : {}),
+    ...(flag(findOverride('classify')) === 'model' ? { classify: 'model' as const } : {}),
   };
+}
+
+/**
+ * Sets one `key: value` line in `{root}/config.md`: replaces the live line
+ * when there is one, uncomments a `# key: …` line when that is what exists,
+ * else appends. The marker lines are never touched. Used by the Settings
+ * switches that edit the vault's own config (spec §7's outcomes switch).
+ */
+export function writeVaultConfigOverride(root: string, key: string, value: string): void {
+  const path = join(root, 'config.md');
+  let text = '';
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    text = '';
+  }
+  const lines = text.split('\n');
+  const live = lines.findIndex(l => l.startsWith(`${key}:`));
+  if (live !== -1) {
+    lines[live] = `${key}: ${value}`;
+  } else {
+    const commented = lines.findIndex(l => /^#\s*/.test(l) && l.replace(/^#\s*/, '').startsWith(`${key}:`));
+    if (commented !== -1) lines[commented] = `${key}: ${value}`;
+    else {
+      if (lines.length > 0 && lines[lines.length - 1] === '') lines.pop();
+      lines.push(`${key}: ${value}`, '');
+    }
+  }
+  writeFileSync(path, lines.join('\n'), 'utf8');
 }

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -9,7 +9,7 @@
 import { parseSseChunk } from './sse';
 import { clearToken, readToken } from './token';
 import { reportUnauthorized } from './unauthorized';
-import type { StepBody, StreamEvent } from './types';
+import type { RunMark, StepBody, StreamEvent, TaskSource } from './types';
 
 /** A request that came back with a status the caller has to reason about.
  * `body` is the parsed JSON when there was any — 409 on approve carries the
@@ -82,6 +82,31 @@ export async function setProviderFields(id: string, fields: Record<string, strin
     method: 'PUT',
     body: JSON.stringify({ fields: clean }),
   });
+}
+
+/** `POST /threads/:id/turns/:runId/mark` (routing-and-evals spec §7): the
+ * lawyer's mark on one answer. The runtime keeps it on the run record. */
+export async function markTurn(threadId: string, runId: string, mark: 'useful' | 'not-right', reason?: string): Promise<RunMark> {
+  const body = await fetchJson<{ mark: RunMark }>(`/threads/${encodeURIComponent(threadId)}/turns/${encodeURIComponent(runId)}/mark`, {
+    method: 'POST',
+    body: JSON.stringify({ mark, ...(reason === undefined || reason.trim() === '' ? {} : { reason: reason.trim() }) }),
+  });
+  return body.mark;
+}
+
+/** `PATCH /threads/:id/steps/:runId/task` (spec §3): the lawyer corrects
+ * what kind of work a step was. */
+export async function correctTask(threadId: string, runId: string, task: string): Promise<{ task: string; taskSource: TaskSource }> {
+  return fetchJson(`/threads/${encodeURIComponent(threadId)}/steps/${encodeURIComponent(runId)}/task`, {
+    method: 'PATCH',
+    body: JSON.stringify({ task }),
+  });
+}
+
+/** `PATCH /settings/vault` — the vault's own switches (`config.md`). */
+export async function setVaultOutcomes(outcomes: boolean): Promise<boolean> {
+  const body = await fetchJson<{ outcomes: boolean }>('/settings/vault', { method: 'PATCH', body: JSON.stringify({ outcomes }) });
+  return body.outcomes;
 }
 
 export async function deleteProviderKey(id: string): Promise<void> {

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -52,7 +52,7 @@ export type ProposalStatus = 'pending' | 'approved' | 'rejected';
  * `t`, the step events embedded in the log use `type`. */
 export type ThreadEvent =
   | { t: 'user'; at: string; content: string }
-  | { t: 'step'; at: string; runId: string; provider: string; task?: string }
+  | { t: 'step'; at: string; runId: string; provider: string; task?: string; taskSource?: TaskSource }
   | { t: 'warning'; at: string; message: string }
   | (StepEvent & { at: string })
   | {
@@ -113,6 +113,17 @@ export interface ToolCallLog {
 
 export type RunStatus = 'running' | 'done' | 'error' | 'timeout' | 'abandoned';
 
+/** Where a step's task came from (routing-and-evals spec §3). COPIED from
+ * `runtime/src/tasks/taxonomy.ts`. */
+export type TaskSource = 'caller' | 'rule' | 'model' | 'default' | 'corrected';
+
+/** The lawyer's mark on an answer (spec §7), kept on the run record. */
+export interface RunMark {
+  mark: 'useful' | 'not-right';
+  reason?: string;
+  at: string;
+}
+
 export interface RunRecord {
   runId: string;
   threadId: string;
@@ -123,6 +134,8 @@ export interface RunRecord {
   message: string;
   provider: string;
   task?: string;
+  taskSource?: TaskSource;
+  mark?: RunMark;
   primitivesRead: string[];
   toolCalls: ToolCallLog[];
   proposals: string[];
@@ -188,6 +201,9 @@ export interface Health {
    * registry accepts a default you have not added yet. */
   default: string | null;
   stepTimeoutMs: number;
+  /** Whether the vault keeps its local record of decisions and marks
+   * (routing-and-evals spec §7). Absent on an older runtime. */
+  outcomes?: boolean;
 }
 
 /** The body of `POST /threads/:id/steps`. */

--- a/runtime/ui/src/settings/Health.test.tsx
+++ b/runtime/ui/src/settings/Health.test.tsx
@@ -1,0 +1,68 @@
+import { cleanup, render, screen, userEvent, waitFor } from '../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../api/token';
+import type { Health as HealthData, SettingsView } from '../api/types';
+import { Health } from './Health';
+
+const health: HealthData = { vault: '/Users/jack/legal', tenant: 'default', providers: [], default: 'fake/fake', stepTimeoutMs: 120000, outcomes: true };
+const effective: SettingsView['effective'] = { default: 'fake/fake', stepTimeoutMs: 120000, providers: [] };
+
+const realFetch = globalThis.fetch;
+let patches: unknown[] = [];
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function install(answer: (body: { outcomes: boolean }) => Response): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    if (url === '/settings/vault' && init?.method === 'PATCH') {
+      const body = JSON.parse(String(init.body)) as { outcomes: boolean };
+      patches.push(body);
+      return answer(body);
+    }
+    throw new Error(`unexpected fetch: ${init?.method ?? 'GET'} ${url}`);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  patches = [];
+  sessionStorage.setItem(TOKEN_KEY, 'test-token');
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+describe('the Decisions and marks switch (routing-and-evals spec §7)', () => {
+  test('reads the runtime, and one set-text link flips it through PATCH /settings/vault', async () => {
+    install(body => json({ outcomes: body.outcomes }));
+    render(<Health health={health} effective={effective} file="/Users/jack/.counsel-os/providers.yaml" />);
+    expect(screen.getByText('Decisions and marks')).toBeTruthy();
+    expect(screen.getByText(/kept locally · on/)).toBeTruthy();
+
+    await userEvent.click(screen.getByRole('button', { name: 'turn off' }));
+    await waitFor(() => expect(screen.getByText(/not kept · off/)).toBeTruthy());
+    expect(patches).toEqual([{ outcomes: false }]);
+    expect(screen.getByRole('button', { name: 'turn on' })).toBeTruthy();
+  });
+
+  test('an older runtime that does not report the switch shows no row', () => {
+    const { outcomes: _drop, ...older } = health;
+    render(<Health health={older} effective={effective} file="/x/providers.yaml" />);
+    expect(screen.queryByText('Decisions and marks')).toBeNull();
+  });
+
+  test('a refused flip says so and keeps the runtime\'s answer', async () => {
+    install(() => json({ error: 'config.md is read-only' }, 500));
+    render(<Health health={health} effective={effective} file="/x/providers.yaml" />);
+    await userEvent.click(screen.getByRole('button', { name: 'turn off' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByText(/kept locally · on/)).toBeTruthy();
+  });
+});

--- a/runtime/ui/src/settings/Health.tsx
+++ b/runtime/ui/src/settings/Health.tsx
@@ -1,4 +1,5 @@
-import { signOut } from '../api/client';
+import { useState } from 'react';
+import { ApiError, setVaultOutcomes, signOut } from '../api/client';
 import { dataLineOf } from '../v2/vendors';
 import type { Health as HealthData, SettingsView } from '../api/types';
 
@@ -41,6 +42,29 @@ export function timeoutInWords(ms: number): string {
 }
 
 export function Health({ health, effective, file, secrets }: HealthProps): JSX.Element {
+  // The vault's record of decisions and marks (routing-and-evals spec §7):
+  // one switch, written to config.md by the runtime. Seeded from /health;
+  // a flip keeps the answer the runtime returned.
+  const [outcomes, setOutcomes] = useState<boolean | undefined>(health?.outcomes);
+  const [seededFrom, setSeededFrom] = useState(health?.outcomes);
+  if (health?.outcomes !== seededFrom) {
+    setSeededFrom(health?.outcomes);
+    setOutcomes(health?.outcomes);
+  }
+  const [flipping, setFlipping] = useState(false);
+  const [flipFailed, setFlipFailed] = useState<string | null>(null);
+  const flip = async (): Promise<void> => {
+    if (outcomes === undefined) return;
+    setFlipping(true);
+    setFlipFailed(null);
+    try {
+      setOutcomes(await setVaultOutcomes(!outcomes));
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setFlipFailed(err instanceof Error ? err.message : String(err));
+    } finally {
+      setFlipping(false);
+    }
+  };
   return (
     <section className="settings-health">
       <h2>Runtime</h2>
@@ -92,7 +116,31 @@ export function Health({ health, effective, file, secrets }: HealthProps): JSX.E
           </dt>
           <dd>{keysInWords(secrets, file)}</dd>
         </div>
+        {outcomes === undefined ? null : (
+          <div className="fact">
+            <dt>
+              Decisions and marks
+              <span className="leader" aria-hidden="true" />
+            </dt>
+            <dd>
+              {outcomes ? 'kept locally · on' : 'not kept · off'}
+              {' · '}
+              <button type="button" className="v2-link" disabled={flipping} onClick={() => void flip()}>
+                {outcomes ? 'turn off' : 'turn on'}
+              </button>
+              {flipFailed === null ? null : (
+                <span className="v2-marks-failed" role="alert">
+                  {' — '}
+                  {flipFailed}
+                </span>
+              )}
+            </dd>
+          </div>
+        )}
       </dl>
+      <p className="muted">
+        Decisions and marks is the vault&rsquo;s own record of what you did with counsel&rsquo;s work — approvals, rejections, useful / not right, task corrections. It stays in <code>.counsel/outcomes.jsonl</code> on this machine, is never sent anywhere, and feeds the retro. Off stops every write.
+      </p>
 
       <p className="muted settings-signout">
         This browser is signed in to the runtime and stays so across tabs and restarts.{' '}

--- a/runtime/ui/src/settings/ProviderCombo.tsx
+++ b/runtime/ui/src/settings/ProviderCombo.tsx
@@ -14,6 +14,9 @@ export interface ProviderComboProps {
   options: string[];
   /** Shown when the field is empty — the value the runtime falls back to. */
   placeholder?: string;
+  /** The toggle's own accessible name. Default `Show providers`; a field
+   * that lists something else (the task taxonomy) names it itself. */
+  toggleLabel?: string;
   onChange(value: string): void;
 }
 
@@ -27,7 +30,7 @@ export interface ProviderComboProps {
  * positioned sibling of the input, which keeps it inside the form's DOM for
  * tests and screen readers alike.
  */
-export function ProviderCombo({ id, label, value, options, placeholder, onChange }: ProviderComboProps): JSX.Element {
+export function ProviderCombo({ id, label, value, options, placeholder, onChange, toggleLabel }: ProviderComboProps): JSX.Element {
   const { contains } = useFilter({ sensitivity: 'base' });
   const items = options.map(option => ({ id: option }));
   const children = (item: { id: string }): JSX.Element => <Item textValue={item.id}>{item.id}</Item>;
@@ -67,7 +70,7 @@ export function ProviderCombo({ id, label, value, options, placeholder, onChange
           ref={buttonRef}
           type="button"
           className="v2-combo-toggle"
-          aria-label="Show providers"
+          aria-label={toggleLabel ?? 'Show providers'}
           aria-labelledby={undefined}
         >
           {/* Always down: a dropdown trigger points down open or closed —

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -456,6 +456,16 @@ a { color: var(--accent); }
 .v2-record dt { color: var(--fg-muted); }
 .v2-record dd { margin: 0; }
 .v2-record-id { margin-right: var(--s2); }
+.v2-record-source { color: var(--fg-faint); }
+.v2-task-pick { vertical-align: baseline; }
+.v2-task-pop { min-width: 160px; }
+/* The lawyer's mark (routing-and-evals spec §7): two words under the strip,
+   set text like every other verb on the page; the chosen one goes to the
+   text weight via `aria-pressed`. */
+.v2-marks { margin: 4px 0 0; font: 12px var(--sans); color: var(--fg-faint); }
+.v2-marks .v2-link { font-size: 12px; color: var(--fg-faint); }
+.v2-marks .v2-link[aria-pressed="true"] { color: var(--fg); }
+.v2-marks-failed { color: var(--error); }
 
 /* ── v2 proposal slip ─────────────────────────────────────────────────── */
 
@@ -784,6 +794,10 @@ a { color: var(--accent); }
 .v2-slip-why { padding: 0 2px 10px; margin: 0; color: var(--fg-muted); font: 14px/1.5 var(--sans); }
 .v2-slip-acts { display: flex; gap: 8px; align-items: center; padding: 10px 2px; }
 .v2-slip-base { margin-left: auto; font-size: 12px; color: var(--fg-faint); }
+.v2-slip-reason-link { font-size: 12px; }
+.v2-slip-reason { display: flex; gap: 8px; align-items: baseline; padding: 6px 2px 0; font-size: 12.5px; }
+.v2-slip-reason-label { color: var(--fg-muted); }
+.v2-slip-reason input { flex: 1; font: 12.5px var(--sans); padding: 3px 6px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: var(--radius); color: var(--fg); }
 
 /* Word-style tracked changes: the document itself, marked up inline. */
 .v2-redline { border: 1px solid var(--border); border-radius: 6px; background: var(--bg-raised); padding: 14px 18px; margin: 0 0 2px; font: 15px/1.7 var(--serif); max-height: 24rem; overflow: auto; }

--- a/runtime/ui/src/tasks.ts
+++ b/runtime/ui/src/tasks.ts
@@ -1,0 +1,27 @@
+/**
+ * The legal task taxonomy the runtime speaks (routing-and-evals spec §3).
+ * COPIED from `runtime/src/tasks/taxonomy.ts`; a change there is a change
+ * here. The page uses it for the task picker on a turn's record and for the
+ * Task field of a route — as suggestions there, never a constraint.
+ */
+export const TASK_IDS: readonly string[] = ['review', 'redline', 'draft', 'research', 'extract', 'summarize', 'compare', 'remember', 'docket', 'retro', 'chat'];
+
+export type TaskSource = 'caller' | 'rule' | 'model' | 'default' | 'corrected';
+
+/** Where a step's task came from, in the words a reader of the record sees. */
+export function sourceWord(source: TaskSource | undefined): string {
+  switch (source) {
+    case 'caller':
+      return 'stated';
+    case 'rule':
+      return 'by rule';
+    case 'model':
+      return 'guessed';
+    case 'corrected':
+      return 'corrected';
+    case 'default':
+      return 'by default';
+    default:
+      return '';
+  }
+}

--- a/runtime/ui/src/v2/chat/ProposalCard.test.tsx
+++ b/runtime/ui/src/v2/chat/ProposalCard.test.tsx
@@ -332,3 +332,32 @@ describe('ProposalCard as the docket anchor', () => {
     }
   });
 });
+
+describe('a reason on the decision (routing-and-evals spec §7)', () => {
+  test('closed by default; `add a reason` opens the field and the reason rides with the decision', async () => {
+    install({ approve: () => json({ proposal: { ...proposal, status: 'rejected' }, version: null }) });
+    render(<ProposalCard threadId="t-1" proposal={proposal} onReload={() => {}} />);
+    await waitFor(() => expect(marks('del').length).toBeGreaterThan(0));
+    expect(screen.queryByLabelText('Reason')).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'add a reason' }));
+    const field = screen.getByLabelText('Reason') as HTMLInputElement;
+    expect(field.maxLength).toBe(500);
+    await userEvent.type(field, 'Too broad for the standard.');
+    await userEvent.click(screen.getByRole('button', { name: 'Reject' }));
+
+    await waitFor(() => expect(screen.getByText(/rejected/)).toBeTruthy());
+    expect(calls.at(-1)).toEqual({ url: '/threads/t-1/approve', body: { proposalId: 'p-1', decision: 'reject', reason: 'Too broad for the standard.' } });
+  });
+
+  test('an empty reason is not sent', async () => {
+    install({ approve: () => json({ proposal: { ...proposal, status: 'approved' }, version: 'new0000' }) });
+    render(<ProposalCard threadId="t-1" proposal={proposal} onReload={() => {}} />);
+    await waitFor(() => expect(marks('del').length).toBeGreaterThan(0));
+    await userEvent.click(screen.getByRole('button', { name: 'add a reason' }));
+    await userEvent.type(screen.getByLabelText('Reason'), '   ');
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    await waitFor(() => expect(screen.getByText(/✓ approved/)).toBeTruthy());
+    expect(calls.at(-1)).toEqual({ url: '/threads/t-1/approve', body: { proposalId: 'p-1', decision: 'approve' } });
+  });
+});

--- a/runtime/ui/src/v2/chat/ProposalCard.tsx
+++ b/runtime/ui/src/v2/chat/ProposalCard.tsx
@@ -80,6 +80,10 @@ export function ProposalCard({ threadId, proposal, onReload, onDecided, onOpenFi
   }, [anchor, proposal.id]);
   const [status, setStatus] = useState<ProposalStatus>(proposal.status);
   const [decidedAt, setDecidedAt] = useState<string | undefined>(undefined);
+  // An optional word on WHY (routing-and-evals spec §7): closed by default,
+  // one set-text link opens the field; the reason rides with the decision.
+  const [askReason, setAskReason] = useState(false);
+  const [reason, setReason] = useState('');
   const [busy, setBusy] = useState(false);
   const [conflict, setConflict] = useState<Conflict | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -125,7 +129,7 @@ export function ProposalCard({ threadId, proposal, onReload, onDecided, onOpenFi
     try {
       const result = await fetchJson<ApproveResult>(`/threads/${encodeURIComponent(threadId)}/approve`, {
         method: 'POST',
-        body: JSON.stringify({ proposalId: proposal.id, decision }),
+        body: JSON.stringify({ proposalId: proposal.id, decision, ...(reason.trim() === '' ? {} : { reason: reason.trim() }) }),
       });
       setStatus(result.proposal?.status ?? (decision === 'approve' ? 'approved' : 'rejected'));
       setDecidedAt(new Date().toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }).toLowerCase());
@@ -285,6 +289,14 @@ export function ProposalCard({ threadId, proposal, onReload, onDecided, onOpenFi
         </>
       )}
 
+      {status === 'pending' && conflict === null && askReason ? (
+        <div className="v2-slip-reason">
+          <label htmlFor={`v2-reason-${proposal.id}`} className="v2-slip-reason-label">
+            Reason
+          </label>
+          <input id={`v2-reason-${proposal.id}`} value={reason} maxLength={500} placeholder="optional — why you decided this way" onChange={e => setReason(e.target.value)} />
+        </div>
+      ) : null}
       {status === 'pending' && conflict === null ? (
         <div className="v2-slip-acts">
           <button type="button" className="v2-primary" disabled={busy} onClick={() => void decide('approve')}>
@@ -293,6 +305,11 @@ export function ProposalCard({ threadId, proposal, onReload, onDecided, onOpenFi
           <button type="button" disabled={busy} onClick={() => void decide('reject')}>
             Reject
           </button>
+          {askReason ? null : (
+            <button type="button" className="v2-link v2-slip-reason-link" onClick={() => setAskReason(true)}>
+              add a reason
+            </button>
+          )}
           {current.state === 'ready' && current.version !== null ? (
             <span className="v2-slip-base">against version {current.version.slice(0, 7)}</span>
           ) : null}

--- a/runtime/ui/src/v2/chat/Strip.test.tsx
+++ b/runtime/ui/src/v2/chat/Strip.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, render, screen, userEvent } from '../../test/dom';
+import { cleanup, render, screen, userEvent, waitFor } from '../../test/dom';
 
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../../api/token';
 import type { RunRecord } from '../../api/types';
 import { emptyAssistantTurn, type AssistantTurn } from '../../chat/turns';
 import { pillFor, shortId, Strip, stripLine } from './Strip';
@@ -38,7 +39,33 @@ const run: RunRecord = {
   durationMs: 1640,
 };
 
-afterEach(cleanup);
+const realFetch = globalThis.fetch;
+let posts: { url: string; method: string; body: unknown }[] = [];
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+}
+
+function install(answer: (url: string, body: Record<string, unknown>) => Response): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    const body = init?.body === undefined ? {} : (JSON.parse(String(init.body)) as Record<string, unknown>);
+    posts.push({ url, method: init?.method ?? 'GET', body });
+    return answer(url, body);
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  posts = [];
+  sessionStorage.setItem(TOKEN_KEY, 'test-token');
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
 
 describe('pillFor', () => {
   test('the run record wins; a turn alone reads its own status', () => {
@@ -189,5 +216,60 @@ describe('stripLine with produced documents', () => {
       artifacts: [{ id: 'a-1', kind: 'docx-redline', path: 'matters/acme/nda-redline.docx', summary: { changes: 1, comments: 0, applied: 1, skipped: 0, clauses: 1, bytes: 10 }, tracked: true }],
     });
     expect(stripLine(produced)).toBe('1 source · 1 document produced');
+  });
+});
+
+describe('the task and the marks (routing-and-evals spec §3, §7)', () => {
+  test('the record names the task and where it came from; outside a thread there is nothing to click', async () => {
+    render(<Strip turn={turn} run={{ ...run, task: 'redline', taskSource: 'rule' }} ms={{}} />);
+    await userEvent.click(document.querySelector('summary') as HTMLElement);
+    const cell = document.querySelector('.v2-record-task') as HTMLElement;
+    expect(cell.textContent).toBe('redline · by rule');
+    expect(screen.queryByRole('button', { name: 'change' })).toBeNull();
+    expect(document.querySelector('.v2-marks')).toBeNull();
+  });
+
+  test('inside a thread: `change` opens the closed taxonomy, a pick PATCHes the step and the line says corrected', async () => {
+    install((url, body) => (url.endsWith('/task') ? json({ task: body.task, taskSource: 'corrected' }) : json({}, 404)));
+    render(<Strip turn={turn} run={{ ...run, task: 'chat', taskSource: 'default' }} ms={{}} threadId="t-1" />);
+    await userEvent.click(document.querySelector('summary') as HTMLElement);
+    expect((document.querySelector('.v2-record-task') as HTMLElement).textContent).toBe('chat · by default · change');
+
+    await userEvent.click(screen.getByRole('button', { name: 'change' }));
+    const items = Array.from(document.querySelectorAll('.v2-task-pop .v2-switch-item'), el => el.textContent?.trim());
+    expect(items).toEqual(['review', 'redline', 'draft', 'research', 'extract', 'summarize', 'compare', 'remember', 'docket', 'retro', 'chat']);
+
+    await userEvent.click(screen.getByText('review'));
+    await waitFor(() => expect((document.querySelector('.v2-record-task') as HTMLElement).textContent).toBe('review · corrected · change'));
+    expect(posts).toEqual([{ url: '/threads/t-1/steps/r-1/task', method: 'PATCH', body: { task: 'review' } }]);
+    expect(document.querySelector('.v2-task-pop')).toBeNull();
+  });
+
+  test('useful · not right under the strip: a click POSTs the mark and the chosen word is set', async () => {
+    install((url, body) => (url.endsWith('/mark') ? json({ mark: { mark: body.mark, at: '2026-09-02T00:00:00.000Z' } }) : json({}, 404)));
+    render(<Strip turn={turn} run={run} ms={{}} threadId="t-1" />);
+    const useful = screen.getByRole('button', { name: 'useful' });
+    const notRight = screen.getByRole('button', { name: 'not right' });
+    expect(useful.getAttribute('aria-pressed')).toBe('false');
+
+    await userEvent.click(notRight);
+    await waitFor(() => expect(notRight.getAttribute('aria-pressed')).toBe('true'));
+    expect(useful.getAttribute('aria-pressed')).toBe('false');
+    expect(posts).toEqual([{ url: '/threads/t-1/turns/r-1/mark', method: 'POST', body: { mark: 'not-right' } }]);
+  });
+
+  test('a mark already on the record shows as chosen; a failed post says so and keeps the old answer', async () => {
+    install(() => json({ error: 'vault is read-only' }, 500));
+    render(<Strip turn={turn} run={{ ...run, mark: { mark: 'useful', at: '2026-09-02T00:00:00.000Z' } }} ms={{}} threadId="t-1" />);
+    expect(screen.getByRole('button', { name: 'useful' }).getAttribute('aria-pressed')).toBe('true');
+
+    await userEvent.click(screen.getByRole('button', { name: 'not right' }));
+    await waitFor(() => expect(screen.getByRole('alert')).toBeTruthy());
+    expect(screen.getByRole('button', { name: 'useful' }).getAttribute('aria-pressed')).toBe('true');
+  });
+
+  test('a run that is not done cannot be marked', () => {
+    render(<Strip turn={{ ...turn, status: 'error' }} run={{ ...run, status: 'error' }} ms={{}} threadId="t-1" />);
+    expect(document.querySelector('.v2-marks')).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/chat/Strip.tsx
+++ b/runtime/ui/src/v2/chat/Strip.tsx
@@ -1,4 +1,8 @@
-import type { RunRecord, RunStatus } from '../../api/types';
+import { useState } from 'react';
+import { ApiError, correctTask, markTurn } from '../../api/client';
+import type { RunMark, RunRecord, RunStatus, TaskSource } from '../../api/types';
+import { sourceWord } from '../../tasks';
+import { TaskPicker } from './TaskPicker';
 import type { AssistantTurn } from '../../chat/turns';
 import { Chevron } from '../icons';
 import { stateOf } from '../verbs';
@@ -11,6 +15,9 @@ export interface StripProps {
   run?: RunRecord;
   /** Milliseconds per tool id (from the record, or measured live). */
   ms: Record<string, number>;
+  /** The thread the run belongs to — the marks and the task picker need it.
+   * `null` (or absent) hides both: nothing to post against. */
+  threadId?: string | null;
   onOpenFile?: (path: string) => void;
 }
 
@@ -81,8 +88,44 @@ export function stripLine(turn: AssistantTurn): string {
  * Open, it is the full record — the steps with show/hide, primitives read,
  * proposals, usage and cost, the run id.
  */
-export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
+export function Strip({ turn, run, ms, threadId = null, onOpenFile }: StripProps): JSX.Element {
   const pill = pillFor(turn, run);
+  // The lawyer's word on the answer and on the task (routing-and-evals spec
+  // §3, §7): the record on disk seeds both; a click posts and the page keeps
+  // the answer without a reload.
+  const [mark, setMark] = useState<RunMark | undefined>(run?.mark);
+  const [task, setTask] = useState<{ task: string; source: TaskSource | undefined } | undefined>(run?.task === undefined ? undefined : { task: run.task, source: run.taskSource });
+  const [busy, setBusy] = useState(false);
+  const [postFailed, setPostFailed] = useState<string | null>(null);
+  const [synced, setSynced] = useState(run);
+  if (run !== synced) {
+    setSynced(run);
+    setMark(run?.mark);
+    setTask(run?.task === undefined ? undefined : { task: run.task, source: run.taskSource });
+  }
+  const canAct = run !== undefined && threadId !== null && run.status === 'done';
+  const post = async (work: () => Promise<void>): Promise<void> => {
+    setBusy(true);
+    setPostFailed(null);
+    try {
+      await work();
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setPostFailed(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+  const doMark = (value: RunMark['mark']): void => {
+    if (run === undefined || threadId === null) return;
+    void post(async () => setMark(await markTurn(threadId, run.runId, value)));
+  };
+  const doTask = (value: string): void => {
+    if (run === undefined || threadId === null) return;
+    void post(async () => {
+      const next = await correctTask(threadId, run.runId, value);
+      setTask({ task: next.task, source: next.taskSource });
+    });
+  };
   const provider = run?.provider !== undefined && run.provider !== '' ? run.provider : (turn.provider ?? '');
   // `stripLine` counts sources and pending proposals, so a failed call is
   // invisible in it. Carried alongside rather than folded in: the count is
@@ -93,6 +136,7 @@ export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
   // instead of an empty vault.
   const empty = turn.tools.filter(tool => stateOf(tool) === 'empty').length;
   return (
+    <>
     <details className="v2-strip" data-status={pill.kind} data-testid={run === undefined ? undefined : `run-${run.runId}`}>
       <summary>
         <span className={`v2-pill v2-pill-${pill.kind} v2-strip-status`} title={pill.title}>
@@ -123,10 +167,19 @@ export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
                 <dd>{formatMs(run.durationMs)}</dd>
               </>
             )}
-            {run.task === undefined ? null : (
+            {task === undefined ? null : (
               <>
                 <dt>Task</dt>
-                <dd>{run.task}</dd>
+                <dd className="v2-record-task">
+                  {task.task}
+                  {sourceWord(task.source) === '' ? null : <span className="v2-record-source"> · {sourceWord(task.source)}</span>}
+                  {canAct ? (
+                    <>
+                      {' · '}
+                      <TaskPicker current={task.task} onPick={doTask} />
+                    </>
+                  ) : null}
+                </dd>
               </>
             )}
             <dt>Primitives read</dt>
@@ -172,5 +225,26 @@ export function Strip({ turn, run, ms, onOpenFile }: StripProps): JSX.Element {
         )}
       </div>
     </details>
+    {/* The lawyer's mark: two set-text words under the strip, the chosen one
+        set in the text weight (`aria-pressed`), never a thumbs pair of icons.
+        Only a finished run can be marked, and only from inside its thread. */}
+    {canAct ? (
+      <p className="v2-marks">
+        <button type="button" className="v2-link" aria-pressed={mark?.mark === 'useful'} disabled={busy} onClick={() => doMark('useful')}>
+          useful
+        </button>
+        {' · '}
+        <button type="button" className="v2-link" aria-pressed={mark?.mark === 'not-right'} disabled={busy} onClick={() => doMark('not-right')}>
+          not right
+        </button>
+        {postFailed === null ? null : (
+          <span className="v2-marks-failed" role="alert">
+            {' — '}
+            {postFailed}
+          </span>
+        )}
+      </p>
+    ) : null}
+    </>
   );
 }

--- a/runtime/ui/src/v2/chat/TaskPicker.tsx
+++ b/runtime/ui/src/v2/chat/TaskPicker.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import { useButton, useMenuTrigger } from 'react-aria';
+import { Item, useMenuTriggerState } from 'react-stately';
+import { TASK_IDS } from '../../tasks';
+import { HeadlessMenu } from '../menu';
+
+export interface TaskPickerProps {
+  /** The step's task as recorded. */
+  current: string;
+  /** A pick of a DIFFERENT task from the closed set. */
+  onPick(task: string): void;
+}
+
+interface Row {
+  id: string;
+}
+
+/**
+ * The record's task picker (routing-and-evals spec §3): a set-text `change`
+ * that opens the closed taxonomy. The same headless menu as the matter
+ * picker — no portal, no pill; the popover sits inside the record.
+ */
+export function TaskPicker({ current, onPick }: TaskPickerProps): JSX.Element {
+  const state = useMenuTriggerState({});
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const wrapRef = useRef<HTMLSpanElement | null>(null);
+  const { menuTriggerProps, menuProps } = useMenuTrigger<Row>({}, state, triggerRef);
+  const { buttonProps } = useButton(menuTriggerProps, triggerRef);
+
+  const closeRef = useRef(state.close);
+  closeRef.current = state.close;
+  useEffect(() => {
+    if (!state.isOpen) return;
+    const onDown = (event: Event): void => {
+      const target = event.target;
+      if (wrapRef.current !== null && target instanceof globalThis.Node && !wrapRef.current.contains(target)) {
+        closeRef.current();
+      }
+    };
+    document.addEventListener('pointerdown', onDown);
+    return () => document.removeEventListener('pointerdown', onDown);
+  }, [state.isOpen]);
+
+  const rows: Row[] = TASK_IDS.map(id => ({ id }));
+  const act = (key: React.Key): void => {
+    state.close();
+    const id = String(key);
+    if (id !== current) onPick(id);
+  };
+
+  return (
+    <span className="v2-matter-pick v2-task-pick" ref={wrapRef}>
+      <button {...buttonProps} ref={triggerRef} type="button" className="v2-thread-link">
+        change
+      </button>
+      {state.isOpen ? (
+        <div
+          className="v2-matter-pop v2-task-pop"
+          onKeyDown={event => {
+            if (event.key === 'Escape') {
+              state.close();
+              triggerRef.current?.focus();
+            }
+          }}
+        >
+          <HeadlessMenu {...menuProps} label="Correct the task" items={rows} autoFocus={state.focusStrategy || true} onAction={act} onClose={state.close}>
+            {(row: Row) => (
+              <Item textValue={row.id}>
+                <span className="v2-plate-vendor">
+                  <span className={row.id === current ? 'v2-dot' : 'v2-dot v2-dot-off'} aria-hidden="true" />
+                  {row.id}
+                </span>
+              </Item>
+            )}
+          </HeadlessMenu>
+        </div>
+      ) : null}
+    </span>
+  );
+}

--- a/runtime/ui/src/v2/chat/Turn.tsx
+++ b/runtime/ui/src/v2/chat/Turn.tsx
@@ -246,7 +246,7 @@ export function TurnView({ turn, threadId, run, live = false, liveMs = {}, onRel
             <ArtifactSlip key={artifact.id} artifact={artifact} onOpenFile={onOpenFile} />
           ))}
 
-          <Strip turn={turn} run={run} ms={ms} onOpenFile={onOpenFile} />
+          <Strip turn={turn} run={run} ms={ms} threadId={threadId} onOpenFile={onOpenFile} />
         </>
       )}
     </article>

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -438,3 +438,24 @@ describe('the enterprise vendors in Settings (providers spec §3 step 5)', () =>
     expect(puts).toHaveLength(0);
   });
 });
+
+describe('the Task field (routing-and-evals spec §3)', () => {
+  test('offers the closed taxonomy and still takes a typed name', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByLabelText('Task')).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Show tasks' }));
+    const listed = Array.from(document.querySelectorAll('.v2-combo-item'), el => el.textContent);
+    expect(listed).toEqual(['review', 'redline', 'draft', 'research', 'extract', 'summarize', 'compare', 'remember', 'docket', 'retro', 'chat']);
+    await userEvent.click(screen.getByText('redline'));
+    await waitFor(() => expect(document.querySelector('.v2-combo-pop')).toBeNull());
+    const field = screen.getByLabelText('Task') as HTMLInputElement;
+    expect(field.value).toBe('redline');
+
+    const user = userEvent.setup({ document });
+    await user.clear(field);
+    await user.type(field, 'classify');
+    expect(field.value).toBe('classify');
+  });
+});

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -10,6 +10,7 @@ import { addableVendors, dataLineFor, isEnterpriseVendor, pickerLabel, prefixOf,
 import { EnterpriseFields } from './EnterpriseFields';
 import { KeyControl } from './KeyControl';
 import { ContentGroup } from './ContentGroup';
+import { TASK_IDS } from '../../tasks';
 import { DoctorLedger } from './DoctorLedger';
 import { RetroAction } from './RetroAction';
 import {
@@ -465,8 +466,10 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
             <div className="v2-provider" key={row.key}>
               <div className="v2-provider-grid">
                 <div className="field">
-                  <label htmlFor={`v2-${row.key}-task`}>Task</label>
-                  <input id={`v2-${row.key}-task`} value={row.task} placeholder="review" onChange={e => patchRoute(index, { task: e.target.value })} />
+                  {/* The closed taxonomy as suggestions (routing-and-evals
+                      spec §3); a typed name still goes through — the route
+                      shape allows a custom task. */}
+                  <ProviderCombo id={`v2-${row.key}-task`} label="Task" value={row.task} options={[...TASK_IDS]} placeholder="review" toggleLabel="Show tasks" onChange={value => patchRoute(index, { task: value })} />
                   <FieldError message={errors[`route.${row.key}.task`] ?? errors[`tasks.${name}`]} />
                 </div>
                 <div className="field">


### PR DESCRIPTION
Spec: `docs/superpowers/specs/2026-09-02-routing-and-evals-design.md` §3, §7, §11 step 1. Plan: `docs/superpowers/plans/2026-09-02-routing-1.md`.

## What

- **Task taxonomy** (`runtime/src/tasks/taxonomy.ts`): the closed set `review · redline · draft · research · extract · summarize · compare · remember · docket · retro · chat`, each with a one-line definition and a default scorer.
- **Classification** (`runtime/src/tasks/classify.ts`): caller > thread > rules > model > `chat`. The model classifier is an injected loop dependency (`deps.classifier`) and **opt-in** via `classify: model` in `config.md` (default rules-only). The step event and the run record carry `task` + `taskSource` (`caller | rule | model | default | corrected`).
- **Outcomes record** (`runtime/src/outcomes/store.ts`): `.counsel/outcomes.jsonl`, 0600 under a 0700 dir, one line per `proposal.decided` (with optional `reason`), `answer.marked`, `task.corrected`, `artifact.produced` (redline + compare), `thread.deleted`. `outcomes: off` stops every write; `/health` reports `outcomes`.
- **Routes**: `POST /threads/:id/turns/:runId/mark`, `PATCH /threads/:id/steps/:runId/task`, `GET /outcomes?since=`, `PATCH /settings/vault {outcomes}`; `reason` on approve.
- **Retro evidence**: a *Decisions and marks* section with the period's counts.
- **UI**: the turn's record shows `task · by rule · change` with a headless-menu picker; `useful · not right` set-text marks under the strip (persisted on the run record); the proposal slip's `add a reason`; the Task route field offers the taxonomy (custom still allowed); Settings → Runtime → *Decisions and marks · turn off/on*.
- Docs: `CONFIGURATION.md` (`outcomes`, `classify`), CHANGELOG Unreleased.

## Tests

| suite | before | after |
|---|---|---|
| runtime (`bun run test`) | 1032 | 1072 |
| ui (`bun run ui:test`) | 521 | 532 |

Both typechecks and `ui:build` green.

## Decisions to review

1. **Model classifier opt-in** (`classify: model`). Wired by default it consumed a scripted fake-provider turn in every route/serve test (11 failures) and would spend a metered turn before every chat message. Rules run always.
2. **Custom route names stay**: `classifyTask` keeps a caller's or thread's task as given even outside the taxonomy (e.g. `classify`), so existing routes keep working; only the correction endpoint enforces the closed set.
3. **No reason field on marks in the UI** (the API takes one): two words under the strip, nothing more; the proposal slip is where a reason belongs.
4. The setup-generated `config.md` template is untouched (absent = on); the two new keys are documented, not seeded.

## Concerns

- `docx-tools.ts` local `thread` option type duplicates the `builtin.ts` shape for `outcome?`; a shared type would be cleaner (left as-is to keep the diff local).
- `Strip` now returns a fragment (`<details>` + the marks `<p>`); `Turn.tsx` wraps it fine, but any CSS that assumed the strip is the last child of the turn should be checked visually.