### PR TITLE
Routing and evals, step 4 — the scoreboard picks the model, and the step says why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+Routing from the scoreboard (routing-and-evals spec §6)
+
+- The scoreboard picks the model for a task: candidates clear the task's bar on the practice's own fixtures, or the shipped suite until the practice has its own; a pin wins among them; `cost` and `latency` choose only among peers within 0.05 of the best score, so a cheaper model never displaces a materially better answer.
+- Two things routing will not do: send a matter that stays on this machine to the cloud, however well a cloud model scores; or refuse to answer for want of a measurement — an unscored task falls to the configured route and the default, as before.
+- Every run records why its model answered — the scoreboard, a pin, the route, the default, or the matter's policy — and the record shows it beside the model.
+- `practice/routing.yaml` holds the bar, the preference and the pin for each task; a typo in one task costs that task, not the file.
+
 Routing and evals, step 1 — every step has a task, and the vault keeps what you did with the answer (routing-and-evals spec §3, §7)
 
 - A closed legal task taxonomy — `review`, `redline`, `draft`, `research`, `extract`, `summarize`, `compare`, `remember`, `docket`, `retro`, `chat` — and where a step's task came from: named on the request, set on the conversation, a rule over the message and its attachments, an optional model call (`classify: model` in `config.md`, off by default), else `chat`. The task and its source sit on the step event and the run record; the turn's record shows `task · by rule · change`, and the picker corrects it (`PATCH /threads/:id/steps/:runId/task`).

--- a/docs/superpowers/specs/2026-09-02-routing-and-evals-design.md
+++ b/docs/superpowers/specs/2026-09-02-routing-and-evals-design.md
@@ -99,7 +99,7 @@ Keeps v1 (id, title, document_type, vault, task, input, expected_catches, negati
 1. Taxonomy, classification (rules + the small structured call), task picker in Settings' route rows, task on the step/strip with correction; outcome capture store + `proposal.decided` / `artifact.produced` / `answer.marked` / `task.corrected` / `thread.deleted`; the Settings switch.
 2. Eval runner in TypeScript with fixture v2 and the five scorers; the shipped fixtures ported; parity with the Python; CLI `counsel-os eval`; the results store; Python scripts retired; CI switched.
 3. Scoreboard API and the Models group in Settings; "score this provider" with the cost guard.
-4. Routing from the scoreboard with proposals and reasons; the strip line.
+4. Routing from the scoreboard with reasons; the record's line. **Split while building (2026-09-02):** the router, `practice/routing.yaml`, and the reason on every run shipped first; the editing surface (the bar and the preference per task in Settings) and the route-change proposal after a scoring run follow in 4b, because the proposal wants a thread to live on and that is a design question of its own — a route is configuration, not knowledge, so 4b may instead offer it in the Models group with an explicit "use it" rather than in the docket.
 5. `file.edited-after-counsel` (written hashes, doctor/retro/watcher comparison) and "make this a fixture" with the anonymization review.
 6. Benchmark loaders with license fields.
 

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -2,12 +2,14 @@ import { randomUUID } from 'node:crypto';
 import type { ZodType } from 'zod';
 import type { Message, ModelProvider, Platform, StepEvent, StepRequest, Tenant, ToolDef, Usage, VaultStore, ArtifactSummary } from '../core/types';
 import { currentPlatform } from '../core/types';
-import type { Router } from '../router/router';
+import type { Routed, RouteReason, Router } from '../router/router';
 import { ThreadStore, type ThreadEvent, type ThreadHeader } from '../threads/store';
 import { window } from '../threads/window';
 import { readVaultConfig, type VaultConfig } from '../vault/resolve-root';
 import { policyForStep, readerOver, type StepPolicy } from '../vault/policy';
 import { isLocal } from '../router/router';
+import { taskPolicy, type RoutingPolicy } from '../router/policy';
+import type { RouteScores } from '../router/scores';
 import { MatterStaysLocalError } from '../core/types';
 import { guardedVaultTools } from '../vault/vault-tools';
 import { builtinTools } from '../tools/builtin';
@@ -73,6 +75,10 @@ export interface CounselLoopDeps {
    * when neither the caller nor the thread named a task and no rule fired.
    * Absent → rules then `chat`; serve wires `modelClassifier`. */
   classifier?: ModelClassifier;
+  /** What the scoreboard measured and how this practice wants each task
+   * routed (routing-and-evals spec §6). Absent → the configured route and
+   * the default decide, exactly as before scoring existed. */
+  routing?: () => { scores: RouteScores; policy: RoutingPolicy };
 }
 
 export interface RunStepOptions {
@@ -142,16 +148,22 @@ export async function policyForOptions(
  * that is not local is refused outright under `localOnly` (never a silent
  * swap), and the router's local-only path picks among what is loaded.
  */
-export function resolveStepProvider(deps: CounselLoopDeps, opts: RunStepOptions, policy: StepPolicy): ModelProvider {
+export function resolveStepProvider(deps: CounselLoopDeps, opts: RunStepOptions, policy: StepPolicy): Routed {
   if (opts.providerId) {
     const found = deps.providers.find(p => p.id === opts.providerId);
     if (!found) throw new Error(`unknown provider: ${opts.providerId}`);
     if (policy.localOnly && !isLocal(found.capabilities)) {
       throw new MatterStaysLocalError(`This matter stays on this machine; ${found.id} is not a local model.`);
     }
-    return found;
+    return { provider: found, reason: { kind: 'default', text: 'you chose this model' } };
   }
-  return deps.router.resolve(opts.task, { localOnly: policy.localOnly });
+  const routing = deps.routing?.();
+  return deps.router.route(opts.task, {
+    localOnly: policy.localOnly,
+    ...(routing === undefined || opts.task === undefined
+      ? {}
+      : { scores: routing.scores[opts.task] ?? [], policy: taskPolicy(routing.policy, opts.task) }),
+  });
 }
 
 
@@ -274,14 +286,18 @@ export async function* runStep(
     // or no local model at all) never ran, so the transcript must not show
     // a question nobody answered.
     let provider: ModelProvider;
+    // Why this step went where it did, for the record and the strip.
+    let routeReason: RouteReason | null = null;
     try {
-      provider = bindToThread(deps, resolveStepProvider(deps, opts, policy), threadId);
+      const routed = resolveStepProvider(deps, opts, policy);
+      routeReason = routed.reason;
+      provider = bindToThread(deps, routed.provider, threadId);
     } catch (err) {
       failRun(message(err));
       yield { type: 'error', message: message(err), runId };
       return;
     }
-    patchRun(deps, runId, { provider: provider.id, ...(policy.localOnly ? { policy: 'stays-local' as const } : {}) });
+    patchRun(deps, runId, { provider: provider.id, ...(routeReason === null ? {} : { routeReason }), ...(policy.localOnly ? { policy: 'stays-local' as const } : {}) });
 
     const userFailed = await tryPersist(() =>
       store.append(tenant, threadId, { t: 'user', at: nowIso(), content: opts.message }),

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -58,6 +58,9 @@ export interface RunRecord {
   /** `stays-local` when the matter's privacy policy chose the provider
    * (providers spec §7) — the record shows the policy was in force. */
   policy?: 'stays-local';
+  /** Why this provider (routing-and-evals spec §6): the scoreboard, a pin,
+   * the configured route, or the default. */
+  routeReason?: { kind: string; text: string };
 }
 
 /**

--- a/runtime/src/router/policy.ts
+++ b/runtime/src/router/policy.ts
@@ -1,0 +1,116 @@
+/**
+ * The routing policy (routing-and-evals spec §6): how the practice wants each
+ * kind of work routed, given what the scoreboard measured.
+ *
+ * It lives in the VAULT (`practice/routing.yaml`), beside the standards and
+ * the methods, because it is a decision about the practice rather than about
+ * this machine — `providers.yaml` in the counsel home stays the place for
+ * credentials and endpoints.
+ *
+ * Nothing here chooses a provider; `Router` does that. This module is the
+ * file: its shape, its defaults, and the two directions it travels.
+ */
+import { join } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+import { writeFileAtomic } from '../core/atomic-write';
+
+/** How the practice picks among the providers that clear the bar. */
+export type Preference = 'quality' | 'cost' | 'latency';
+
+export interface TaskPolicy {
+  /** The lowest score a provider may carry and still be a candidate. */
+  min_score?: number;
+  prefer?: Preference;
+  /** A provider the lawyer chose by hand. It still has to clear the bar and
+   * the matter's locality, so a pin can never quietly send a stays-local
+   * matter to the cloud. */
+  pinned?: string;
+}
+
+export interface RoutingPolicy {
+  tasks: Record<string, TaskPolicy>;
+}
+
+/** A task with no policy of its own is scored at 0.7 and ranked by quality. */
+export const DEFAULT_MIN_SCORE = 0.7;
+export const DEFAULT_PREFERENCE: Preference = 'quality';
+
+export const EMPTY_POLICY: RoutingPolicy = { tasks: {} };
+
+export function policyPath(vaultRoot: string): string {
+  return join(vaultRoot, 'practice', 'routing.yaml');
+}
+
+const PREFERENCES: readonly Preference[] = ['quality', 'cost', 'latency'];
+
+/**
+ * Parse the file. A malformed entry is dropped with the rest kept: a typo in
+ * one task's block must not cost the practice every other route, and the
+ * router's fallback (the default provider) is always safe.
+ */
+export function parseRoutingPolicy(yamlText: string): RoutingPolicy {
+  const raw = Bun.YAML.parse(yamlText) as unknown;
+  if (raw === null || typeof raw !== 'object') return { tasks: {} };
+  const rawTasks = (raw as { tasks?: unknown }).tasks;
+  if (rawTasks === null || typeof rawTasks !== 'object' || rawTasks === undefined) return { tasks: {} };
+  const tasks: Record<string, TaskPolicy> = {};
+  for (const [task, value] of Object.entries(rawTasks as Record<string, unknown>)) {
+    if (value === null || typeof value !== 'object') continue;
+    const v = value as Record<string, unknown>;
+    const entry: TaskPolicy = {};
+    if (typeof v['min_score'] === 'number' && v['min_score'] >= 0 && v['min_score'] <= 1) entry.min_score = v['min_score'];
+    if (typeof v['prefer'] === 'string' && PREFERENCES.includes(v['prefer'] as Preference)) entry.prefer = v['prefer'] as Preference;
+    if (typeof v['pinned'] === 'string' && v['pinned'] !== '') entry.pinned = v['pinned'];
+    if (Object.keys(entry).length > 0) tasks[task] = entry;
+  }
+  return { tasks };
+}
+
+export function readRoutingPolicy(vaultRoot: string): RoutingPolicy {
+  const path = policyPath(vaultRoot);
+  if (!existsSync(path)) return { tasks: {} };
+  try {
+    return parseRoutingPolicy(readFileSync(path, 'utf8'));
+  } catch {
+    // An unreadable or unparseable file routes by the defaults rather than
+    // stopping the practice from working.
+    return { tasks: {} };
+  }
+}
+
+/** The file as a lawyer would read it: one block per task, comments kept. */
+export function renderRoutingPolicy(policy: RoutingPolicy): string {
+  const head = [
+    '# How counsel-os routes each kind of work (docs: routing-and-evals spec §6).',
+    '# Scores come from the eval fixtures; see Settings › Models.',
+    '#   min_score: the lowest score a provider may carry and still be chosen',
+    `#   prefer:    quality (default), cost, or latency`,
+    '#   pinned:    a provider you chose by hand; it still has to clear the bar',
+    '',
+  ];
+  const names = Object.keys(policy.tasks).sort();
+  if (names.length === 0) return `${head.join('\n')}tasks: {}\n`;
+  const lines = ['tasks:'];
+  for (const task of names) {
+    const entry = policy.tasks[task]!;
+    lines.push(`  ${task}:`);
+    if (entry.min_score !== undefined) lines.push(`    min_score: ${entry.min_score}`);
+    if (entry.prefer !== undefined) lines.push(`    prefer: ${entry.prefer}`);
+    if (entry.pinned !== undefined) lines.push(`    pinned: ${entry.pinned}`);
+  }
+  return `${head.join('\n')}${lines.join('\n')}\n`;
+}
+
+export function writeRoutingPolicy(vaultRoot: string, policy: RoutingPolicy): void {
+  // A practice file, not a secret: readable like the standards beside it.
+  writeFileAtomic(policyPath(vaultRoot), renderRoutingPolicy(policy), { mode: 0o644 });
+}
+
+export function taskPolicy(policy: RoutingPolicy, task: string | undefined): Required<Pick<TaskPolicy, 'min_score' | 'prefer'>> & { pinned?: string } {
+  const entry = (task === undefined ? undefined : policy.tasks[task]) ?? {};
+  return {
+    min_score: entry.min_score ?? DEFAULT_MIN_SCORE,
+    prefer: entry.prefer ?? DEFAULT_PREFERENCE,
+    ...(entry.pinned === undefined ? {} : { pinned: entry.pinned }),
+  };
+}

--- a/runtime/src/router/router.ts
+++ b/runtime/src/router/router.ts
@@ -1,5 +1,12 @@
 import type { Capabilities, ModelProvider } from '../core/types';
 import { localityOf, MatterStaysLocalError, RouterError } from '../core/types';
+import { DEFAULT_MIN_SCORE, DEFAULT_PREFERENCE, type TaskPolicy } from './policy';
+import type { ProviderScore } from './scores';
+
+/** Providers within this much of the best score count as equally good, so a
+ * `cost` or `latency` preference chooses among real peers rather than
+ * trading a materially better answer for a cheaper one. */
+const SCORE_BAND = 0.05;
 
 export type Require = Partial<Pick<Capabilities, 'tools' | 'caching' | 'thinking' | 'contextTokens'>>;
 
@@ -35,6 +42,39 @@ export interface ResolveOptions {
   /** The matter stays on this machine (providers spec §7): only local
    * providers are candidates, whatever the route or the default say. */
   localOnly?: boolean;
+  /** What the scoreboard measured for this task, best first. Absent (or
+   * empty) means nothing has been scored and the configured route decides,
+   * exactly as before. */
+  scores?: ProviderScore[];
+  /** How this practice wants the task routed. */
+  policy?: TaskPolicy;
+}
+
+/** Why a step went where it went — shown on the step and stamped on the run
+ * record, so a route is never a mystery. */
+export interface RouteReason {
+  kind: 'default' | 'task-route' | 'pinned' | 'scored' | 'no-score' | 'below-bar' | 'stays-local';
+  /** One phrase, already in the words a lawyer reads. */
+  text: string;
+}
+
+export interface Routed {
+  provider: ModelProvider;
+  reason: RouteReason;
+}
+
+/** Cheaper per run; a provider with no known price never displaces one with
+ * a price, so an unknown cost is not mistaken for a free one. */
+function cheaper(a: ProviderScore, b: ProviderScore): boolean {
+  if (a.meanCostUsd === null) return false;
+  if (b.meanCostUsd === null) return true;
+  return a.meanCostUsd < b.meanCostUsd;
+}
+
+function faster(a: ProviderScore, b: ProviderScore): boolean {
+  if (a.medianMs === null) return false;
+  if (b.medianMs === null) return true;
+  return a.medianMs < b.medianMs;
 }
 
 function satisfies(caps: Capabilities, req: Require | undefined, allowRemote: boolean): boolean {
@@ -55,13 +95,87 @@ export class Router {
   }
 
   resolve(task?: string, options: ResolveOptions = {}): ModelProvider {
+    return this.route(task, options).provider;
+  }
+
+  /**
+   * The provider for a task, and why (routing-and-evals spec §6).
+   *
+   * The scoreboard leads when it has something to say: candidates are the
+   * providers that clear this task's bar, minus anything the matter's
+   * locality forbids; a pin wins among them; otherwise the practice's
+   * preference orders them. With no score, or none clearing the bar, the
+   * configured route and the default decide exactly as they did before —
+   * routing never refuses to answer for want of a measurement.
+   */
+  route(task?: string, options: ResolveOptions = {}): Routed {
+    const scored = this.byScore(task, options);
+    if (scored) return scored;
+
     const route = task ? this.cfg.tasks?.[task] : undefined;
-    if (options.localOnly === true) return this.resolveLocal(route);
+    const fallback = this.byConfig(task, route, options);
+    // A "nothing scored" note belongs on the step only when scoring is a
+    // thing this practice does for this task at all; otherwise the honest
+    // reason is simply the route or the default.
+    if (options.scores !== undefined && fallback.reason.kind !== 'stays-local') {
+      const best = [...options.scores].sort((a, b) => b.score - a.score)[0];
+      const bar = options.policy?.min_score ?? DEFAULT_MIN_SCORE;
+      const reason: RouteReason = best
+        ? { kind: 'below-bar', text: `no model clears ${bar.toFixed(2)}${task ? ` for ${task}` : ''} (best ${best.score.toFixed(2)})` }
+        : { kind: 'no-score', text: 'no score yet' };
+      return { provider: fallback.provider, reason };
+    }
+    return fallback;
+  }
+
+  /** The scoreboard's pick, or `null` when it has nothing usable to say. */
+  private byScore(task: string | undefined, options: ResolveOptions): Routed | null {
+    const scores = options.scores ?? [];
+    if (task === undefined || scores.length === 0) return null;
+    const bar = options.policy?.min_score ?? DEFAULT_MIN_SCORE;
+    const prefer = options.policy?.prefer ?? DEFAULT_PREFERENCE;
+    const route = this.cfg.tasks?.[task];
+
+    const candidates = scores
+      .filter(s => s.score >= bar)
+      .map(s => ({ s, p: this.byId.get(s.providerId) }))
+      .filter((c): c is { s: ProviderScore; p: ModelProvider } => c.p !== undefined)
+      // The matter's policy and the route's requirements bind the scoreboard
+      // too: a high score never buys a way past "stays on this machine".
+      .filter(c => (options.localOnly === true ? isLocal(c.p.capabilities) : true))
+      .filter(c => satisfies(c.p.capabilities, route?.require, options.localOnly === true ? false : route?.allow_remote ?? true));
+    if (candidates.length === 0) return null;
+
+    const pinned = options.policy?.pinned;
+    if (pinned !== undefined) {
+      const hit = candidates.find(c => c.s.providerId === pinned);
+      if (hit) return { provider: hit.p, reason: { kind: 'pinned', text: `pinned for ${task} · ${hit.s.score.toFixed(2)}` } };
+    }
+
+    const best = candidates.reduce((a, b) => (b.s.score > a.s.score ? b : a));
+    const peers = candidates.filter(c => best.s.score - c.s.score <= SCORE_BAND);
+    const chosen =
+      prefer === 'cost'
+        ? peers.reduce((a, b) => (cheaper(b.s, a.s) ? b : a))
+        : prefer === 'latency'
+          ? peers.reduce((a, b) => (faster(b.s, a.s) ? b : a))
+          : best;
+    const how = prefer === 'quality' ? '' : ` · by ${prefer}`;
+    return { provider: chosen.p, reason: { kind: 'scored', text: `${task} ${chosen.s.score.toFixed(2)}${how}` } };
+  }
+
+  /** The pre-scoreboard behaviour, unchanged, with its reason named. */
+  private byConfig(task: string | undefined, route: TaskRoute | undefined, options: ResolveOptions): Routed {
+    if (options.localOnly === true) {
+      return { provider: this.resolveLocal(route), reason: { kind: 'stays-local', text: 'stays on this machine' } };
+    }
     const allowRemote = route?.allow_remote ?? true;
 
     if (route) {
       const preferred = this.byId.get(route.prefer);
-      if (preferred && satisfies(preferred.capabilities, route.require, allowRemote)) return preferred;
+      if (preferred && satisfies(preferred.capabilities, route.require, allowRemote)) {
+        return { provider: preferred, reason: { kind: 'task-route', text: `route for ${task}` } };
+      }
     }
     const def = this.byId.get(this.cfg.default);
     if (!def) throw new RouterError(`default provider not configured: ${this.cfg.default}`);
@@ -71,7 +185,7 @@ export class Router {
         `neither ${route.prefer} nor default ${def.id} satisfies it`,
       );
     }
-    return def;
+    return { provider: def, reason: { kind: 'default', text: 'the default model' } };
   }
 
   /**

--- a/runtime/src/router/routing.test.ts
+++ b/runtime/src/router/routing.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Router, parseRouterConfig } from './router';
+import { parseRoutingPolicy, readRoutingPolicy, renderRoutingPolicy, taskPolicy, writeRoutingPolicy } from './policy';
+import { routeScores } from './scores';
+import type { ProviderScore } from './scores';
+import type { Scoreboard, ScoreboardRow } from '../evals/scoreboard';
+import type { ModelProvider } from '../core/types';
+
+function p(id: string, caps: Partial<ModelProvider['capabilities']> = {}): ModelProvider {
+  return {
+    id, kind: 'direct',
+    capabilities: { tools: true, caching: false, thinking: false, contextTokens: 200_000, auth: 'apikey', ...caps },
+    async *run() { yield { type: 'done', output: null, usage: { inputTokens: 0, outputTokens: 0 } }; },
+  };
+}
+
+const providers = [
+  p('anthropic/claude-opus-5'),
+  p('openai/gpt-5.6'),
+  p('ollama/gemma4', { auth: 'local', contextTokens: 32_000 }),
+];
+const router = new Router(parseRouterConfig('default: anthropic/claude-opus-5\n'), providers);
+
+function score(providerId: string, over: Partial<ProviderScore> = {}): ProviderScore {
+  return { providerId, score: 0.9, meanCostUsd: 0.2, medianMs: 40_000, set: 'shipped', ...over };
+}
+
+describe('routing from the scoreboard', () => {
+  test('the best score above the bar wins, and the reason says so', () => {
+    const routed = router.route('review', {
+      scores: [score('openai/gpt-5.6', { score: 0.74 }), score('anthropic/claude-opus-5', { score: 0.91 })],
+    });
+    expect(routed.provider.id).toBe('anthropic/claude-opus-5');
+    expect(routed.reason).toEqual({ kind: 'scored', text: 'review 0.91' });
+  });
+
+  test('a provider below the bar is not a candidate; the default answers and says why', () => {
+    const routed = router.route('review', { scores: [score('openai/gpt-5.6', { score: 0.61 })] });
+    expect(routed.provider.id).toBe('anthropic/claude-opus-5');
+    expect(routed.reason.kind).toBe('below-bar');
+    expect(routed.reason.text).toBe('no model clears 0.70 for review (best 0.61)');
+  });
+
+  test('a task nothing has scored falls to the default and says nothing is scored', () => {
+    const routed = router.route('draft', { scores: [] });
+    expect(routed.provider.id).toBe('anthropic/claude-opus-5');
+    expect(routed.reason).toEqual({ kind: 'no-score', text: 'no score yet' });
+  });
+
+  test('with no scoreboard at all the reason is the plain default, not a complaint', () => {
+    expect(router.route('review').reason).toEqual({ kind: 'default', text: 'the default model' });
+  });
+
+  test('cost and latency choose among peers within the band, never a materially worse answer', () => {
+    const scores = [
+      score('anthropic/claude-opus-5', { score: 0.91, meanCostUsd: 0.30, medianMs: 60_000 }),
+      score('openai/gpt-5.6', { score: 0.88, meanCostUsd: 0.05, medianMs: 20_000 }),
+      // Cheapest and fastest of all, but a materially worse answer: out of band.
+      score('ollama/gemma4', { score: 0.72, meanCostUsd: 0, medianMs: 5_000 }),
+    ];
+    expect(router.route('review', { scores, policy: { prefer: 'cost' } }).provider.id).toBe('openai/gpt-5.6');
+    expect(router.route('review', { scores, policy: { prefer: 'latency' } }).provider.id).toBe('openai/gpt-5.6');
+    expect(router.route('review', { scores, policy: { prefer: 'quality' } }).provider.id).toBe('anthropic/claude-opus-5');
+    expect(router.route('review', { scores, policy: { prefer: 'cost' } }).reason.text).toBe('review 0.88 · by cost');
+  });
+
+  test('an unknown cost never passes for a free one', () => {
+    const scores = [
+      score('anthropic/claude-opus-5', { score: 0.90, meanCostUsd: 0.30 }),
+      score('openai/gpt-5.6', { score: 0.89, meanCostUsd: null }),
+    ];
+    expect(router.route('review', { scores, policy: { prefer: 'cost' } }).provider.id).toBe('anthropic/claude-opus-5');
+  });
+
+  test('a pin wins among the candidates and is named', () => {
+    const scores = [score('anthropic/claude-opus-5', { score: 0.91 }), score('openai/gpt-5.6', { score: 0.80 })];
+    const routed = router.route('review', { scores, policy: { pinned: 'openai/gpt-5.6' } });
+    expect(routed.provider.id).toBe('openai/gpt-5.6');
+    expect(routed.reason).toEqual({ kind: 'pinned', text: 'pinned for review · 0.80' });
+  });
+
+  test('a pin below the bar is not honoured — the bar is the practice’s floor', () => {
+    const scores = [score('anthropic/claude-opus-5', { score: 0.91 }), score('openai/gpt-5.6', { score: 0.40 })];
+    expect(router.route('review', { scores, policy: { pinned: 'openai/gpt-5.6' } }).provider.id).toBe('anthropic/claude-opus-5');
+  });
+
+  test('a high score never buys a way past a matter that stays on this machine', () => {
+    const scores = [score('anthropic/claude-opus-5', { score: 0.95 }), score('ollama/gemma4', { score: 0.71 })];
+    const routed = router.route('review', { scores, localOnly: true });
+    expect(routed.provider.id).toBe('ollama/gemma4');
+    expect(routed.reason.kind).toBe('scored');
+  });
+
+  test('stays-local with no scored local model still answers locally, by the old path', () => {
+    const routed = router.route('review', { scores: [score('anthropic/claude-opus-5', { score: 0.95 })], localOnly: true });
+    expect(routed.provider.id).toBe('ollama/gemma4');
+    expect(routed.reason).toEqual({ kind: 'stays-local', text: 'stays on this machine' });
+  });
+
+  test('a scored provider that is not loaded is skipped, not resolved to nothing', () => {
+    const routed = router.route('review', { scores: [score('mistral/large', { score: 0.99 }), score('openai/gpt-5.6', { score: 0.75 })] });
+    expect(routed.provider.id).toBe('openai/gpt-5.6');
+  });
+
+  test('resolve() keeps its old shape for every caller that does not ask why', () => {
+    expect(router.resolve('review', { scores: [score('openai/gpt-5.6')] }).id).toBe('openai/gpt-5.6');
+    expect(router.resolve().id).toBe('anthropic/claude-opus-5');
+  });
+});
+
+describe('the practice’s own fixtures lead the shipped ones', () => {
+  function row(over: Partial<ScoreboardRow> & { providerId: string }): ScoreboardRow {
+    return {
+      modelVersion: over.providerId.split('/')[1] ?? over.providerId,
+      score: 0.8, scored: 2, sampleSize: 2, failed: [], medianMs: 1000, meanCostUsd: 0.1,
+      lastAt: '2026-09-02T00:00:00.000Z', staleDays: 0, ...over,
+    };
+  }
+  const board: Scoreboard = {
+    at: '2026-09-02T00:00:00.000Z',
+    tasks: [
+      {
+        task: 'review',
+        sets: {
+          practice: { fixtures: 2, rows: [row({ providerId: 'ollama/gemma4', score: 0.77 })] },
+          shipped: { fixtures: 8, rows: [row({ providerId: 'anthropic/claude-opus-5', score: 0.95 })] },
+          benchmark: { fixtures: 100, rows: [row({ providerId: 'anthropic/claude-opus-5', score: 0.99 })] },
+        },
+      },
+      {
+        task: 'redline',
+        sets: {
+          practice: { fixtures: 0, rows: [] },
+          shipped: { fixtures: 1, rows: [row({ providerId: 'anthropic/claude-opus-5', score: 0.74 }), row({ providerId: 'openai/gpt-5.6', score: null })] },
+          benchmark: { fixtures: 0, rows: [] },
+        },
+      },
+    ],
+  };
+
+  test('practice scores win where they exist; shipped stands in where they do not; benchmarks never route', () => {
+    const scores = routeScores(board);
+    expect(scores['review']).toEqual([{ providerId: 'ollama/gemma4', score: 0.77, meanCostUsd: 0.1, medianMs: 1000, set: 'practice' }]);
+    expect(scores['redline']?.map(s => s.providerId)).toEqual(['anthropic/claude-opus-5']);
+    expect(scores['redline']?.[0]?.set).toBe('shipped');
+  });
+
+  test('a failed cell is not a candidate', () => {
+    expect(routeScores(board)['redline']?.some(s => s.providerId === 'openai/gpt-5.6')).toBe(false);
+  });
+});
+
+describe('the routing policy file', () => {
+  test('reads a written file back, and a lawyer can read the file itself', () => {
+    const root = mkdtempSync(join(tmpdir(), 'routing-policy-'));
+    mkdirSync(join(root, 'practice'), { recursive: true });
+    writeRoutingPolicy(root, { tasks: { review: { min_score: 0.8, prefer: 'cost', pinned: 'ollama/gemma4' } } });
+    const text = readFileSync(join(root, 'practice', 'routing.yaml'), 'utf8');
+    expect(text).toContain('# How counsel-os routes each kind of work');
+    expect(text).toContain('    pinned: ollama/gemma4');
+    expect(readRoutingPolicy(root)).toEqual({ tasks: { review: { min_score: 0.8, prefer: 'cost', pinned: 'ollama/gemma4' } } });
+  });
+
+  test('a typo in one task costs that task, not the file', () => {
+    const parsed = parseRoutingPolicy('tasks:\n  review: { min_score: 0.8 }\n  redline: { prefer: cheapest }\n  draft: nonsense\n');
+    expect(parsed.tasks['review']).toEqual({ min_score: 0.8 });
+    expect(parsed.tasks['redline']).toBeUndefined();
+    expect(parsed.tasks['draft']).toBeUndefined();
+  });
+
+  test('an absent file routes by the defaults', () => {
+    const root = mkdtempSync(join(tmpdir(), 'routing-policy-'));
+    expect(readRoutingPolicy(root)).toEqual({ tasks: {} });
+    expect(taskPolicy(readRoutingPolicy(root), 'review')).toEqual({ min_score: 0.7, prefer: 'quality' });
+  });
+
+  test('a garbled file routes by the defaults rather than stopping the practice', () => {
+    const root = mkdtempSync(join(tmpdir(), 'routing-policy-'));
+    mkdirSync(join(root, 'practice'), { recursive: true });
+    writeFileSync(join(root, 'practice', 'routing.yaml'), 'tasks: [this is not a map\n');
+    expect(readRoutingPolicy(root)).toEqual({ tasks: {} });
+  });
+
+  test('an empty policy still renders a file a lawyer can open and edit', () => {
+    expect(renderRoutingPolicy({ tasks: {} })).toContain('tasks: {}');
+  });
+});

--- a/runtime/src/router/scores.ts
+++ b/runtime/src/router/scores.ts
@@ -1,0 +1,46 @@
+/**
+ * The scoreboard as the router reads it (routing-and-evals spec §6).
+ *
+ * The scoreboard keeps three sets apart on purpose; routing has to pick one,
+ * and it picks the practice's own fixtures whenever they have a score for
+ * the task, because those measure the work this practice actually does. The
+ * shipped suite stands in until then. Benchmarks never route: they measure
+ * generic legal competence, not this practice's positions.
+ */
+import type { Scoreboard, SetKind } from '../evals/scoreboard';
+
+export interface ProviderScore {
+  providerId: string;
+  score: number;
+  meanCostUsd: number | null;
+  medianMs: number | null;
+  /** Which set the score came from, so the reason can say. */
+  set: SetKind;
+}
+
+/** task → the providers with a score, best first. */
+export type RouteScores = Record<string, ProviderScore[]>;
+
+function rowsFor(board: Scoreboard, task: string): { rows: ProviderScore[]; set: SetKind } | null {
+  const entry = board.tasks.find(t => t.task === task);
+  if (!entry) return null;
+  for (const set of ['practice', 'shipped'] as const) {
+    const scored = entry.sets[set].rows.filter(r => r.score !== null);
+    if (scored.length === 0) continue;
+    return {
+      set,
+      rows: scored.map(r => ({ providerId: r.providerId, score: r.score as number, meanCostUsd: r.meanCostUsd, medianMs: r.medianMs, set })),
+    };
+  }
+  return null;
+}
+
+export function routeScores(board: Scoreboard): RouteScores {
+  const out: RouteScores = {};
+  for (const task of board.tasks) {
+    const found = rowsFor(board, task.task);
+    if (found === null) continue;
+    out[task.task] = [...found.rows].sort((a, b) => b.score - a.score);
+  }
+  return out;
+}

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -40,6 +40,8 @@ import { pickJudge, providerJudge } from '../evals/judge';
 import { appendResult, readResults } from '../evals/results';
 import { runSet, summarize } from '../evals/runner';
 import { fixtureCounts, scoreboard } from '../evals/scoreboard';
+import { routeScores } from '../router/scores';
+import { readRoutingPolicy } from '../router/policy';
 import type { Judge } from '../evals/scorers/types';
 import { runnable, selectFixtures, taskOf } from '../evals/select';
 import { serveStatic, type StaticSource } from './static';
@@ -407,6 +409,27 @@ export function createApp(deps: ServerDeps): App {
    * — a value captured once is exactly the staleness `RuntimeState` exists
    * to prevent.
    */
+  /**
+   * What the router needs from the scoreboard (routing-and-evals spec §6),
+   * read once and kept until a scoring run or a policy save moves it. The
+   * results file grows one line per fixture run, so re-reading it on every
+   * step would be work for nothing.
+   */
+  let routingCache: { scores: ReturnType<typeof routeScores>; policy: ReturnType<typeof readRoutingPolicy> } | null = null;
+  const routingView = (): { scores: ReturnType<typeof routeScores>; policy: ReturnType<typeof readRoutingPolicy> } => {
+    if (routingCache === null) {
+      const counts = fixtureCounts(evalLoaded().map(l => ({ task: taskOf(l), set: sourceKindOf(l), runnable: runnable(l) })));
+      routingCache = {
+        scores: routeScores(scoreboard(readResults(deps.vaultRoot, { since: null }), counts)),
+        policy: readRoutingPolicy(deps.vaultRoot),
+      };
+    }
+    return routingCache;
+  };
+  const forgetRouting = (): void => {
+    routingCache = null;
+  };
+
   const loopDeps = (): CounselLoopDeps => {
     const state = deps.state();
     return {
@@ -423,6 +446,7 @@ export function createApp(deps: ServerDeps): App {
       // The model classifier is opt-in (`classify: model` in config.md): a
       // scripted or metered provider must not spend a turn on it unasked.
       ...(readVaultConfig(deps.vaultRoot).classify === 'model' ? { classifier: modelClassifier(state.providers, state.router, deps.tenant) } : {}),
+      routing: routingView,
     };
   };
 
@@ -758,6 +782,7 @@ export function createApp(deps: ServerDeps): App {
               send('result', line);
             },
           });
+          if (input.save === true) forgetRouting();
           send('done', { summary: summarize(results), saved: input.save === true });
         } catch (err) {
           send('error', { message: err instanceof Error ? err.message : String(err) });

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -136,6 +136,11 @@ export interface RunRecord {
   task?: string;
   taskSource?: TaskSource;
   mark?: RunMark;
+  /** Why this model answered (routing-and-evals spec §6). COPIED from
+   * `runtime/src/router/router.ts`; a change there is a change here. */
+  routeReason?: { kind: string; text: string };
+  /** `stays-local` when the matter's privacy policy chose the model. */
+  policy?: 'stays-local';
   primitivesRead: string[];
   toolCalls: ToolCallLog[];
   proposals: string[];

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -457,6 +457,8 @@ a { color: var(--accent); }
 .v2-record dd { margin: 0; }
 .v2-record-id { margin-right: var(--s2); }
 .v2-record-source { color: var(--fg-faint); }
+/* Why this model answered, beside its name in the record. */
+.v2-record-route { color: var(--fg-faint); }
 .v2-task-pick { vertical-align: baseline; }
 .v2-task-pop { min-width: 160px; }
 /* The lawyer's mark (routing-and-evals spec §7): two words under the strip,

--- a/runtime/ui/src/v2/chat/Strip.test.tsx
+++ b/runtime/ui/src/v2/chat/Strip.test.tsx
@@ -273,3 +273,38 @@ describe('the task and the marks (routing-and-evals spec §3, §7)', () => {
     expect(document.querySelector('.v2-marks')).toBeNull();
   });
 });
+
+describe('why this model answered', () => {
+  test('the record names the reason beside the model, and the policy when it bound the choice', async () => {
+    render(
+      <Strip
+        turn={turn}
+        threadId="t-1"
+        run={{ ...run, provider: 'ollama/gemma4', routeReason: { kind: 'scored', text: 'review 0.82' }, policy: 'stays-local' }}
+        ms={{}}
+      />,
+    );
+    await userEvent.click(document.querySelector('summary') as HTMLElement);
+    const model = document.querySelector('.v2-record-route')!;
+    expect(model.textContent).toBe(' · review 0.82 · stays on this machine');
+  });
+
+  test('the stays-local reason is not repeated after itself', async () => {
+    render(
+      <Strip
+        turn={turn}
+        threadId="t-1"
+        run={{ ...run, routeReason: { kind: 'stays-local', text: 'stays on this machine' }, policy: 'stays-local' }}
+        ms={{}}
+      />,
+    );
+    await userEvent.click(document.querySelector('summary') as HTMLElement);
+    expect(document.querySelector('.v2-record-route')!.textContent).toBe(' · stays on this machine');
+  });
+
+  test('an older run with no reason recorded shows the model alone', async () => {
+    render(<Strip turn={turn} threadId="t-1" run={run} ms={{}} />);
+    await userEvent.click(document.querySelector('summary') as HTMLElement);
+    expect(document.querySelector('.v2-record-route')).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/chat/Strip.tsx
+++ b/runtime/ui/src/v2/chat/Strip.tsx
@@ -160,7 +160,19 @@ export function Strip({ turn, run, ms, threadId = null, onOpenFile }: StripProps
                 and the duration live HERE, where a reader who opened the
                 record came looking for them. */}
             <dt>Model</dt>
-            <dd>{provider === '' ? 'no provider' : <code>{provider}</code>}</dd>
+            <dd>
+              {provider === '' ? 'no provider' : <code>{provider}</code>}
+              {/* Why this model and not another (routing-and-evals spec §6):
+                  the scoreboard's pick, a pin, the route, or the default —
+                  and whether the matter's policy bound the choice. */}
+              {run.routeReason === undefined ? null : (
+                <span className="v2-record-route">
+                  {' · '}
+                  {run.routeReason.text}
+                  {run.policy === 'stays-local' && run.routeReason.kind !== 'stays-local' ? ' · stays on this machine' : ''}
+                </span>
+              )}
+            </dd>
             {run.durationMs === undefined ? null : (
               <>
                 <dt>Duration</dt>


### PR DESCRIPTION
The router gains a score-aware path (routing-and-evals spec §6). Candidates are the providers that clear the task's bar on the practice's own fixtures, or the shipped suite until the practice has its own; a pin wins among them; otherwise the practice's preference orders them, with `cost` and `latency` choosing only among peers within 0.05 of the best score so a cheaper model never displaces a materially better answer.

Two things it will not do:
- route a matter that stays on this machine to the cloud, however well a cloud model scores;
- refuse to answer for want of a measurement — an unscored task falls to the configured route and the default, exactly as before.

The choice is never a mystery: every run records why (`scored`, `pinned`, `task-route`, `default`, `no-score`, `below-bar`, `stays-local`) and the turn's record shows it beside the model.

`practice/routing.yaml` holds the bar, the preference and the pin per task, in the vault beside the standards. A typo in one task costs that task, not the file; an absent or garbled file routes by the defaults (bar 0.70, by quality).

**Verified in the running app**, not only in tests: with `fake/fake` scored 0.90 on `review`, a "Review this NDA…" message classified `review` by rule, routed by the scoreboard, and recorded `{kind: 'scored', text: 'review 0.90'}`; the record reads `fake/fake · review 0.90`. Dropping the score to 0.50 produced `no model clears 0.70 for review (best 0.50)` and the default answered.

Tests: runtime 1159 pass, UI 544 pass, both typechecks clean; 19 new routing cases cover the bar, the sets, locality, pins, each preference, unknown costs, unloaded providers, and the old `resolve()` shape.

**Split from the spec's step 4**, recorded there: the editing surface (bar and preference in Settings) and the route-change proposal after a scoring run follow in 4b — a route is configuration rather than knowledge, so whether it belongs in the docket or in the Models group with an explicit "use it" is a design question worth its own pass.