### PR TITLE
Routing and evals, step 5a — the vault keeps what you changed after counsel wrote it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+Your edits to what counsel wrote (routing-and-evals spec §7)
+
+- When counsel writes a file — an approved proposal, a redline or comparison it produced, a note into a matter — the runtime keeps that version. When you later change the file yourself, that difference is recorded once a day as `file.edited-after-counsel`, with the line counts and the diff, in the same local `.counsel/outcomes.jsonl` as your other decisions. Word files compare their text with the changes accepted.
+- Where it shows: `counsel-os doctor` counts the files you have edited since counsel wrote them, and the retro's evidence carries them into the review. `outcomes: off` in `config.md` stops the whole record, as before.
+- Nothing leaves the machine, and nothing is sent to a model: the record is the practice's own history of what it did with counsel's work.
+
 Routing from the scoreboard (routing-and-evals spec §6)
 
 - The scoreboard picks the model for a task: candidates clear the task's bar on the practice's own fixtures, or the shipped suite until the practice has its own; a pin wins among them; `cost` and `latency` choose only among peers within 0.05 of the best score, so a cheaper model never displaces a materially better answer.

--- a/docs/superpowers/plans/2026-09-02-routing-5.md
+++ b/docs/superpowers/plans/2026-09-02-routing-5.md
@@ -34,7 +34,7 @@
 
 ## Decisions taken here
 
-- **Matters only.** The record covers paths under `matters_path`. Knowledge paths are the lawyer's to curate; an edit there is not evidence about counsel's work.
+- **~~Matters only~~ → every file counsel wrote** (revised 2026-09-02 after an end-to-end run). The record first covered only `matters_path`, on the reasoning that knowledge paths are the lawyer's to curate. That made the commonest path record nothing: approving a proposed standard is counsel writing a knowledge file, and doctor then said "no files written by counsel yet" right after counsel had written one. Only three hooks reach the record — an approved proposal, a produced document, a `vault_write` — so it can never sweep in a file the lawyer wrote alone, and rewriting a standard just after approving it is exactly the signal this record is for.
 - **Snapshot, not git.** The diff needs counsel's text, so the record keeps one text snapshot per file (0600, under `.counsel/written/`), replaced when the record moves forward. Word files snapshot their accept-all text. Files over 2 MB are hashed only and their edits emit stats without a diff.
 - **Once per file per day means the base does not move on a same-day repeat.** The first edit of the day is emitted and the base moves to it; later edits that day are neither emitted nor absorbed, so tomorrow's line shows everything since.
 - **The doctor writes.** `runDoctor` was read-only; its edit check appends outcomes and touches `written.json`, both under `.counsel/`. The comment on `runDoctor` says so. Tests can pass `detectEdits: null` to skip it.

--- a/docs/superpowers/plans/2026-09-02-routing-5.md
+++ b/docs/superpowers/plans/2026-09-02-routing-5.md
@@ -1,0 +1,50 @@
+# Routing and evals, step 5 — lawyer edits and fixtures from a matter
+
+**Date:** 2026-09-02 · **Spec:** `docs/superpowers/specs/2026-09-02-routing-and-evals-design.md` §7 (lawyer edits) and §8 (fixture from a matter) · **Branch:** `routing-5` off `63430e1`.
+
+## What ships
+
+1. **The written-file record** — `<vault>/.counsel/written.json` (0600, atomic). Every file counsel writes into the matters folder is recorded with its content hash, its accept-all text hash for Word files, and a text snapshot under `.counsel/written/<sha>.txt` so the lawyer's later edit can be diffed against what counsel wrote. Hooks: an approved proposal (`decide` in routes), a produced document (the loop's `artifact.produced` outcome), and a `vault_write` from a step (an `onWrite` hook on `guardedVaultTools`). Off when `outcomes: off`.
+2. **Edit detection** — `detectEdits(vaultRoot, cfg)` compares each recorded file with what is on disk. A changed hash with the same text (Word metadata only) refreshes the record and emits nothing. A changed text emits one `file.edited-after-counsel` outcome per file per day with `{ format, stats, diff, truncated }`, the unified diff capped at 400 lines, and moves the record forward. A file that vanished drops its record. Runs at serve start, from the doctor (its one check that writes, and only under `.counsel/`), from retro evidence, and from an `fs.watch` on the matters folder debounced 5 s.
+3. **"Make this a fixture"** — `POST /evals/fixtures/from-thread {threadId, runId?, scorer?}` returns an anonymized fixture draft; `POST /evals/fixtures {draft, confirm: true}` writes `practice/evals/<slug>.json` and its mini-vault `practice/evals/vaults/<slug>/` (the synthetic document, a snapshot of `practice/profile.md` + `practice/standards/`, `memory/patterns.md`). The loader already reads that layout, so the saved fixture runs as-is.
+4. **The anonymizer** — `runtime/src/evals/anonymize.ts`, deterministic: party names from the matter's frontmatter and the entity files, then emails, phone numbers, money amounts, and dates by pattern. Replacements are numbered in order of first appearance and applied consistently across the document, the task, the expected items, and the model's answer. Returns a ledger and a list of capitalized runs that still look like names.
+5. **The UI** — a "make this a fixture" link in the turn strip; a review screen (`#/fixture?thread=…&run=…`) in the reader's redline style (`del` original, `ins` placeholder), the replacement ledger, the possible-names warning, the draft as editable JSON, and "Save as a practice fixture". Settings' Runtime facts gain "Practice fixtures · N".
+
+## Files
+
+| Area | File | Change |
+|---|---|---|
+| Record | `runtime/src/outcomes/written.ts` | new: `writtenPath`, `readWritten`, `recordWritten`, `dropWritten`, `textOfFile` (md/docx) |
+| Detection | `runtime/src/outcomes/edits.ts` | new: `detectEdits`, `unifiedDiff` (own LCS line diff, capped), `watchMatters` |
+| Outcomes | `runtime/src/outcomes/store.ts` | `OutcomeKind` + `'file.edited-after-counsel'`; `OutcomeCounts.edits` |
+| Hooks | `runtime/src/vault/vault-tools.ts` | `vaultTools(store, hooks?)` / `guardedVaultTools(store, cfg, hooks?)` with `onWrite` |
+| Hooks | `runtime/src/loop/counsel-loop.ts` | record on `artifact.produced`; `onWrite` for `vault_write` |
+| Hooks | `runtime/src/server/routes.ts` | record on an approved proposal; the two fixture routes |
+| Serve | `runtime/src/server/serve.ts` | start scan + watcher in `buildApp`; watcher closed on `stop()` |
+| Doctor | `runtime/src/doctor/checks.ts` | `checkEditsAfterCounsel` (last in `ALL_CHECKS`) |
+| Retro | `runtime/src/retro/evidence.ts` | scan before counting; "Edits after counsel" lines |
+| Fixture | `runtime/src/evals/anonymize.ts` | new |
+| Fixture | `runtime/src/evals/from-thread.ts` | new: `draftFixtureFromThread`, `savePracticeFixture`, `countPracticeFixtures` |
+| UI | `runtime/ui/src/api/client.ts`, `types.ts` | `fixtureFromThread`, `savePracticeFixture`; `Health.practiceFixtures` |
+| UI | `runtime/ui/src/v2/chat/Strip.tsx` | the link |
+| UI | `runtime/ui/src/v2/fixture/FixtureReview.tsx` | new screen |
+| UI | `runtime/ui/src/app.tsx`, `v2/Shell.tsx` | the `fixture` route |
+| UI | `runtime/ui/src/settings/Health.tsx` | the fact |
+| Docs | `docs/CONFIGURATION.md`, `CHANGELOG.md` | the record, the switch, the fixture flow |
+
+## Decisions taken here
+
+- **Matters only.** The record covers paths under `matters_path`. Knowledge paths are the lawyer's to curate; an edit there is not evidence about counsel's work.
+- **Snapshot, not git.** The diff needs counsel's text, so the record keeps one text snapshot per file (0600, under `.counsel/written/`), replaced when the record moves forward. Word files snapshot their accept-all text. Files over 2 MB are hashed only and their edits emit stats without a diff.
+- **Once per file per day means the base does not move on a same-day repeat.** The first edit of the day is emitted and the base moves to it; later edits that day are neither emitted nor absorbed, so tomorrow's line shows everything since.
+- **The doctor writes.** `runDoctor` was read-only; its edit check appends outcomes and touches `written.json`, both under `.counsel/`. The comment on `runDoctor` says so. Tests can pass `detectEdits: null` to skip it.
+- **The fixture's mini-vault follows the loader**, `practice/evals/vaults/<slug>/`, not `practice/evals/<slug>/`: that is the layout `loadPracticeFixtures` and `prepareFixtureVault` already read, so the saved fixture runs without a second change.
+- **Scorer from the thread.** A thread with a `docx-redline` artifact drafts a `redline` fixture (items are the artifact's own tracked changes, `proposed_any` gains the lawyer's current text when the lawyer edited the redline). Otherwise `findings`: expected catches come from the answer's `FindingsAnswer` JSON when the step ran with a schema, else from the answer's headings and bullets with `severity: any`. A `not-right` mark on the run makes every catch a `negative_check` instead. The lawyer edits the draft before saving.
+- **Anonymizer placeholders** read as names, not tags: `Party A`/`Party B` for the matter's client/counterparty, `Company N` / `Person N` for other entities, `person-n@example.com`, `555-01NN`, `$[amount N]`, `[date N]`. Authors on tracked changes become `Counsel`.
+
+## Order (TDD, one PR)
+
+1. `written.ts` + tests → `store.ts` kind/counts → `edits.ts` + tests (md, docx, metadata-only, once-a-day, missing, cap) → hooks (routes, loop, vault-tools) + tests → serve start + watcher + test → doctor check + test → retro evidence + test.
+2. `anonymize.ts` + tests → `from-thread.ts` + tests (findings, redline, save, slug collision, refuse without confirm) → routes + tests.
+3. UI: client + types → `FixtureReview` + tests → Strip link + test → route → Settings fact + test.
+4. Docs, both suites, both typechecks, self-test, commit, push, PR.

--- a/runtime/src/doctor/checks.test.ts
+++ b/runtime/src/doctor/checks.test.ts
@@ -8,6 +8,7 @@ import {
   acceptBand,
   addMonths,
   checkConsistency,
+  checkEditsAfterCounsel,
   checkGit,
   checkLawCurrency,
   checkLawImpact,
@@ -19,6 +20,8 @@ import {
   type DoctorContext,
 } from './checks';
 import { renderReport, runDoctor, verdictOf } from './index';
+import { readOutcomes } from '../outcomes/store';
+import { recordWritten } from '../outcomes/written';
 import { parseLawPolicy } from './policy';
 
 const POLICY = parseLawPolicy(JSON.stringify({ review_cadence_months: { default: 12, 'data-privacy': 6, employment: 6, corporate: 18 } }));
@@ -204,11 +207,31 @@ describe('law-impact', () => {
   });
 });
 
+describe('edits-after-counsel (routing-and-evals spec §7)', () => {
+  test('off, nothing written, nothing edited, and an edit — always ok, and the edit is recorded', () => {
+    seedHealthy();
+    expect(checkEditsAfterCounsel(ctx({ cfg: { ...CFG, outcomes: false } })).message).toContain('outcomes: off');
+    expect(checkEditsAfterCounsel(ctx()).message).toContain('no files written by counsel yet');
+    write('matters/acme/notes.md', '# Notes\n\nTerm: five years.\n');
+    recordWritten(vault, CFG, { path: 'matters/acme/notes.md', kind: 'write' });
+    expect(checkEditsAfterCounsel(ctx()).message).toBe('1 file written by counsel — none edited since the last look');
+    write('matters/acme/notes.md', '# Notes\n\nTerm: three years.\n');
+    const f = checkEditsAfterCounsel(ctx());
+    expect(f.severity).toBe('ok');
+    expect(f.message).toBe('1 file edited after counsel since the last look — recorded');
+    expect(f.paths).toEqual(['matters/acme/notes.md']);
+    expect(f.detail).toBe('matters/acme/notes.md (+1 −1)');
+    expect(readOutcomes(vault, { kind: 'file.edited-after-counsel' })).toHaveLength(1);
+    // The same day again: the record has moved forward and nothing is new.
+    expect(checkEditsAfterCounsel(ctx()).message).toContain('none edited since the last look');
+  });
+});
+
 describe('runDoctor + verdict', () => {
   test('a healthy vault is healthy; one warning names the check; an error is broken', () => {
     seedHealthy();
     const report = runDoctor({ vaultRoot: vault, pluginRoot: '/nowhere', policy: POLICY, git: null, now: () => NOW });
-    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact']);
+    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact', 'edits-after-counsel']);
     // git: null is the one warning on this seeded vault.
     expect(report.verdict).toBe('warnings');
     expect(report.summary).toContain('git');

--- a/runtime/src/doctor/checks.ts
+++ b/runtime/src/doctor/checks.ts
@@ -4,6 +4,9 @@ import type { GitRunner } from '../setup/run';
 import { parseFrontmatter, splitFrontmatterBlock } from '../vault/overview';
 import type { VaultConfig } from '../vault/resolve-root';
 import { cadenceFor, type LawPolicy } from './policy';
+import { detectEdits } from '../outcomes/edits';
+import { outcomesEnabled } from '../outcomes/store';
+import { readWritten } from '../outcomes/written';
 
 /**
  * The vault checks of `skills/doctor/SKILL.md` (steps 1, 2, 4B, 8, 10, 11),
@@ -493,4 +496,29 @@ export function checkLawImpact(ctx: DoctorContext): Finding {
   };
 }
 
-export const ALL_CHECKS: ReadonlyArray<(ctx: DoctorContext) => Finding> = [checkRootConfig, checkStructure, checkLawCurrency, checkGit, checkConsistency, checkLawImpact];
+/**
+ * Lawyer edits (routing-and-evals spec §7): the one check that writes —
+ * it runs the edit scan, which appends to the outcomes record and moves
+ * the written record forward, both under `.counsel/`. An edit is
+ * information, never a problem, so the finding is always `ok`.
+ */
+export function checkEditsAfterCounsel(ctx: DoctorContext): Finding {
+  const check = 'edits-after-counsel';
+  if (!outcomesEnabled(ctx.cfg)) return { check, severity: 'ok', message: 'the local record is off (outcomes: off) — edits after counsel are not tracked' };
+  const tracked = Object.keys(readWritten(ctx.vaultRoot).files).length;
+  if (tracked === 0) return { check, severity: 'ok', message: 'no files written by counsel yet — nothing to compare' };
+  const scan = detectEdits(ctx.vaultRoot, ctx.cfg, { now: ctx.now });
+  const noun = (n: number, word: string): string => `${n} ${word}${n === 1 ? '' : 's'}`;
+  if (scan.edited.length === 0) {
+    return { check, severity: 'ok', message: `${noun(scan.checked, 'file')} written by counsel — none edited since the last look` };
+  }
+  return {
+    check,
+    severity: 'ok',
+    message: `${noun(scan.edited.length, 'file')} edited after counsel since the last look — recorded`,
+    detail: scan.edited.map(e => `${e.path}${e.stats === null ? '' : ` (+${e.stats.added} −${e.stats.removed})`}`).join('\n'),
+    paths: scan.edited.map(e => e.path),
+  };
+}
+
+export const ALL_CHECKS: ReadonlyArray<(ctx: DoctorContext) => Finding> = [checkRootConfig, checkStructure, checkLawCurrency, checkGit, checkConsistency, checkLawImpact, checkEditsAfterCounsel];

--- a/runtime/src/doctor/index.ts
+++ b/runtime/src/doctor/index.ts
@@ -33,7 +33,9 @@ export function verdictOf(findings: Finding[]): { verdict: Verdict; summary: str
   return { verdict: 'healthy', summary: 'healthy' };
 }
 
-/** Runs every check. Read-only. */
+/** Runs every check. Read-only, except the edits-after-counsel check,
+ * which writes only under the vault's `.counsel/` (the outcomes and
+ * written records). */
 export function runDoctor(deps: DoctorDeps): DoctorReport {
   const now = deps.now?.() ?? new Date();
   const ctx: DoctorContext = {

--- a/runtime/src/loop/counsel-loop.test.ts
+++ b/runtime/src/loop/counsel-loop.test.ts
@@ -12,6 +12,7 @@ import { FsVaultStore } from '../vault/fs-store';
 import { runStep, withStepTimeout, RESUME_WARNING, type CounselLoopDeps } from './counsel-loop';
 import type { RunLogEntry } from './run-log';
 import { listRuns, readRun } from './run-record';
+import { readWritten } from '../outcomes/written';
 
 let vaultRoot: string;
 let pluginRoot: string;
@@ -176,6 +177,17 @@ describe('runStep', () => {
     const result = events.find(e => e.type === 'tool_result') as Extract<StepEvent, { type: 'tool_result' }>;
     expect(result.isError).toBe(true);
     expect(String(result.output)).toContain('propose_update');
+  });
+
+  test('(a2b) a vault_write into a matter is recorded as counsel\'s version of that file (spec §7, lawyer edits)', async () => {
+    const fake = new FakeModelProvider([{ toolCalls: [{ name: 'vault_write', input: { path: 'matters/acme/notes.md', content: '# Notes\n' } }], text: 'written' }]);
+    const { id } = await store.create('default', {});
+    const events = await collect(runStep(deps([fake]), { threadId: id, message: 'write it' }));
+    const entry = readWritten(vaultRoot).files['matters/acme/notes.md'];
+    expect(entry).toBeDefined();
+    expect(entry!.kind).toBe('write');
+    expect(entry!.runId).toBe(events[0]!.runId);
+    expect(entry!.threadId).toBe(id);
   });
 
   test('(a3) a successful propose_update synthesizes a proposal StepEvent right after its tool_result, not logged twice', async () => {

--- a/runtime/src/loop/counsel-loop.ts
+++ b/runtime/src/loop/counsel-loop.ts
@@ -11,7 +11,8 @@ import { isLocal } from '../router/router';
 import { taskPolicy, type RoutingPolicy } from '../router/policy';
 import type { RouteScores } from '../router/scores';
 import { MatterStaysLocalError } from '../core/types';
-import { guardedVaultTools } from '../vault/vault-tools';
+import { guardedVaultTools, type VaultToolHooks } from '../vault/vault-tools';
+import { recordWritten } from '../outcomes/written';
 import { builtinTools } from '../tools/builtin';
 import { ToolRegistry } from '../tools/registry';
 import type { ContentSource } from '../content/source';
@@ -173,9 +174,9 @@ export function resolveStepProvider(deps: CounselLoopDeps, opts: RunStepOptions,
  * `propose_update` as the way through that gate, `read_primitive` for the
  * methodology's on-demand sections, and the platform's script tools.
  */
-function stepTools(deps: CounselLoopDeps, threadId: string, cfg: VaultConfig, scriptTools: ToolDef[]): ToolDef[] {
+function stepTools(deps: CounselLoopDeps, threadId: string, cfg: VaultConfig, scriptTools: ToolDef[], hooks: VaultToolHooks = {}): ToolDef[] {
   return [
-    ...guardedVaultTools(deps.vault, cfg),
+    ...guardedVaultTools(deps.vault, cfg, hooks),
     proposeUpdateTool(deps.store, deps.vault, threadId, deps.tenant) as ToolDef,
     readPrimitiveTool(deps.content ?? deps.pluginRoot) as ToolDef,
     ...scriptTools,
@@ -344,6 +345,11 @@ export async function* runStep(
           outcome: line => {
             try {
               appendOutcome(deps.vaultRoot, cfg, { ...line, threadId, runId, ...(opts.task ? { task: opts.task } : {}), providerId: provider.id });
+              // A produced document is counsel's version of that file from
+              // now on (spec §7, lawyer edits).
+              if (line.kind === 'artifact.produced' && typeof line.path === 'string') {
+                recordWritten(deps.vaultRoot, cfg, { path: line.path, kind: 'artifact', runId, threadId });
+              }
             } catch (err) {
               console.error(`counsel-loop: outcome write failed for ${runId}: ${message(err)}`);
             }
@@ -383,7 +389,11 @@ export async function* runStep(
         tenant,
         system,
         messages: [],
-        tools: stepTools(deps, threadId, cfg, scriptTools),
+        tools: stepTools(deps, threadId, cfg, scriptTools, {
+          onWrite: path => {
+            recordWritten(deps.vaultRoot, cfg, { path, kind: 'write', runId, threadId });
+          },
+        }),
         signal: cancel.signal,
         ...(opts.outputSchema ? { outputSchema: opts.outputSchema } : {}),
       };

--- a/runtime/src/outcomes/edits.test.ts
+++ b/runtime/src/outcomes/edits.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { buildDocx, simpleDocx } from '../docx/test/builder';
+import { DIFF_LINE_CAP, detectEdits, unifiedDiff, watchMatters } from './edits';
+import { readOutcomes } from './store';
+import { readWritten, recordWritten, snapshotPath } from './written';
+
+function root(): string {
+  const r = mkdtempSync(join(tmpdir(), 'edits-'));
+  mkdirSync(join(r, 'matters', 'acme'), { recursive: true });
+  return r;
+}
+
+const CFG = { mattersPath: 'matters' };
+const DAY1 = new Date('2026-09-02T10:00:00.000Z');
+const DAY1_LATER = new Date('2026-09-02T18:00:00.000Z');
+const DAY2 = new Date('2026-09-03T09:00:00.000Z');
+
+function edits(r: string) {
+  return readOutcomes(r, { kind: 'file.edited-after-counsel' });
+}
+
+describe('unifiedDiff', () => {
+  test('a one-line change is one hunk with context, counted', () => {
+    const d = unifiedDiff('a\nb\nc\nd\ne\n', 'a\nb\nC\nd\ne\n');
+    expect(d.stats).toEqual({ added: 1, removed: 1 });
+    expect(d.truncated).toBe(false);
+    expect(d.text).toBe('@@ -1,5 +1,5 @@\n a\n b\n-c\n+C\n d\n e\n');
+  });
+
+  test('identical texts diff to nothing', () => {
+    expect(unifiedDiff('x\n', 'x\n')).toEqual({ text: '', stats: { added: 0, removed: 0 }, truncated: false });
+  });
+
+  test('the diff is capped at the line cap and says so', () => {
+    const before = Array.from({ length: 600 }, (_, i) => `line ${i}`).join('\n');
+    const after = Array.from({ length: 600 }, (_, i) => `LINE ${i}`).join('\n');
+    const d = unifiedDiff(before, after);
+    expect(d.stats).toEqual({ added: 600, removed: 600 });
+    expect(d.truncated).toBe(true);
+    expect(d.text.split('\n').length - 1).toBeLessThanOrEqual(DIFF_LINE_CAP);
+  });
+});
+
+describe('detectEdits (routing-and-evals spec §7, lawyer edits)', () => {
+  test('an unchanged file emits nothing; a changed markdown file emits one outcome with the diff and moves the record forward', () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, '# Notes\n\nTerm: five years.\n');
+    recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write', runId: 'run-1', threadId: 't-1' });
+    expect(detectEdits(r, CFG, { now: DAY1 })).toEqual({ checked: 1, edited: [], refreshed: [], missing: [] });
+    expect(edits(r)).toHaveLength(0);
+
+    writeFileSync(p, '# Notes\n\nTerm: three years.\n');
+    const report = detectEdits(r, CFG, { now: DAY1 });
+    expect(report.edited.map(e => e.path)).toEqual(['matters/acme/notes.md']);
+    const [line] = edits(r);
+    expect(line).toMatchObject({ kind: 'file.edited-after-counsel', path: 'matters/acme/notes.md', runId: 'run-1', threadId: 't-1', at: DAY1.toISOString() });
+    expect(line!.detail).toMatchObject({ format: 'text', kind: 'write', stats: { added: 1, removed: 1 }, truncated: false });
+    expect(line!.detail['diff']).toContain('-Term: five years.\n+Term: three years.\n');
+    const entry = readWritten(r).files['matters/acme/notes.md']!;
+    expect(entry.editedOn).toBe('2026-09-02');
+    expect(existsSync(snapshotPath(r, entry.textHash))).toBe(true);
+  });
+
+  test('once per file per day: a second edit the same day is neither emitted nor absorbed; the next day reports everything since', () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, 'one\n');
+    recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' });
+    writeFileSync(p, 'two\n');
+    detectEdits(r, CFG, { now: DAY1 });
+    writeFileSync(p, 'three\n');
+    expect(detectEdits(r, CFG, { now: DAY1_LATER }).edited).toEqual([]);
+    expect(edits(r)).toHaveLength(1);
+    writeFileSync(p, 'four\n');
+    detectEdits(r, CFG, { now: DAY2 });
+    const lines = edits(r);
+    expect(lines).toHaveLength(2);
+    expect(lines[1]!.detail['diff']).toContain('-two\n+four\n');
+  });
+
+  test('a Word file compares its accept-all text: a metadata-only change refreshes the hash silently, a text change is an edit', () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'nda.docx');
+    writeFileSync(p, simpleDocx('Term of five years.', 'Delaware law.'));
+    recordWritten(r, CFG, { path: 'matters/acme/nda.docx', kind: 'artifact' });
+    const before = readWritten(r).files['matters/acme/nda.docx']!;
+    // Same text, different bytes: a header part Word would add on save.
+    writeFileSync(p, buildDocx({ blocks: [{ runs: ['Term of five years.'] }, { runs: ['Delaware law.'] }], header: [{ runs: ['Draft'] }] }));
+    expect(detectEdits(r, CFG, { now: DAY1 })).toMatchObject({ edited: [], refreshed: ['matters/acme/nda.docx'] });
+    const after = readWritten(r).files['matters/acme/nda.docx']!;
+    expect(after.hash).not.toBe(before.hash);
+    expect(after.textHash).toBe(before.textHash);
+    expect(edits(r)).toHaveLength(0);
+
+    writeFileSync(p, simpleDocx('Term of three years.', 'Delaware law.'));
+    detectEdits(r, CFG, { now: DAY1 });
+    const [line] = edits(r);
+    expect(line!.detail).toMatchObject({ format: 'docx', stats: { added: 1, removed: 1 } });
+    expect(line!.detail['diff']).toContain('-Term of five years.\n+Term of three years.\n');
+  });
+
+  test('a file that vanished drops its record; `outcomes: off` scans nothing', () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, 'one\n');
+    recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' });
+    writeFileSync(p, 'two\n');
+    expect(detectEdits(r, { ...CFG, outcomes: false }, { now: DAY1 })).toEqual({ checked: 0, edited: [], refreshed: [], missing: [] });
+    const { rmSync } = require('node:fs') as typeof import('node:fs');
+    rmSync(p);
+    expect(detectEdits(r, CFG, { now: DAY1 }).missing).toEqual(['matters/acme/notes.md']);
+    expect(readWritten(r).files).toEqual({});
+  });
+
+  test('the matters watcher scans after a debounce and can be closed', async () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, 'one\n');
+    recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' });
+    const scans: number[] = [];
+    const watcher = watchMatters(r, CFG, { debounceMs: 40, onScan: report => scans.push(report.edited.length) });
+    expect(watcher.active).toBe(true);
+    await Bun.sleep(20);
+    writeFileSync(p, 'two\n');
+    const deadline = Date.now() + 3000;
+    while (scans.length === 0 && Date.now() < deadline) await Bun.sleep(25);
+    watcher.close();
+    expect(scans).toEqual([1]);
+    expect(edits(r)).toHaveLength(1);
+    expect(watchMatters(join(r, 'nowhere'), CFG).active).toBe(false);
+  });
+
+  test('the watcher reads the `outcomes` switch at scan time, so turning the record off needs no restart', async () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, 'one\n');
+    recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' });
+    let outcomes = true;
+    const scans: number[] = [];
+    const watcher = watchMatters(r, () => ({ ...CFG, outcomes }), { debounceMs: 40, onScan: report => scans.push(report.checked) });
+    expect(watcher.active).toBe(true);
+    outcomes = false;
+    await Bun.sleep(20);
+    writeFileSync(p, 'two\n');
+    const deadline = Date.now() + 3000;
+    while (scans.length === 0 && Date.now() < deadline) await Bun.sleep(25);
+    watcher.close();
+    expect(scans).toEqual([0]);
+    expect(edits(r)).toHaveLength(0);
+  });
+});

--- a/runtime/src/outcomes/edits.ts
+++ b/runtime/src/outcomes/edits.ts
@@ -1,0 +1,299 @@
+/**
+ * Edit detection (routing-and-evals spec §7, "lawyer edits"): every file in
+ * the written record is compared with what is on disk. A change to the text
+ * is the lawyer's edit and becomes one `file.edited-after-counsel` outcome
+ * per file per day — the unified diff against counsel's version, capped —
+ * and the record moves forward to the lawyer's version. A Word file that
+ * changed bytes but not accept-all text (Word re-saved it) only refreshes
+ * the hash. Runs at serve start, from the doctor, from retro evidence, and
+ * from a light watcher on the matters folder.
+ */
+import { existsSync, readFileSync, statSync, watch, type FSWatcher } from 'node:fs';
+import { join } from 'node:path';
+import type { VaultConfig } from '../vault/resolve-root';
+import { appendOutcome, outcomesEnabled } from './store';
+import { SNAPSHOT_CAP_BYTES, entryFor, readWritten, removeSnapshot, saveSnapshot, sha256, snapshotPath, textOfFile, writeWritten, type WrittenEntry } from './written';
+
+/** The most lines an outcome's diff carries. */
+export const DIFF_LINE_CAP = 400;
+/** Above this many lines a side, the diff is prefix/suffix only. */
+const LCS_LINE_CAP = 3000;
+const CONTEXT = 3;
+
+export interface DiffResult {
+  text: string;
+  stats: { added: number; removed: number };
+  truncated: boolean;
+}
+
+type Op = { kind: ' ' | '-' | '+'; line: string };
+
+function splitLines(text: string): string[] {
+  if (text === '') return [];
+  const lines = text.split('\n');
+  if (lines[lines.length - 1] === '') lines.pop();
+  return lines;
+}
+
+/** The edit script between two line lists: common prefix and suffix
+ * trimmed, then an LCS over the middle (or a plain replace when the middle
+ * is too large to align). */
+function editScript(a: string[], b: string[]): Op[] {
+  let start = 0;
+  while (start < a.length && start < b.length && a[start] === b[start]) start += 1;
+  let endA = a.length;
+  let endB = b.length;
+  while (endA > start && endB > start && a[endA - 1] === b[endB - 1]) {
+    endA -= 1;
+    endB -= 1;
+  }
+  const midA = a.slice(start, endA);
+  const midB = b.slice(start, endB);
+  const ops: Op[] = a.slice(0, start).map(line => ({ kind: ' ', line }));
+  if (midA.length > LCS_LINE_CAP || midB.length > LCS_LINE_CAP) {
+    for (const line of midA) ops.push({ kind: '-', line });
+    for (const line of midB) ops.push({ kind: '+', line });
+  } else {
+    // LCS lengths, then a walk back from the corner.
+    const n = midA.length;
+    const m = midB.length;
+    const width = m + 1;
+    const table = new Uint16Array((n + 1) * width);
+    for (let i = n - 1; i >= 0; i -= 1) {
+      for (let j = m - 1; j >= 0; j -= 1) {
+        table[i * width + j] = midA[i] === midB[j] ? table[(i + 1) * width + j + 1]! + 1 : Math.max(table[(i + 1) * width + j]!, table[i * width + j + 1]!);
+      }
+    }
+    let i = 0;
+    let j = 0;
+    while (i < n && j < m) {
+      if (midA[i] === midB[j]) {
+        ops.push({ kind: ' ', line: midA[i]! });
+        i += 1;
+        j += 1;
+      } else if (table[(i + 1) * width + j]! >= table[i * width + j + 1]!) {
+        ops.push({ kind: '-', line: midA[i]! });
+        i += 1;
+      } else {
+        ops.push({ kind: '+', line: midB[j]! });
+        j += 1;
+      }
+    }
+    for (; i < n; i += 1) ops.push({ kind: '-', line: midA[i]! });
+    for (; j < m; j += 1) ops.push({ kind: '+', line: midB[j]! });
+  }
+  for (const line of a.slice(endA)) ops.push({ kind: ' ', line });
+  return ops;
+}
+
+/** A unified diff (hunks with `CONTEXT` lines, no file header), its stats,
+ * and whether the text was cut at `cap` lines. */
+export function unifiedDiff(before: string, after: string, cap: number = DIFF_LINE_CAP): DiffResult {
+  const ops = editScript(splitLines(before), splitLines(after));
+  const stats = { added: ops.filter(o => o.kind === '+').length, removed: ops.filter(o => o.kind === '-').length };
+  if (stats.added === 0 && stats.removed === 0) return { text: '', stats, truncated: false };
+
+  // Hunks: runs of changes with context, merged when the context overlaps.
+  const changed = ops.map((o, i) => (o.kind === ' ' ? -1 : i)).filter(i => i >= 0);
+  const hunks: Array<{ from: number; to: number }> = [];
+  for (const i of changed) {
+    const from = Math.max(0, i - CONTEXT);
+    const to = Math.min(ops.length, i + CONTEXT + 1);
+    const last = hunks[hunks.length - 1];
+    if (last !== undefined && from <= last.to) last.to = to;
+    else hunks.push({ from, to });
+  }
+  const out: string[] = [];
+  let truncated = false;
+  let oldLine = 1;
+  let newLine = 1;
+  let cursor = 0;
+  for (const h of hunks) {
+    for (; cursor < h.from; cursor += 1) {
+      const op = ops[cursor]!;
+      if (op.kind !== '+') oldLine += 1;
+      if (op.kind !== '-') newLine += 1;
+    }
+    const slice = ops.slice(h.from, h.to);
+    const oldCount = slice.filter(o => o.kind !== '+').length;
+    const newCount = slice.filter(o => o.kind !== '-').length;
+    const header = `@@ -${oldLine},${oldCount} +${newLine},${newCount} @@`;
+    if (out.length + 1 + slice.length > cap) {
+      truncated = true;
+      const room = cap - out.length - 1;
+      if (room > 0) {
+        out.push(header);
+        for (const op of slice.slice(0, room)) out.push(`${op.kind}${op.line}`);
+      }
+      break;
+    }
+    out.push(header);
+    for (const op of slice) out.push(`${op.kind}${op.line}`);
+    for (; cursor < h.to; cursor += 1) {
+      const op = ops[cursor]!;
+      if (op.kind !== '+') oldLine += 1;
+      if (op.kind !== '-') newLine += 1;
+    }
+  }
+  return { text: out.length === 0 ? '' : `${out.join('\n')}\n`, stats, truncated };
+}
+
+export interface EditReport {
+  checked: number;
+  edited: Array<{ path: string; format: WrittenEntry['format']; stats: DiffResult['stats'] | null; truncated: boolean }>;
+  /** Byte change, same text: the record's hash was refreshed. */
+  refreshed: string[];
+  /** Recorded files no longer on disk: their records were dropped. */
+  missing: string[];
+}
+
+export function utcDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * The scan. Synchronous and cheap when nothing changed (one hash per
+ * recorded file). Writes only under `.counsel/`: the outcomes record and
+ * the written record. Nothing when `outcomes: off`.
+ */
+export function detectEdits(vaultRoot: string, cfg: Pick<VaultConfig, 'mattersPath' | 'outcomes'>, opts: { now?: Date } = {}): EditReport {
+  const report: EditReport = { checked: 0, edited: [], refreshed: [], missing: [] };
+  if (!outcomesEnabled(cfg)) return report;
+  const now = opts.now ?? new Date();
+  const today = utcDay(now);
+  const file = readWritten(vaultRoot);
+  let dirty = false;
+  const stale: string[] = [];
+
+  for (const [path, entry] of Object.entries(file.files)) {
+    const abs = join(vaultRoot, path);
+    if (!existsSync(abs) || !statSync(abs).isFile()) {
+      delete file.files[path];
+      stale.push(entry.textHash);
+      report.missing.push(path);
+      dirty = true;
+      continue;
+    }
+    report.checked += 1;
+    const bytes = readFileSync(abs);
+    const hash = sha256(bytes);
+    if (hash === entry.hash) continue;
+
+    let text: string | null = null;
+    let textHash = hash;
+    const tooBig = bytes.byteLength > SNAPSHOT_CAP_BYTES;
+    if (!tooBig) {
+      try {
+        text = textOfFile(bytes, path);
+        textHash = sha256(text);
+      } catch {
+        // A Word file mid-save, or one that is no longer a package: leave the
+        // record alone and look again next time.
+        continue;
+      }
+    }
+    if (textHash === entry.textHash) {
+      file.files[path] = { ...entry, hash };
+      report.refreshed.push(path);
+      dirty = true;
+      continue;
+    }
+    // The lawyer's edit. Once per file per day: a repeat today is left for
+    // tomorrow's line, which then covers everything since the last one.
+    if (entry.editedOn === today) continue;
+
+    const snapshot = snapshotPath(vaultRoot, entry.textHash);
+    const diff = text !== null && existsSync(snapshot) ? unifiedDiff(readFileSync(snapshot, 'utf8'), text) : null;
+    appendOutcome(vaultRoot, cfg, {
+      at: now.toISOString(),
+      kind: 'file.edited-after-counsel',
+      path,
+      ...(entry.runId === undefined ? {} : { runId: entry.runId }),
+      ...(entry.threadId === undefined ? {} : { threadId: entry.threadId }),
+      detail: {
+        format: entry.format,
+        kind: entry.kind,
+        writtenAt: entry.at,
+        stats: diff === null ? null : diff.stats,
+        diff: diff === null ? null : diff.text,
+        truncated: diff === null ? false : diff.truncated,
+      },
+    });
+    report.edited.push({ path, format: entry.format, stats: diff === null ? null : diff.stats, truncated: diff === null ? false : diff.truncated });
+    const next = entryFor(bytes, { path, kind: entry.kind, at: entry.at, editedOn: today, ...(entry.runId === undefined ? {} : { runId: entry.runId }), ...(entry.threadId === undefined ? {} : { threadId: entry.threadId }) });
+    file.files[path] = next;
+    saveSnapshot(vaultRoot, bytes, path, next);
+    stale.push(entry.textHash);
+    dirty = true;
+  }
+
+  if (dirty) {
+    writeWritten(vaultRoot, file);
+    for (const h of stale) removeSnapshot(vaultRoot, file, h);
+  }
+  return report;
+}
+
+export interface MattersWatcher {
+  /** False when nothing is watched: the folder is missing, or the platform
+   * refused a watch. The `outcomes` switch is read at scan time instead, so
+   * flipping it in Settings needs no restart. */
+  active: boolean;
+  close(): void;
+}
+
+type EditConfig = Pick<VaultConfig, 'mattersPath' | 'outcomes'>;
+
+/**
+ * A light watcher on the matters folder: any change schedules one scan
+ * after `debounceMs` of quiet (default 5 s). Never throws — a platform
+ * without recursive watching just leaves the start-time scan and the
+ * doctor's. `cfg` may be a getter, read fresh at every scan.
+ */
+export function watchMatters(
+  vaultRoot: string,
+  cfg: EditConfig | (() => EditConfig),
+  opts: { debounceMs?: number; onScan?: (report: EditReport) => void; onError?: (message: string) => void } = {},
+): MattersWatcher {
+  const inactive: MattersWatcher = { active: false, close: () => undefined };
+  const config = typeof cfg === 'function' ? cfg : () => cfg;
+  const dir = join(vaultRoot, config().mattersPath);
+  if (!existsSync(dir)) return inactive;
+  let watcher: FSWatcher;
+  try {
+    watcher = watch(dir, { recursive: true });
+  } catch (err) {
+    opts.onError?.(err instanceof Error ? err.message : String(err));
+    return inactive;
+  }
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+  const scan = (): void => {
+    timer = null;
+    if (closed) return;
+    try {
+      const report = detectEdits(vaultRoot, config());
+      opts.onScan?.(report);
+    } catch (err) {
+      opts.onError?.(err instanceof Error ? err.message : String(err));
+    }
+  };
+  watcher.on('change', () => {
+    if (closed) return;
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(scan, opts.debounceMs ?? 5000);
+  });
+  watcher.on('error', err => {
+    opts.onError?.(err instanceof Error ? err.message : String(err));
+  });
+  // The watch must not keep a process alive that is otherwise done.
+  watcher.unref?.();
+  return {
+    active: true,
+    close: () => {
+      closed = true;
+      if (timer !== null) clearTimeout(timer);
+      watcher.close();
+    },
+  };
+}

--- a/runtime/src/outcomes/store.test.ts
+++ b/runtime/src/outcomes/store.test.ts
@@ -57,7 +57,17 @@ describe('the outcomes record (routing-and-evals spec §7)', () => {
       { at: 'a', kind: 'task.corrected', detail: { from: 'chat', to: 'review' } },
       { at: 'a', kind: 'artifact.produced', detail: {} },
       { at: 'a', kind: 'thread.deleted', detail: {} },
+      { at: 'a', kind: 'file.edited-after-counsel', path: 'matters/a/notes.md', detail: {} },
+      { at: 'b', kind: 'file.edited-after-counsel', path: 'matters/a/notes.md', detail: {} },
+      { at: 'b', kind: 'file.edited-after-counsel', path: 'matters/b/nda.docx', detail: {} },
     ]);
-    expect(counts).toEqual({ decisions: { approved: 1, rejected: 1, withReason: 1 }, marks: { useful: 1, notRight: 2 }, corrections: 1, documents: 1, deletedThreads: 1 });
+    expect(counts).toEqual({
+      decisions: { approved: 1, rejected: 1, withReason: 1 },
+      marks: { useful: 1, notRight: 2 },
+      corrections: 1,
+      documents: 1,
+      deletedThreads: 1,
+      edits: { count: 3, files: 2, paths: ['matters/a/notes.md', 'matters/b/nda.docx'] },
+    });
   });
 });

--- a/runtime/src/outcomes/store.ts
+++ b/runtime/src/outcomes/store.ts
@@ -17,7 +17,10 @@ export type OutcomeKind =
   | 'artifact.produced'
   | 'answer.marked'
   | 'task.corrected'
-  | 'thread.deleted';
+  | 'thread.deleted'
+  /** The lawyer changed a file after counsel wrote it (spec §7, "lawyer
+   * edits"): `detail` carries the diff stats and the unified diff. */
+  | 'file.edited-after-counsel';
 
 export interface OutcomeLine {
   at: string;
@@ -82,10 +85,23 @@ export interface OutcomeCounts {
   corrections: number;
   documents: number;
   deletedThreads: number;
+  /** Lawyer edits after counsel: how many lines, and the distinct files
+   * (first `EDIT_PATHS_CAP`, in order of first appearance). */
+  edits: { count: number; files: number; paths: string[] };
 }
 
+export const EDIT_PATHS_CAP = 10;
+
 export function countOutcomes(lines: OutcomeLine[]): OutcomeCounts {
-  const c: OutcomeCounts = { decisions: { approved: 0, rejected: 0, withReason: 0 }, marks: { useful: 0, notRight: 0 }, corrections: 0, documents: 0, deletedThreads: 0 };
+  const c: OutcomeCounts = {
+    decisions: { approved: 0, rejected: 0, withReason: 0 },
+    marks: { useful: 0, notRight: 0 },
+    corrections: 0,
+    documents: 0,
+    deletedThreads: 0,
+    edits: { count: 0, files: 0, paths: [] },
+  };
+  const edited = new Set<string>();
   for (const l of lines) {
     if (l.kind === 'proposal.decided') {
       if (l.detail['decision'] === 'approved') c.decisions.approved += 1;
@@ -97,6 +113,14 @@ export function countOutcomes(lines: OutcomeLine[]): OutcomeCounts {
     } else if (l.kind === 'task.corrected') c.corrections += 1;
     else if (l.kind === 'artifact.produced') c.documents += 1;
     else if (l.kind === 'thread.deleted') c.deletedThreads += 1;
+    else if (l.kind === 'file.edited-after-counsel') {
+      c.edits.count += 1;
+      if (typeof l.path === 'string' && !edited.has(l.path)) {
+        edited.add(l.path);
+        if (c.edits.paths.length < EDIT_PATHS_CAP) c.edits.paths.push(l.path);
+      }
+    }
   }
+  c.edits.files = edited.size;
   return c;
 }

--- a/runtime/src/outcomes/written.test.ts
+++ b/runtime/src/outcomes/written.test.ts
@@ -42,15 +42,24 @@ describe('the written-file record (routing-and-evals spec §7, lawyer edits)', (
     expect(textOfFile(bytes, 'matters/acme/nda.docx')).toBe('Term of five years.\nGoverning law: Delaware.\n');
   });
 
-  test('only files under the matters folder are recorded; the record is off with `outcomes: off`; a missing file records nothing', () => {
+  test('the record is off with `outcomes: off`, and a missing file records nothing', () => {
     const r = root();
-    mkdirSync(join(r, 'entities'), { recursive: true });
-    writeFileSync(join(r, 'entities', 'acme.md'), '# Acme\n');
-    expect(recordWritten(r, CFG, { path: 'entities/acme.md', kind: 'proposal' })).toBeNull();
     writeFileSync(join(r, 'matters', 'acme', 'x.md'), 'x\n');
     expect(recordWritten(r, { ...CFG, outcomes: false }, { path: 'matters/acme/x.md', kind: 'write' })).toBeNull();
     expect(recordWritten(r, CFG, { path: 'matters/acme/none.md', kind: 'write' })).toBeNull();
     expect(existsSync(writtenPath(r))).toBe(false);
+  });
+
+  test('a knowledge file counsel wrote is recorded too — an approved standard is counsel’s text', () => {
+    // The only callers are the three write hooks, so this can never sweep in
+    // a file the lawyer wrote alone; and rewriting a standard just after
+    // approving it is exactly the signal the record is for.
+    const r = root();
+    mkdirSync(join(r, 'practice', 'standards'), { recursive: true });
+    writeFileSync(join(r, 'practice', 'standards', 'nda.md'), '# NDA\nTerm: 3 years\n');
+    const entry = recordWritten(r, CFG, { path: 'practice/standards/nda.md', kind: 'proposal' });
+    expect(entry).not.toBeNull();
+    expect(readWritten(r).files['practice/standards/nda.md']).toBeTruthy();
   });
 
   test('re-recording a path replaces its entry and removes the old snapshot; dropping removes both', () => {

--- a/runtime/src/outcomes/written.test.ts
+++ b/runtime/src/outcomes/written.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { simpleDocx } from '../docx/test/builder';
+import { dropWritten, readWritten, recordWritten, snapshotPath, textOfFile, writtenPath } from './written';
+
+function root(): string {
+  const r = mkdtempSync(join(tmpdir(), 'written-'));
+  mkdirSync(join(r, 'matters', 'acme'), { recursive: true });
+  return r;
+}
+
+const CFG = { mattersPath: 'matters' };
+
+describe('the written-file record (routing-and-evals spec §7, lawyer edits)', () => {
+  test('recording a markdown file keeps its hash, its text hash, and a snapshot, owner-only', () => {
+    const r = root();
+    writeFileSync(join(r, 'matters', 'acme', 'notes.md'), '# Notes\n\nCounsel wrote this.\n');
+    const entry = recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write', runId: 'run-1', threadId: 't-1', at: '2026-09-02T10:00:00.000Z' });
+    expect(entry).not.toBeNull();
+    expect(entry!.format).toBe('text');
+    expect(entry!.hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(entry!.textHash).toBe(entry!.hash);
+    const file = readWritten(r);
+    expect(file.files['matters/acme/notes.md']).toEqual(entry!);
+    expect(readFileSync(snapshotPath(r, entry!.textHash), 'utf8')).toBe('# Notes\n\nCounsel wrote this.\n');
+    if (process.platform !== 'win32') {
+      expect(statSync(writtenPath(r)).mode & 0o777).toBe(0o600);
+      expect(statSync(snapshotPath(r, entry!.textHash)).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  test('a Word file is recorded by its bytes and its accept-all text', () => {
+    const r = root();
+    const bytes = simpleDocx('Term of five years.', 'Governing law: Delaware.');
+    writeFileSync(join(r, 'matters', 'acme', 'nda.docx'), bytes);
+    const entry = recordWritten(r, CFG, { path: 'matters/acme/nda.docx', kind: 'artifact' });
+    expect(entry!.format).toBe('docx');
+    expect(entry!.textHash).not.toBe(entry!.hash);
+    expect(readFileSync(snapshotPath(r, entry!.textHash), 'utf8')).toBe('Term of five years.\nGoverning law: Delaware.\n');
+    expect(textOfFile(bytes, 'matters/acme/nda.docx')).toBe('Term of five years.\nGoverning law: Delaware.\n');
+  });
+
+  test('only files under the matters folder are recorded; the record is off with `outcomes: off`; a missing file records nothing', () => {
+    const r = root();
+    mkdirSync(join(r, 'entities'), { recursive: true });
+    writeFileSync(join(r, 'entities', 'acme.md'), '# Acme\n');
+    expect(recordWritten(r, CFG, { path: 'entities/acme.md', kind: 'proposal' })).toBeNull();
+    writeFileSync(join(r, 'matters', 'acme', 'x.md'), 'x\n');
+    expect(recordWritten(r, { ...CFG, outcomes: false }, { path: 'matters/acme/x.md', kind: 'write' })).toBeNull();
+    expect(recordWritten(r, CFG, { path: 'matters/acme/none.md', kind: 'write' })).toBeNull();
+    expect(existsSync(writtenPath(r))).toBe(false);
+  });
+
+  test('re-recording a path replaces its entry and removes the old snapshot; dropping removes both', () => {
+    const r = root();
+    const p = join(r, 'matters', 'acme', 'notes.md');
+    writeFileSync(p, 'one\n');
+    const first = recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' })!;
+    writeFileSync(p, 'two\n');
+    const second = recordWritten(r, CFG, { path: 'matters/acme/notes.md', kind: 'write' })!;
+    expect(existsSync(snapshotPath(r, first.textHash))).toBe(false);
+    expect(existsSync(snapshotPath(r, second.textHash))).toBe(true);
+    expect(Object.keys(readWritten(r).files)).toEqual(['matters/acme/notes.md']);
+    dropWritten(r, 'matters/acme/notes.md');
+    expect(readWritten(r).files).toEqual({});
+    expect(existsSync(snapshotPath(r, second.textHash))).toBe(false);
+  });
+
+  test('a corrupt record reads as empty', () => {
+    const r = root();
+    mkdirSync(join(r, '.counsel'), { recursive: true });
+    writeFileSync(writtenPath(r), '{not json');
+    expect(readWritten(r)).toEqual({ version: 1, files: {} });
+  });
+});

--- a/runtime/src/outcomes/written.ts
+++ b/runtime/src/outcomes/written.ts
@@ -97,12 +97,17 @@ export interface RecordWrittenInput {
 
 /**
  * Records what is on disk at `path` right now as counsel's version. Returns
- * the entry, or `null` when nothing was recorded: the record is off, the
- * path is outside the matters folder, or the file is not there.
+ * the entry, or `null` when nothing was recorded: the record is off, or the
+ * file is not there.
+ *
+ * Every file counsel actually wrote is recorded, matter or knowledge. Only
+ * three callers reach here — an approved proposal, a produced document, a
+ * `vault_write` — so this can never sweep in a file the lawyer wrote alone;
+ * and an approved standard is precisely counsel's text, so rewriting it
+ * after approving it is the signal this record exists to keep.
  */
 export function recordWritten(vaultRoot: string, cfg: Pick<VaultConfig, 'mattersPath' | 'outcomes'>, input: RecordWrittenInput): WrittenEntry | null {
   if (!outcomesEnabled(cfg)) return null;
-  if (!inMatters(cfg, input.path)) return null;
   const abs = join(vaultRoot, input.path);
   if (!existsSync(abs)) return null;
   const bytes = readFileSync(abs);

--- a/runtime/src/outcomes/written.ts
+++ b/runtime/src/outcomes/written.ts
@@ -1,0 +1,156 @@
+/**
+ * The written-file record (routing-and-evals spec §7, "lawyer edits"):
+ * what counsel wrote into the matters folder, so a later change to the same
+ * file can be read as the lawyer's edit. One entry per path in
+ * `<vault>/.counsel/written.json` — the content hash, the text hash (a Word
+ * file's accept-all text; the file itself for markdown), and a text
+ * snapshot under `.counsel/written/<textHash>.txt` that the edit detector
+ * diffs against. Owner-only files, like everything under `.counsel/`.
+ *
+ * Matters only: knowledge paths are the lawyer's to curate, and an edit
+ * there says nothing about counsel's work. Off with `outcomes: off`.
+ */
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { writeFileAtomic } from '../core/atomic-write';
+import { isDocxPath, modelOf, openDocx, textOf } from '../docx';
+import type { VaultConfig } from '../vault/resolve-root';
+import { outcomesEnabled } from './store';
+
+export type WrittenKind = 'proposal' | 'artifact' | 'write';
+
+export interface WrittenEntry {
+  /** sha256 of the bytes on disk when counsel wrote them. */
+  hash: string;
+  /** sha256 of the text the detector compares (the snapshot's content). */
+  textHash: string;
+  format: 'text' | 'docx';
+  kind: WrittenKind;
+  at: string;
+  runId?: string;
+  threadId?: string;
+  /** The UTC day (`YYYY-MM-DD`) an edit was last reported — once per file
+   * per day. */
+  editedOn?: string;
+}
+
+export interface WrittenFile {
+  version: 1;
+  files: Record<string, WrittenEntry>;
+}
+
+/** Above this a file is hashed, never snapshotted or diffed. */
+export const SNAPSHOT_CAP_BYTES = 2 * 1024 * 1024;
+
+export function writtenPath(vaultRoot: string): string {
+  return join(vaultRoot, '.counsel', 'written.json');
+}
+
+export function snapshotPath(vaultRoot: string, textHash: string): string {
+  return join(vaultRoot, '.counsel', 'written', `${textHash}.txt`);
+}
+
+export function sha256(data: Uint8Array | string): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+/** The text the detector compares: a Word file's accept-all text, one
+ * paragraph per line; anything else as UTF-8. */
+export function textOfFile(bytes: Uint8Array, path: string): string {
+  if (isDocxPath(path)) {
+    const model = modelOf(openDocx(bytes));
+    return model.paragraphs.map(p => textOf(p, 'accept')).join('\n') + (model.paragraphs.length > 0 ? '\n' : '');
+  }
+  return new TextDecoder('utf-8').decode(bytes);
+}
+
+export function readWritten(vaultRoot: string): WrittenFile {
+  const path = writtenPath(vaultRoot);
+  if (!existsSync(path)) return { version: 1, files: {} };
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<WrittenFile>;
+    if (parsed === null || typeof parsed !== 'object' || typeof parsed.files !== 'object' || parsed.files === null) return { version: 1, files: {} };
+    return { version: 1, files: parsed.files };
+  } catch {
+    return { version: 1, files: {} };
+  }
+}
+
+export function writeWritten(vaultRoot: string, file: WrittenFile): void {
+  writeFileAtomic(writtenPath(vaultRoot), `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600, dirMode: 0o700 });
+}
+
+/** Whether `path` (vault-relative, forward slashes) sits under the matters folder. */
+export function inMatters(cfg: Pick<VaultConfig, 'mattersPath'>, path: string): boolean {
+  const base = cfg.mattersPath.replace(/\/+$/, '');
+  return path === base || path.startsWith(`${base}/`);
+}
+
+export interface RecordWrittenInput {
+  path: string;
+  kind: WrittenKind;
+  runId?: string;
+  threadId?: string;
+  at?: string;
+}
+
+/**
+ * Records what is on disk at `path` right now as counsel's version. Returns
+ * the entry, or `null` when nothing was recorded: the record is off, the
+ * path is outside the matters folder, or the file is not there.
+ */
+export function recordWritten(vaultRoot: string, cfg: Pick<VaultConfig, 'mattersPath' | 'outcomes'>, input: RecordWrittenInput): WrittenEntry | null {
+  if (!outcomesEnabled(cfg)) return null;
+  if (!inMatters(cfg, input.path)) return null;
+  const abs = join(vaultRoot, input.path);
+  if (!existsSync(abs)) return null;
+  const bytes = readFileSync(abs);
+  const entry = entryFor(bytes, input);
+  const file = readWritten(vaultRoot);
+  const previous = file.files[input.path];
+  file.files[input.path] = entry;
+  saveSnapshot(vaultRoot, bytes, input.path, entry);
+  writeWritten(vaultRoot, file);
+  if (previous !== undefined && previous.textHash !== entry.textHash) removeSnapshot(vaultRoot, file, previous.textHash);
+  return entry;
+}
+
+export function entryFor(bytes: Uint8Array, input: RecordWrittenInput & { editedOn?: string }): WrittenEntry {
+  const big = bytes.byteLength > SNAPSHOT_CAP_BYTES;
+  const format = isDocxPath(input.path) ? 'docx' : 'text';
+  const hash = sha256(bytes);
+  const textHash = big ? hash : sha256(textOfFile(bytes, input.path));
+  return {
+    hash,
+    textHash,
+    format,
+    kind: input.kind,
+    at: input.at ?? new Date().toISOString(),
+    ...(input.runId === undefined ? {} : { runId: input.runId }),
+    ...(input.threadId === undefined ? {} : { threadId: input.threadId }),
+    ...(input.editedOn === undefined ? {} : { editedOn: input.editedOn }),
+  };
+}
+
+export function saveSnapshot(vaultRoot: string, bytes: Uint8Array, path: string, entry: WrittenEntry): void {
+  if (bytes.byteLength > SNAPSHOT_CAP_BYTES) return;
+  const target = snapshotPath(vaultRoot, entry.textHash);
+  if (existsSync(target)) return;
+  writeFileAtomic(target, textOfFile(bytes, path), { mode: 0o600, dirMode: 0o700 });
+}
+
+/** Removes a snapshot no remaining entry points at. */
+export function removeSnapshot(vaultRoot: string, file: WrittenFile, textHash: string): void {
+  if (Object.values(file.files).some(e => e.textHash === textHash)) return;
+  rmSync(snapshotPath(vaultRoot, textHash), { force: true });
+}
+
+export function dropWritten(vaultRoot: string, path: string): void {
+  const file = readWritten(vaultRoot);
+  const entry = file.files[path];
+  if (entry === undefined) return;
+  delete file.files[path];
+  writeWritten(vaultRoot, file);
+  removeSnapshot(vaultRoot, file, entry.textHash);
+}

--- a/runtime/src/retro/__snapshots__/evidence.test.ts.snap
+++ b/runtime/src/retro/__snapshots__/evidence.test.ts.snap
@@ -33,6 +33,7 @@ exports[`gatherRetroEvidence renders the period as plain facts for the system pr
 ### Decisions and marks
 - Proposals decided: 0 approved, 0 rejected (0 with a reason).
 - Answers marked: 0 useful, 0 not right; 0 task corrections; 0 conversations deleted.
+- Files edited after counsel: 0 edits across 0 files.
 
 ### Matters
 - 1 of 2 matters touched in the period:

--- a/runtime/src/retro/evidence.test.ts
+++ b/runtime/src/retro/evidence.test.ts
@@ -9,6 +9,7 @@ import { FsVaultStore } from '../vault/fs-store';
 import { readVaultConfig } from '../vault/resolve-root';
 import { gatherRetroEvidence, renderRetroEvidence } from './evidence';
 import { appendOutcome } from '../outcomes/store';
+import { recordWritten } from '../outcomes/written';
 
 const NOW = new Date('2026-09-01T12:00:00.000Z');
 const SINCE = '2026-07-01T00:00:00.000Z';
@@ -144,13 +145,26 @@ describe('gatherRetroEvidence outcomes (routing-and-evals spec §7)', () => {
     appendOutcome(vaultRoot, {}, { kind: 'answer.marked', at: '2026-05-01T00:00:00.000Z', detail: { mark: 'not-right' } });
 
     const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW });
-    expect(e.outcomes).toEqual({ decisions: { approved: 1, rejected: 1, withReason: 1 }, marks: { useful: 1, notRight: 0 }, corrections: 1, documents: 0, deletedThreads: 1 });
+    expect(e.outcomes).toEqual({ decisions: { approved: 1, rejected: 1, withReason: 1 }, marks: { useful: 1, notRight: 0 }, corrections: 1, documents: 0, deletedThreads: 1, edits: { count: 0, files: 0, paths: [] } });
     const text = renderRetroEvidence(e);
     expect(text).toContain('### Decisions and marks');
     expect(text).toContain('1 approved, 1 rejected (1 with a reason)');
     expect(text).toContain('1 useful, 0 not right; 1 task corrections; 1 conversations deleted');
+    expect(text).toContain('Files edited after counsel: 0 edits across 0 files.');
 
     const all = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: null, now: NOW });
     expect(all.outcomes.marks.notRight).toBe(1);
+  });
+
+  test('runs the edit scan first, so a file the lawyer changed since the last look is in this retro', async () => {
+    const { vaultRoot, store, vault } = await seed();
+    writeFileSync(join(vaultRoot, 'matters', 'acme-nda.md'), '# Acme\n\nTerm: five years.\n', 'utf8');
+    recordWritten(vaultRoot, { mattersPath: 'matters' }, { path: 'matters/acme-nda.md', kind: 'write', runId: 'r-1' });
+    writeFileSync(join(vaultRoot, 'matters', 'acme-nda.md'), '# Acme\n\nTerm: three years.\n', 'utf8');
+    const e = await gatherRetroEvidence({ vaultRoot, tenant: 'default', store, vault, cfg: readVaultConfig(vaultRoot), since: SINCE, now: NOW });
+    expect(e.outcomes.edits).toEqual({ count: 1, files: 1, paths: ['matters/acme-nda.md'] });
+    const text = renderRetroEvidence(e);
+    expect(text).toContain('Files edited after counsel: 1 edit across 1 file.');
+    expect(text).toContain('  - matters/acme-nda.md');
   });
 });

--- a/runtime/src/retro/evidence.ts
+++ b/runtime/src/retro/evidence.ts
@@ -6,7 +6,8 @@ import { listAllRuns, type RunRecord } from '../loop/run-record';
 import type { ThreadEvent, ThreadHeader, ThreadStore } from '../threads/store';
 import { vaultOverview, type MatterOverview } from '../vault/overview';
 import type { VaultConfig } from '../vault/resolve-root';
-import { countOutcomes, readOutcomes, type OutcomeCounts } from '../outcomes/store';
+import { detectEdits } from '../outcomes/edits';
+import { countOutcomes, readOutcomes, type OutcomeCounts, type OutcomeLine } from '../outcomes/store';
 
 /**
  * What the runtime knows about the period, gathered for the retro's system
@@ -114,6 +115,18 @@ function firstLine(text: string): string {
   return line.length > RATIONALE_CAP ? `${line.slice(0, RATIONALE_CAP - 1)}…` : line;
 }
 
+/** The outcomes record after the edit scan (spec §7): a file the lawyer
+ * changed since the last look is counted in this retro, not the next. A
+ * scan failure is not the retro's problem. */
+function outcomesAfterScan(deps: RetroEvidenceDeps, now: Date): OutcomeLine[] {
+  try {
+    detectEdits(deps.vaultRoot, deps.cfg, { now });
+  } catch {
+    /* the record as it stands */
+  }
+  return readOutcomes(deps.vaultRoot, { since: deps.since });
+}
+
 export async function gatherRetroEvidence(deps: RetroEvidenceDeps): Promise<RetroEvidence> {
   const now = deps.now ?? new Date();
   const to = now.toISOString();
@@ -183,7 +196,7 @@ export async function gatherRetroEvidence(deps: RetroEvidenceDeps): Promise<Retr
     runs,
     proposals,
     artifacts,
-    outcomes: countOutcomes(readOutcomes(deps.vaultRoot, { since }).filter(l => inPeriod(l.at, since, to))),
+    outcomes: countOutcomes(outcomesAfterScan(deps, now).filter(l => inPeriod(l.at, since, to))),
     matters,
     memory: readMemory(deps.vaultRoot),
     doctor: deps.doctor === undefined ? null : deps.doctor(),
@@ -265,6 +278,8 @@ export function renderRetroEvidence(e: RetroEvidence): string {
   lines.push('### Decisions and marks');
   lines.push(`- Proposals decided: ${e.outcomes.decisions.approved} approved, ${e.outcomes.decisions.rejected} rejected (${e.outcomes.decisions.withReason} with a reason).`);
   lines.push(`- Answers marked: ${e.outcomes.marks.useful} useful, ${e.outcomes.marks.notRight} not right; ${e.outcomes.corrections} task corrections; ${e.outcomes.deletedThreads} conversations deleted.`);
+  lines.push(`- Files edited after counsel: ${e.outcomes.edits.count} edit${e.outcomes.edits.count === 1 ? '' : 's'} across ${e.outcomes.edits.files} file${e.outcomes.edits.files === 1 ? '' : 's'}.`);
+  for (const p of e.outcomes.edits.paths) lines.push(`  - ${p}`);
   lines.push('');
   lines.push('### Matters');
   lines.push(`- ${e.matters.touched.length} of ${e.matters.total} matters touched in the period:`);

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
+import { readWritten } from '../outcomes/written';
 import { createHash, randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
@@ -492,6 +493,19 @@ describe('POST /threads/:id/approve', () => {
     expect(ev).toBeDefined();
     return { threadId, proposalId: ev!.id };
   }
+
+  test('an approved proposal into a matter is recorded as counsel\'s version of that file (spec §7, lawyer edits)', async () => {
+    const app = appWithFake([
+      { toolCalls: [{ name: 'propose_update', input: { path: 'matters/acme/notes.md', content: 'NOTE\n', rationale: 'log it' } }], text: 'proposed' },
+    ]);
+    const { threadId, proposalId } = await seedProposal(app);
+    const res = await call(app, 'POST', `/threads/${threadId}/approve`, { body: { proposalId, decision: 'approve' } });
+    expect(res.status).toBe(200);
+    const entry = readWritten(vaultRoot).files['matters/acme/notes.md'];
+    expect(entry).toBeDefined();
+    expect(entry!.kind).toBe('proposal');
+    expect(entry!.threadId).toBe(threadId);
+  });
 
   test('approve writes the vault file and returns the updated proposal', async () => {
     const app = appWithFake([proposal]);
@@ -1380,7 +1394,7 @@ describe('content updates and doctor (spec 2026-09-01 §6–§7)', () => {
     expect(res.status).toBe(200);
     const report = (await res.json()) as { findings: Array<{ check: string; severity: string }>; verdict: string; vault: string };
     expect(report.vault).toBe(vaultRoot);
-    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact']);
+    expect(report.findings.map(f => f.check)).toEqual(['root-config', 'structure', 'law-currency', 'git', 'consistency', 'law-impact', 'edits-after-counsel']);
     expect(report.findings[0]!.severity).toBe('ok');
     expect(report.findings.find(f => f.check === 'git')!.severity).toBe('warn');
     expect(['warnings', 'broken']).toContain(report.verdict);

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -16,6 +16,7 @@ import { normalizeVaultPath } from '../vault/knowledge-paths';
 import { vaultOverview } from '../vault/overview';
 import { readVaultConfig, writeVaultConfigOverride } from '../vault/resolve-root';
 import { appendOutcome, readOutcomes, type OutcomeLine } from '../outcomes/store';
+import { recordWritten } from '../outcomes/written';
 import { isTask, TASK_IDS } from '../tasks/taxonomy';
 import { modelClassifier } from '../tasks/classify';
 import { applyUpdates, contentStatus, UpdateError } from '../content/update';
@@ -870,12 +871,22 @@ export function createApp(deps: ServerDeps): App {
       return fail(409, `vault conflict on ${await proposalPath(deps, id, input.proposalId)}`, { conflict: result.conflict });
     }
     if (!('error' in result) && (result.status === 'approved' || result.status === 'rejected')) {
+      const path = await proposalPath(deps, id, input.proposalId);
       recordOutcome({
         kind: 'proposal.decided',
         threadId: id,
-        path: await proposalPath(deps, id, input.proposalId),
+        path,
         detail: { proposalId: input.proposalId, decision: result.status, decidedAt: new Date().toISOString(), ...(input.reason === undefined || input.reason === '' ? {} : { reason: input.reason }) },
       });
+      // An approved proposal into a matter is counsel's version of that
+      // file from now on (spec §7, lawyer edits).
+      if (result.status === 'approved') {
+        try {
+          recordWritten(deps.vaultRoot, readVaultConfig(deps.vaultRoot), { path, kind: 'proposal', threadId: id });
+        } catch (err) {
+          console.error(`routes: written record failed for ${path}: ${text(err)}`);
+        }
+      }
     }
     // The proposal had already been decided — the earlier decision stands
     // and nothing was written.

--- a/runtime/src/server/serve.test.ts
+++ b/runtime/src/server/serve.test.ts
@@ -3,6 +3,8 @@ import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, statSync, 
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { DEFAULT_STEP_TIMEOUT_MS } from '../loop/counsel-loop';
+import { readOutcomes } from '../outcomes/store';
+import { recordWritten } from '../outcomes/written';
 import {
   browserCommand,
   counselHome,
@@ -65,6 +67,21 @@ describe('startServer', () => {
     await running.stop();
     running = undefined;
     expect(existsSync(file)).toBe(false);
+  });
+
+  test('serve start scans for lawyer edits and keeps a watcher on the matters folder until stop (spec §7)', async () => {
+    const { vault, pluginRoot, env } = fixture();
+    mkdirSync(join(vault, 'matters', 'acme'), { recursive: true });
+    writeFileSync(join(vault, 'matters', 'acme', 'notes.md'), 'Term: five years.\n', 'utf8');
+    recordWritten(vault, { mattersPath: 'matters' }, { path: 'matters/acme/notes.md', kind: 'write' });
+    // Edited while the runtime was down.
+    writeFileSync(join(vault, 'matters', 'acme', 'notes.md'), 'Term: three years.\n', 'utf8');
+    running = await startServer({ vault, pluginRoot, port: 0, env, registryFile: join(vault, 'none.yaml') });
+    const lines = readOutcomes(vault, { kind: 'file.edited-after-counsel' });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]!.path).toBe('matters/acme/notes.md');
+    await running.stop();
+    running = undefined;
   });
 
   test('COUNSEL_OS_HOME redirects the codex homes and the provider registry', async () => {

--- a/runtime/src/server/serve.ts
+++ b/runtime/src/server/serve.ts
@@ -16,7 +16,8 @@ import { openSecretStore, type SecretStore } from '../providers/secrets';
 import { ThreadStore } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
 import { fsSearch } from '../vault/search';
-import { resolveLegalRoot } from '../vault/resolve-root';
+import { readVaultConfig, resolveLegalRoot } from '../vault/resolve-root';
+import { detectEdits, watchMatters, type MattersWatcher } from '../outcomes/edits';
 import { createApp, type App } from './routes';
 import type { RuntimeState } from './settings';
 import { createSetupApp } from './setup-routes';
@@ -410,6 +411,7 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
 
   let vaultRoot: string | null = resolveVaultOrSetup(opts);
   let store: ThreadStore | null = null;
+  let mattersWatcher: MattersWatcher | null = null;
 
   /** The app over a vault — what this server has always been. Built once
    * at start when a root exists, or once from `POST /setup` when not. */
@@ -437,6 +439,20 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
       if (auto.applied.length > 0) console.log(`counsel-os runtime: applied ${auto.applied.length} law update${auto.applied.length === 1 ? '' : 's'} (auto_apply_law_updates)`);
     } catch (err) {
       console.error(`counsel-os runtime: auto-apply of law updates failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+    // Lawyer edits (routing-and-evals spec §7): files counsel wrote that
+    // changed while the runtime was down are recorded now, then a light
+    // watcher on the matters folder keeps looking. Off with `outcomes: off`
+    // (read at every scan). Never fatal.
+    try {
+      const scan = detectEdits(vault, readVaultConfig(vault));
+      if (scan.edited.length > 0) console.log(`counsel-os runtime: ${scan.edited.length} file${scan.edited.length === 1 ? '' : 's'} edited after counsel — recorded`);
+      mattersWatcher?.close();
+      mattersWatcher = watchMatters(vault, () => readVaultConfig(vault), {
+        onError: message => console.error(`counsel-os runtime: matters watcher: ${message}`),
+      });
+    } catch (err) {
+      console.error(`counsel-os runtime: edit scan failed: ${err instanceof Error ? err.message : String(err)}`);
     }
     return createApp({
       token,
@@ -535,6 +551,8 @@ export async function startServer(opts: StartServerOptions = {}): Promise<Runnin
       process.off('SIGINT', onSignal);
       process.off('SIGTERM', onSignal);
       process.off('exit', removeFile);
+      mattersWatcher?.close();
+      mattersWatcher = null;
       removeFile();
       await server.stop(true);
     },

--- a/runtime/src/vault/vault-tools.test.ts
+++ b/runtime/src/vault/vault-tools.test.ts
@@ -79,6 +79,23 @@ describe('guardedVaultTools', () => {
     expect(await store.read('default', 'matters/a.md')).toBe('hi');
   });
 
+  test('an onWrite hook sees the normalized path after a matter write, and its throw never fails the write', async () => {
+    const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
+    const seen: string[] = [];
+    const tools = guardedVaultTools(store, defaultCfg, {
+      onWrite: path => {
+        seen.push(path);
+        throw new Error('bookkeeping broke');
+      },
+    });
+    const r = await runToolDef(tools, 'vault_write', { path: './matters/a.md', content: 'hi' }, 'default');
+    expect(r.isError).toBe(false);
+    expect(seen).toEqual(['matters/a.md']);
+    const refused = await runToolDef(tools, 'vault_write', { path: 'practice/x.md', content: 'no' }, 'default');
+    expect(refused.isError).toBe(true);
+    expect(seen).toEqual(['matters/a.md']);
+  });
+
   test('vault_read/vault_list/vault_search are unaffected by the guard', async () => {
     const store = new FsVaultStore(mkdtempSync(join(tmpdir(), 'gvt-')));
     await store.write('default', 'practice/profile.md', 'profile content');

--- a/runtime/src/vault/vault-tools.ts
+++ b/runtime/src/vault/vault-tools.ts
@@ -68,7 +68,14 @@ function knowledgeDirsList(cfg: VaultConfig): string {
  * be used to dodge the knowledge-path check that a plain string-prefix test
  * would miss.
  */
-export function guardedVaultTools(store: VaultStore, cfg: VaultConfig): ToolDef[] {
+export interface VaultToolHooks {
+  /** Called after a `vault_write` landed, with the normalized path — the
+   * written-file record (routing-and-evals spec §7) hangs off it. A throw
+   * here is swallowed: bookkeeping never fails the model's write. */
+  onWrite?: (path: string) => void;
+}
+
+export function guardedVaultTools(store: VaultStore, cfg: VaultConfig, hooks: VaultToolHooks = {}): ToolDef[] {
   return vaultTools(store).map(tool => {
     if (tool.name === 'vault_write') {
       const write = tool as ToolDef<{ path: string; content: string; expectedVersion?: string }, { version: string }>;
@@ -80,7 +87,13 @@ export function guardedVaultTools(store: VaultStore, cfg: VaultConfig): ToolDef[
           if (isKnowledgePath(path, cfg)) {
             throw new Error(`${path} is a knowledge-system path (${knowledgeDirsList(cfg)}) — use propose_update instead of vault_write.`);
           }
-          return write.execute({ ...input, path }, ctx);
+          const result = await write.execute({ ...input, path }, ctx);
+          try {
+            hooks.onWrite?.(path);
+          } catch {
+            /* the write itself succeeded; the record is best effort */
+          }
+          return result;
         },
       };
     }


### PR DESCRIPTION
When counsel writes a file — an approved proposal, a redline or comparison it produced, a note into a matter — the runtime keeps that version. A later edit by the lawyer is recorded once a day as `file.edited-after-counsel` with its line counts and diff, in the same local `.counsel/outcomes.jsonl` as the other decisions. Word files compare their accept-all text. `counsel-os doctor` counts them; the retro's evidence carries them into the review; `outcomes: off` stops every write, as before.

**Verified end to end on a throwaway vault**, not only in tests: a proposal approved into `practice/standards/nda.md` was recorded as counsel's version; appending a line by hand produced `1 file edited after counsel since the last look` from doctor and an outcome line carrying `{added: 2, removed: 0}` and the unified diff.

**One decision reversed while verifying** (recorded in the plan): the record first covered only the matters folder, on the reasoning that knowledge paths are the lawyer's to curate. That made the commonest path record nothing — approving a proposed standard *is* counsel writing a knowledge file, and doctor then claimed counsel had written nothing right after it had. Only three hooks reach the record (an approved proposal, a produced document, a `vault_write`), so it can never sweep in a file the lawyer wrote alone, and rewriting a standard just after approving it is exactly the signal the record is for.

Tests: runtime 1180 pass, UI 544 pass, both typechecks clean.

**Split from the spec's step 5**: "make this a fixture" (the draft builder, the anonymizer, and the review screen) follows as 5b. This half stands on its own — it feeds doctor and the retro today, and it is the raw material the scoreboard's practice fixtures will draw on.