### PR TITLE
Routing knobs: the bar, the preference and the pin in Settings

### DIFF
--- a/runtime/src/router/policy.ts
+++ b/runtime/src/router/policy.ts
@@ -78,7 +78,23 @@ export function readRoutingPolicy(vaultRoot: string): RoutingPolicy {
   }
 }
 
-/** The file as a lawyer would read it: one block per task, comments kept. */
+/**
+ * A YAML scalar that means exactly the string it holds. A task name or a
+ * provider id reaches this file from the UI, so anything that would be read
+ * as YAML syntax — a colon, a leading `#`, `&`, `*`, `-`, a newline — is
+ * quoted. Unquoted, one such value makes the whole file unparseable, and an
+ * unparseable file reads as "no policy at all": every bar and every pin in
+ * it silently gone.
+ */
+function scalar(s: string): string {
+  return /^[A-Za-z0-9_][A-Za-z0-9_./-]*$/.test(s) ? s : `"${s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n')}"`;
+}
+
+/**
+ * The file as a lawyer would read it: the header, then one block per task.
+ * The whole file is rewritten from the policy, so a hand-written comment
+ * below the header does not survive a change made in Settings.
+ */
 export function renderRoutingPolicy(policy: RoutingPolicy): string {
   const head = [
     '# How counsel-os routes each kind of work (docs: routing-and-evals spec §6).',
@@ -93,10 +109,10 @@ export function renderRoutingPolicy(policy: RoutingPolicy): string {
   const lines = ['tasks:'];
   for (const task of names) {
     const entry = policy.tasks[task]!;
-    lines.push(`  ${task}:`);
+    lines.push(`  ${scalar(task)}:`);
     if (entry.min_score !== undefined) lines.push(`    min_score: ${entry.min_score}`);
     if (entry.prefer !== undefined) lines.push(`    prefer: ${entry.prefer}`);
-    if (entry.pinned !== undefined) lines.push(`    pinned: ${entry.pinned}`);
+    if (entry.pinned !== undefined) lines.push(`    pinned: ${scalar(entry.pinned)}`);
   }
   return `${head.join('\n')}${lines.join('\n')}\n`;
 }

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -1918,6 +1918,41 @@ describe('the eval runner over HTTP (routing-and-evals spec §4.2)', () => {
     expect(board.tasks.find(t => t.task === 'review')!.sets.practice!.rows).toEqual([]);
   });
 
+  test('GET /routing reports the bar, the preference and who that picks; PUT changes one task and the next step follows it', async () => {
+    const app = appWith([new FakeModelProvider([{ output: sample('law-beats-practice'), usage: { inputTokens: 10, outputTokens: 2, costUsd: 0.01 } }])], { evals: evalsDeps() });
+    // Nothing scored yet: the defaults stand and no task claims a pick.
+    const bare = (await (await call(app, 'GET', '/routing')).json()) as { defaults: { minScore: number; prefer: string }; tasks: Record<string, unknown> };
+    expect(bare.defaults).toEqual({ minScore: 0.7, prefer: 'quality' });
+
+    // Score the fake provider on `review`; it clears the default bar.
+    await (await call(app, 'POST', '/evals/run', { body: { fixtures: ['law-beats-practice'], save: true } })).text();
+    const scored = (await (await call(app, 'GET', '/routing')).json()) as {
+      tasks: Record<string, { minScore: number; prefer: string; pinned?: string; picked?: { providerId: string; reason: string } }>;
+    };
+    expect(scored.tasks['review']).toMatchObject({ minScore: 0.7, prefer: 'quality' });
+    expect(scored.tasks['review']?.picked).toEqual({ providerId: 'fake/fake', reason: 'review 1.00' });
+
+    // Raise the bar above what it scored: the same provider is no longer the
+    // scoreboard's pick, and the reason says so.
+    const raised = (await (await call(app, 'PUT', '/routing', { body: { task: 'review', minScore: 1 } })).json()) as typeof scored;
+    expect(raised.tasks['review']?.minScore).toBe(1);
+    const lowered = (await (await call(app, 'PUT', '/routing', { body: { task: 'review', minScore: 0.5, prefer: 'cost', pinned: 'fake/fake' } })).json()) as typeof scored;
+    expect(lowered.tasks['review']).toMatchObject({ minScore: 0.5, prefer: 'cost', pinned: 'fake/fake' });
+    expect(lowered.tasks['review']?.picked?.reason).toBe('pinned for review · 1.00');
+
+    // Unpinning leaves the rest of the task's policy alone.
+    const unpinned = (await (await call(app, 'PUT', '/routing', { body: { task: 'review', pinned: null } })).json()) as typeof scored;
+    expect(unpinned.tasks['review']?.pinned).toBeUndefined();
+    expect(unpinned.tasks['review']).toMatchObject({ minScore: 0.5, prefer: 'cost' });
+  });
+
+  test('PUT /routing refuses a body that is not a routing change', async () => {
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { evals: evalsDeps() });
+    expect((await call(app, 'PUT', '/routing', { body: { task: '' } })).status).toBe(400);
+    expect((await call(app, 'PUT', '/routing', { body: { task: 'review', minScore: 2 } })).status).toBe(400);
+    expect((await call(app, 'PUT', '/routing', { body: { task: 'review', prefer: 'cheapest' } })).status).toBe(400);
+  });
+
   test('GET /evals/estimate says how many fixtures a task runs and what it may cost', async () => {
     const app = appWith([new FakeModelProvider([{ text: 'x' }])], { evals: evalsDeps({ pricing: () => ({ prompt: 3, completion: 15 }) }) });
     const res = await call(app, 'GET', '/evals/estimate?task=review&providerId=fake%2Ffake');

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { FakeModelProvider, runToolDef } from '../core/fake-provider';
 import type { Capabilities, ModelProvider, StepEvent, StepRequest } from '../core/types';
+import { readRoutingPolicy, writeRoutingPolicy } from '../router/policy';
 import { Router } from '../router/router';
 import { ThreadStore, type ThreadEvent } from '../threads/store';
 import { FsVaultStore } from '../vault/fs-store';
@@ -1951,6 +1952,26 @@ describe('the eval runner over HTTP (routing-and-evals spec §4.2)', () => {
     expect((await call(app, 'PUT', '/routing', { body: { task: '' } })).status).toBe(400);
     expect((await call(app, 'PUT', '/routing', { body: { task: 'review', minScore: 2 } })).status).toBe(400);
     expect((await call(app, 'PUT', '/routing', { body: { task: 'review', prefer: 'cheapest' } })).status).toBe(400);
+    // A task name is a name, not free text: it becomes a key in the policy file.
+    expect((await call(app, 'PUT', '/routing', { body: { task: 'review: contracts', minScore: 0.5 } })).status).toBe(400);
+    expect((await call(app, 'PUT', '/routing', { body: { task: '#urgent', minScore: 0.5 } })).status).toBe(400);
+    // A pin names a provider this practice has loaded.
+    expect((await call(app, 'PUT', '/routing', { body: { task: 'review', pinned: 'ghost/ghost' } })).status).toBe(422);
+  });
+
+  test('a change to one task leaves every other task alone, whatever its name looks like in YAML', async () => {
+    const app = appWith([new FakeModelProvider([{ text: 'x' }])], { evals: evalsDeps() });
+    // A fixture may name any task, and that name reaches the policy file. A
+    // name that reads as YAML syntax must survive the write, or the file
+    // parses back as no policy at all and every bar in it is lost.
+    writeRoutingPolicy(vaultRoot, { tasks: { 'draft: memo': { min_score: 0.9 }, extract: { prefer: 'cost' } } });
+    const after = (await (await call(app, 'PUT', '/routing', { body: { task: 'review', minScore: 0.6 } })).json()) as {
+      tasks: Record<string, { minScore: number; prefer: string }>;
+    };
+    expect(after.tasks['review']).toMatchObject({ minScore: 0.6 });
+    expect(after.tasks['draft: memo']).toMatchObject({ minScore: 0.9 });
+    expect(after.tasks['extract']).toMatchObject({ prefer: 'cost' });
+    expect(readRoutingPolicy(vaultRoot).tasks['draft: memo']?.min_score).toBe(0.9);
   });
 
   test('GET /evals/estimate says how many fixtures a task runs and what it may cost', async () => {

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -744,7 +744,9 @@ export function createApp(deps: ServerDeps): App {
   };
 
   const RoutingBody = z.object({
-    task: z.string().min(1),
+    /** A task name, not free text: it becomes a key in `practice/routing.yaml`
+     * and names a row of the ledger. */
+    task: z.string().regex(/^[a-z0-9][a-z0-9_.-]{0,63}$/, 'a task is a lowercase name'),
     minScore: z.number().min(0).max(1).optional(),
     prefer: z.enum(['quality', 'cost', 'latency']).optional(),
     /** `null` unpins; a string pins that provider. */
@@ -755,7 +757,11 @@ export function createApp(deps: ServerDeps): App {
    * and forgets the cached view so the next step routes by it. */
   const routingPut = async (req: Request): Promise<Response> => {
     const input = await body(req, RoutingBody);
-    if (input instanceof Response) return input;
+    // A pin names a provider this practice actually loaded. Anything else is
+    // a pin that can never be honoured, written into a file the lawyer reads.
+    if (typeof input.pinned === 'string' && !deps.state().providers.some(p => p.id === input.pinned)) {
+      return fail(422, `unknown provider: ${input.pinned}`);
+    }
     const release = await locks.acquire(SETTINGS_LOCK);
     try {
       const policy: RoutingPolicy = readRoutingPolicy(deps.vaultRoot);
@@ -769,10 +775,14 @@ export function createApp(deps: ServerDeps): App {
       policy.tasks[input.task] = entry;
       writeRoutingPolicy(deps.vaultRoot, policy);
       forgetRouting();
+      // Read back INSIDE the lock: two quick changes from the same screen
+      // would otherwise each answer with whatever the file held when they
+      // got round to reading it, and the later answer could be the older
+      // one.
+      return routingGet();
     } finally {
       release();
     }
-    return routingGet();
   };
 
   /** What scoring a task on a provider would run and roughly cost — the

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -42,7 +42,7 @@ import { appendResult, readResults } from '../evals/results';
 import { runSet, summarize } from '../evals/runner';
 import { fixtureCounts, scoreboard } from '../evals/scoreboard';
 import { routeScores } from '../router/scores';
-import { readRoutingPolicy } from '../router/policy';
+import { DEFAULT_MIN_SCORE, DEFAULT_PREFERENCE, readRoutingPolicy, taskPolicy, writeRoutingPolicy, type RoutingPolicy } from '../router/policy';
 import type { Judge } from '../evals/scorers/types';
 import { runnable, selectFixtures, taskOf } from '../evals/select';
 import { serveStatic, type StaticSource } from './static';
@@ -90,7 +90,7 @@ export type App = (req: Request) => Promise<Response>;
  * static, served with no credential, so a new route whose prefix is missing
  * here would be reachable by anyone who can reach the port.
  */
-export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session', 'retro', 'providers', 'outcomes', 'evals'];
+export const API_PREFIXES: readonly string[] = ['health', 'threads', 'runs', 'vault', 'settings', 'proposals', 'docket', 'setup', 'content', 'doctor', 'session', 'retro', 'providers', 'outcomes', 'evals', 'routing'];
 
 /** True when `pathname` belongs to the API (and so needs a token). `/` and
  * every client-side route are false. */
@@ -713,6 +713,68 @@ export function createApp(deps: ServerDeps): App {
     return json(scoreboard(readResults(deps.vaultRoot, { since: null }), counts));
   };
 
+  /**
+   * How the practice routes each task, and who that picks today
+   * (routing-and-evals spec §6). The pick runs the router itself, so the
+   * Models group marks the provider a step would actually get rather than
+   * a second guess at the same rule.
+   */
+  const routingGet = (): Response => {
+    const { scores, policy } = routingView();
+    const state = deps.state();
+    const tasks: Record<string, { minScore: number; prefer: string; pinned?: string; picked?: { providerId: string; reason: string } }> = {};
+    const named = new Set([...Object.keys(policy.tasks), ...Object.keys(scores)]);
+    for (const task of named) {
+      const entry = taskPolicy(policy, task);
+      const row: { minScore: number; prefer: string; pinned?: string; picked?: { providerId: string; reason: string } } = {
+        minScore: entry.min_score,
+        prefer: entry.prefer,
+        ...(entry.pinned === undefined ? {} : { pinned: entry.pinned }),
+      };
+      try {
+        const routed = state.router.route(task, { scores: scores[task] ?? [], policy: entry });
+        row.picked = { providerId: routed.provider.id, reason: routed.reason.text };
+      } catch {
+        // A router that cannot resolve at all (no default loaded) leaves the
+        // row without a pick rather than failing the whole view.
+      }
+      tasks[task] = row;
+    }
+    return json({ defaults: { minScore: DEFAULT_MIN_SCORE, prefer: DEFAULT_PREFERENCE }, tasks });
+  };
+
+  const RoutingBody = z.object({
+    task: z.string().min(1),
+    minScore: z.number().min(0).max(1).optional(),
+    prefer: z.enum(['quality', 'cost', 'latency']).optional(),
+    /** `null` unpins; a string pins that provider. */
+    pinned: z.string().min(1).nullable().optional(),
+  });
+
+  /** One task's routing, changed in place. Writes `practice/routing.yaml`
+   * and forgets the cached view so the next step routes by it. */
+  const routingPut = async (req: Request): Promise<Response> => {
+    const input = await body(req, RoutingBody);
+    if (input instanceof Response) return input;
+    const release = await locks.acquire(SETTINGS_LOCK);
+    try {
+      const policy: RoutingPolicy = readRoutingPolicy(deps.vaultRoot);
+      const entry = { ...(policy.tasks[input.task] ?? {}) };
+      if (input.minScore !== undefined) entry.min_score = input.minScore;
+      if (input.prefer !== undefined) entry.prefer = input.prefer;
+      if (input.pinned !== undefined) {
+        if (input.pinned === null) delete entry.pinned;
+        else entry.pinned = input.pinned;
+      }
+      policy.tasks[input.task] = entry;
+      writeRoutingPolicy(deps.vaultRoot, policy);
+      forgetRouting();
+    } finally {
+      release();
+    }
+    return routingGet();
+  };
+
   /** What scoring a task on a provider would run and roughly cost — the
    * one-line confirmation the Models group shows before a run. */
   const evalEstimate = (url: URL): Response => {
@@ -1278,6 +1340,11 @@ export function createApp(deps: ServerDeps): App {
         if (second === 'scoreboard' && method === 'GET') return evalScoreboard();
         if (second === 'estimate' && method === 'GET') return evalEstimate(url);
         if (second === 'run' && method === 'POST') return await evalRun(req);
+      }
+
+      if (segments.length === 1 && first === 'routing') {
+        if (method === 'GET') return routingGet();
+        if (method === 'PUT') return await routingPut(req);
       }
 
       if (segments.length === 2 && first === 'settings' && second === 'vault' && method === 'PATCH') return await patchVaultSettings(req);

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -9,7 +9,7 @@
 import { parseSseChunk } from './sse';
 import { clearToken, readToken } from './token';
 import { reportUnauthorized } from './unauthorized';
-import type { EvalStreamEvent, RunMark, StepBody, StreamEvent, TaskSource } from './types';
+import type { EvalStreamEvent, RoutingView, RunMark, StepBody, StreamEvent, TaskSource } from './types';
 
 /** A request that came back with a status the caller has to reason about.
  * `body` is the parsed JSON when there was any — 409 on approve carries the
@@ -328,3 +328,13 @@ async function streamSse(path: string, body: unknown, onFrame: (frame: { event: 
 /** Fed in after the last chunk so a frame missing its terminator is still
  * delivered rather than silently dropped with the connection. */
 const FRAME_TERMINATOR = '\n\n';
+
+/** How each task is routed, and who that picks (routing-and-evals spec §6). */
+export async function readRouting(): Promise<RoutingView> {
+  return fetchJson<RoutingView>('/routing');
+}
+
+/** Change one task's bar, preference or pin; the answer is the fresh view. */
+export async function setRouting(change: { task: string; minScore?: number; prefer?: string; pinned?: string | null }): Promise<RoutingView> {
+  return fetchJson<RoutingView>('/routing', { method: 'PUT', body: JSON.stringify(change) });
+}

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -591,3 +591,19 @@ export type EvalStreamEvent =
   | { event: 'result'; data: { fixtureId: string; score: number | null; error?: string } }
   | { event: 'done'; data: { summary: { count: number; scored: number; failed: number; mean: number | null }; saved: boolean } }
   | { event: 'error'; data: { message: string } };
+
+/** One task's routing (routing-and-evals spec §6). COPIED from
+ * `runtime/src/router/policy.ts` and the `/routing` route; a change there is
+ * a change here. */
+export interface RoutingTask {
+  minScore: number;
+  prefer: string;
+  pinned?: string;
+  /** Who the router picks for this task today, and why. */
+  picked?: { providerId: string; reason: string };
+}
+
+export interface RoutingView {
+  defaults: { minScore: number; prefer: string };
+  tasks: Record<string, RoutingTask>;
+}

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -459,6 +459,16 @@ a { color: var(--accent); }
 .v2-record-source { color: var(--fg-faint); }
 /* Why this model answered, beside its name in the record. */
 .v2-record-route { color: var(--fg-faint); }
+/* How a task is routed, under its name in the Models ledger: set text, the
+   choices revealed in place. */
+.v2-models-taskname { display: block; }
+.v2-routing { display: block; font: 11.5px/1.6 var(--sans); color: var(--fg-faint); font-weight: 400; letter-spacing: 0; text-transform: none; margin-top: 2px; }
+.v2-routing-picked { color: var(--fg-muted); }
+.v2-routing-act { font-size: 11.5px; }
+.v2-routing-choices { display: block; margin-top: 2px; }
+.v2-routing-choice { margin-right: 12px; }
+.v2-routing-choice .v2-link { margin-left: 5px; font-size: 11.5px; }
+.v2-routing-on { color: var(--fg); font-weight: 600; text-decoration: none; }
 .v2-task-pick { vertical-align: baseline; }
 .v2-task-pop { min-width: 160px; }
 /* The lawyer's mark (routing-and-evals spec §7): two words under the strip,

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -462,13 +462,16 @@ a { color: var(--accent); }
 /* How a task is routed, under its name in the Models ledger: set text, the
    choices revealed in place. */
 .v2-models-taskname { display: block; }
-.v2-routing { display: block; font: 11.5px/1.6 var(--sans); color: var(--fg-faint); font-weight: 400; letter-spacing: 0; text-transform: none; margin-top: 2px; }
+/* The task cell sets `white-space: nowrap` for the task name; this line has
+   several phrases and must wrap inside the same cell. */
+.v2-routing { display: block; white-space: normal; font: 11.5px/1.6 var(--sans); color: var(--fg-faint); font-weight: 400; letter-spacing: 0; text-transform: none; margin-top: 2px; }
 .v2-routing-picked { color: var(--fg-muted); }
 .v2-routing-act { font-size: 11.5px; }
 .v2-routing-choices { display: block; margin-top: 2px; }
 .v2-routing-choice { margin-right: 12px; }
 .v2-routing-choice .v2-link { margin-left: 5px; font-size: 11.5px; }
 .v2-routing-on { color: var(--fg); font-weight: 600; text-decoration: none; }
+.v2-routing-error { color: var(--error); }
 .v2-task-pick { vertical-align: baseline; }
 .v2-task-pop { min-width: 160px; }
 /* The lawyer's mark (routing-and-evals spec §7): two words under the strip,

--- a/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
@@ -13,6 +13,7 @@ const baseRouting: RoutingView = {
 };
 let routing: RoutingView = baseRouting;
 let routingPuts: Array<{ task: string; minScore?: number; prefer?: string; pinned?: string | null }> = [];
+let routingPutStatus = 200;
 
 function row(over: Partial<ScoreboardRow> & { providerId: string }): ScoreboardRow {
   return {
@@ -79,6 +80,7 @@ const json = (b: unknown, status = 200): Response => new Response(JSON.stringify
 beforeEach(() => {
   routing = baseRouting;
   routingPuts = [];
+  routingPutStatus = 200;
   board = scored;
   estimate = { count: 8, estimateUsd: 0.6 };
   runs = [];
@@ -99,6 +101,10 @@ beforeEach(() => {
     if (url === '/routing' && (init?.method ?? 'GET') === 'GET') return json(routing);
     if (url === '/routing' && init?.method === 'PUT') {
       const change = JSON.parse(String(init.body)) as { task: string; minScore?: number; prefer?: string; pinned?: string | null };
+      if (routingPutStatus !== 200) {
+        routingPuts.push(change);
+        return json({ error: 'the vault is read-only' }, routingPutStatus);
+      }
       routingPuts.push(change);
       const entry = { ...(routing.tasks[change.task] ?? { minScore: 0.7, prefer: 'quality' }) };
       if (change.minScore !== undefined) entry.minScore = change.minScore;
@@ -293,4 +299,18 @@ describe('how a task is routed', () => {
     await waitFor(() => expect(routingPuts).toEqual([{ task: 'review', pinned: null }]));
     await waitFor(() => expect(document.querySelector('.v2-routing')!.textContent).not.toContain('pinned'));
   });
+});
+
+test('a change that fails says so on its own line and leaves the ledger standing', async () => {
+  routingPutStatus = 500;
+  render(<ModelsGroup providerIds={['claude-sub/claude-opus-5', 'fake/fake']} />);
+  await waitFor(() => expect(screen.getByRole('table', { name: /scores/ })).toBeTruthy());
+  const line = document.querySelector('.v2-routing') as HTMLElement;
+  await userEvent.click(within(line).getByRole('button', { name: 'change' }));
+  await userEvent.click(within(line).getByRole('button', { name: '0.8' }));
+
+  await waitFor(() => expect(document.querySelector('.v2-routing-error')?.textContent).toContain('not changed'));
+  // The scores, the tabs and the score actions are all still there.
+  expect(screen.getByRole('table', { name: /scores/ })).toBeTruthy();
+  expect(document.querySelector('.v2-routing')!.textContent).toContain('bar 0.70');
 });

--- a/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
@@ -2,10 +2,17 @@ import { cleanup, render, screen, userEvent, waitFor, within } from '../../test/
 
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { clearToken, TOKEN_KEY } from '../../api/token';
-import type { Scoreboard, ScoreboardRow, ScoreboardSet } from '../../api/types';
+import type { RoutingView, Scoreboard, ScoreboardRow, ScoreboardSet } from '../../api/types';
 import { confirmLine, ModelsGroup, runCost, scoredLabel, staleness } from './ModelsGroup';
 
 const realFetch = globalThis.fetch;
+
+const baseRouting: RoutingView = {
+  defaults: { minScore: 0.7, prefer: 'quality' },
+  tasks: { review: { minScore: 0.7, prefer: 'quality', picked: { providerId: 'claude-sub/claude-opus-5', reason: 'review 0.91' } } },
+};
+let routing: RoutingView = baseRouting;
+let routingPuts: Array<{ task: string; minScore?: number; prefer?: string; pinned?: string | null }> = [];
 
 function row(over: Partial<ScoreboardRow> & { providerId: string }): ScoreboardRow {
   return {
@@ -70,6 +77,8 @@ function sse(text: string): Response {
 const json = (b: unknown, status = 200): Response => new Response(JSON.stringify(b), { status, headers: { 'content-type': 'application/json' } });
 
 beforeEach(() => {
+  routing = baseRouting;
+  routingPuts = [];
   board = scored;
   estimate = { count: 8, estimateUsd: 0.6 };
   runs = [];
@@ -86,6 +95,18 @@ beforeEach(() => {
     if (url.startsWith('/evals/estimate?')) {
       const q = new URLSearchParams(url.slice(url.indexOf('?') + 1));
       return json({ task: q.get('task'), providerId: q.get('providerId'), ...estimate, needsConfirm: estimate.estimateUsd !== null && estimate.estimateUsd > 1 });
+    }
+    if (url === '/routing' && (init?.method ?? 'GET') === 'GET') return json(routing);
+    if (url === '/routing' && init?.method === 'PUT') {
+      const change = JSON.parse(String(init.body)) as { task: string; minScore?: number; prefer?: string; pinned?: string | null };
+      routingPuts.push(change);
+      const entry = { ...(routing.tasks[change.task] ?? { minScore: 0.7, prefer: 'quality' }) };
+      if (change.minScore !== undefined) entry.minScore = change.minScore;
+      if (change.prefer !== undefined) entry.prefer = change.prefer;
+      if (change.pinned === null) delete entry.pinned;
+      else if (change.pinned !== undefined) entry.pinned = change.pinned;
+      routing = { ...routing, tasks: { ...routing.tasks, [change.task]: entry } };
+      return json(routing);
     }
     if (url === '/evals/run' && init?.method === 'POST') {
       runs.push(JSON.parse(String(init.body)));
@@ -117,7 +138,8 @@ describe('ModelsGroup', () => {
     await userEvent.click(screen.getByRole('tab', { name: 'shipped' }));
     const table = screen.getByRole('table', { name: 'shipped scores' });
     expect(within(table).getAllByRole('columnheader').map(h => h.textContent)).toEqual(['task', 'claude-sub/claude-opus-5', 'fake/fake']);
-    expect(within(table).getAllByRole('rowheader').map(h => h.textContent)).toEqual(['review8 fixtures', 'extract1 fixture']);
+    // The rowheader also carries the routing line; its own text is the task and its fixture count.
+    expect(within(table).getAllByRole('rowheader').map(h => h.querySelector('.v2-models-taskname')!.textContent)).toEqual(['review8 fixtures', 'extract1 fixture']);
     // The score is text, with the facts under it; the failed cell carries its reason and offers a retry.
     expect(screen.getByText('0.91')).toBeTruthy();
     expect(screen.getByText('8/8 · 3d ago · 4.2s · $0.07/run')).toBeTruthy();
@@ -242,5 +264,33 @@ describe('the facts line', () => {
     expect(runCost(0.23)).toBe('$0.23/run');
     expect(runCost(0.005)).toBe('$0.01/run');
     expect(runCost(0.0004)).toBe('<$0.01/run');
+  });
+});
+
+describe('how a task is routed', () => {
+  test('the bar, the preference and who that picks read under the task; changing one saves it', async () => {
+    render(<ModelsGroup providerIds={['claude-sub/claude-opus-5', 'fake/fake']} />);
+    await waitFor(() => expect(screen.getByRole('table', { name: /scores/ })).toBeTruthy());
+    const line = document.querySelector('.v2-routing')!;
+    expect(line.textContent).toContain('bar 0.70 · by quality');
+    expect(line.textContent).toContain('picks claude-sub/claude-opus-5');
+
+    await userEvent.click(within(line as HTMLElement).getByRole('button', { name: 'change' }));
+    await userEvent.click(within(line as HTMLElement).getByRole('button', { name: '0.8' }));
+    await waitFor(() => expect(routingPuts).toEqual([{ task: 'review', minScore: 0.8 }]));
+    await waitFor(() => expect(document.querySelector('.v2-routing')!.textContent).toContain('bar 0.80'));
+
+    await userEvent.click(within(document.querySelector('.v2-routing') as HTMLElement).getByRole('button', { name: 'cost' }));
+    await waitFor(() => expect(routingPuts[1]).toEqual({ task: 'review', prefer: 'cost' }));
+  });
+
+  test('a pinned task says so and offers to unpin', async () => {
+    routing = { ...baseRouting, tasks: { review: { minScore: 0.7, prefer: 'quality', pinned: 'fake/fake' } } };
+    render(<ModelsGroup providerIds={['claude-sub/claude-opus-5', 'fake/fake']} />);
+    await waitFor(() => expect(document.querySelector('.v2-routing')!.textContent).toContain('pinned fake/fake'));
+    await userEvent.click(within(document.querySelector('.v2-routing') as HTMLElement).getByRole('button', { name: 'change' }));
+    await userEvent.click(within(document.querySelector('.v2-routing') as HTMLElement).getByRole('button', { name: 'unpin' }));
+    await waitFor(() => expect(routingPuts).toEqual([{ task: 'review', pinned: null }]));
+    await waitFor(() => expect(document.querySelector('.v2-routing')!.textContent).not.toContain('pinned'));
   });
 });

--- a/runtime/ui/src/v2/settings/ModelsGroup.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.tsx
@@ -1,4 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
+import { readRouting, setRouting } from '../../api/client';
+import type { RoutingView } from '../../api/types';
+import { RoutingLine } from './RoutingLine';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, streamEvals } from '../../api/client';
 import { EVAL_SET_KINDS, type EvalEstimate, type EvalSetKind, type Scoreboard, type ScoreboardRow, type ScoreboardTask } from '../../api/types';
 
@@ -72,6 +75,10 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
   const [error, setError] = useState<string | null>(null);
   const [pending, setPending] = useState<Pending | null>(null);
   const [running, setRunning] = useState<Running | null>(null);
+  // How each task is routed, and who that picks — read beside the scores and
+  // re-read after a change so the pick shown is the pick a step would get.
+  const [routing, setRoutingView] = useState<RoutingView | null>(null);
+  const [routingBusy, setRoutingBusy] = useState(false);
   const [outcome, setOutcome] = useState<{ task: string; providerId: string; line: string } | null>(null);
   const abort = useRef<AbortController | null>(null);
 
@@ -87,8 +94,30 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
     }
   };
 
+  const loadRouting = useCallback(async (): Promise<void> => {
+    try {
+      setRoutingView(await readRouting());
+    } catch (err) {
+      // The ledger still reads without it; an older runtime has no /routing.
+      if (!(err instanceof ApiError && err.status === 401)) setRoutingView(null);
+    }
+  }, []);
+
+  const changeRouting = async (task: string, change: { minScore?: number; prefer?: string; pinned?: string | null }): Promise<void> => {
+    setRoutingBusy(true);
+    try {
+      setRoutingView(await setRouting({ task, ...change }));
+    } catch (err) {
+      if (!(err instanceof ApiError && err.status === 401)) setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRoutingBusy(false);
+    }
+  };
+
   useEffect(() => {
     void load();
+      void loadRouting();
+    void loadRouting();
     return () => abort.current?.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -129,6 +158,8 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
     }
     if (failure !== null) setOutcome({ task, providerId, line: `failed · ${failure}` });
     await load();
+    // A saved run moves the scoreboard, and the pick can move with it.
+    await loadRouting();
   };
 
   if (error !== null) {
@@ -238,8 +269,19 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
               {tasks.map(t => (
                 <tr key={t.task}>
                   <th scope="row" className="v2-models-task">
-                    {t.task}
-                    <span className="v2-models-count">{t.sets[set].fixtures} fixture{t.sets[set].fixtures === 1 ? '' : 's'}</span>
+                    <span className="v2-models-taskname">
+                      {t.task}
+                      <span className="v2-models-count">{t.sets[set].fixtures} fixture{t.sets[set].fixtures === 1 ? '' : 's'}</span>
+                    </span>
+                    {routing === null ? null : (
+                      <RoutingLine
+                        task={t.task}
+                        routing={routing.tasks[t.task]}
+                        defaults={routing.defaults}
+                        busy={routingBusy}
+                        onChange={change => void changeRouting(t.task, change)}
+                      />
+                    )}
                   </th>
                   {columns.map(id => cell(t, id))}
                 </tr>

--- a/runtime/ui/src/v2/settings/ModelsGroup.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.tsx
@@ -78,7 +78,10 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
   // How each task is routed, and who that picks — read beside the scores and
   // re-read after a change so the pick shown is the pick a step would get.
   const [routing, setRoutingView] = useState<RoutingView | null>(null);
-  const [routingBusy, setRoutingBusy] = useState(false);
+  // The task whose change is in flight, and the task whose change failed:
+  // both belong to one row, so neither disables nor blanks the other rows.
+  const [routingBusy, setRoutingBusy] = useState<string | null>(null);
+  const [routingError, setRoutingError] = useState<{ task: string; text: string } | null>(null);
   const [outcome, setOutcome] = useState<{ task: string; providerId: string; line: string } | null>(null);
   const abort = useRef<AbortController | null>(null);
 
@@ -104,19 +107,22 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
   }, []);
 
   const changeRouting = async (task: string, change: { minScore?: number; prefer?: string; pinned?: string | null }): Promise<void> => {
-    setRoutingBusy(true);
+    setRoutingBusy(task);
+    setRoutingError(null);
     try {
       setRoutingView(await setRouting({ task, ...change }));
     } catch (err) {
-      if (!(err instanceof ApiError && err.status === 401)) setError(err instanceof Error ? err.message : String(err));
+      // A failed change is that row's news. It must not replace the ledger:
+      // the only way back from the group-wide error is a button this screen
+      // would have just removed.
+      if (!(err instanceof ApiError && err.status === 401)) setRoutingError({ task, text: err instanceof Error ? err.message : String(err) });
     } finally {
-      setRoutingBusy(false);
+      setRoutingBusy(null);
     }
   };
 
   useEffect(() => {
     void load();
-      void loadRouting();
     void loadRouting();
     return () => abort.current?.abort();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -278,7 +284,8 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
                         task={t.task}
                         routing={routing.tasks[t.task]}
                         defaults={routing.defaults}
-                        busy={routingBusy}
+                        busy={routingBusy === t.task}
+                        error={routingError?.task === t.task ? routingError.text : undefined}
                         onChange={change => void changeRouting(t.task, change)}
                       />
                     )}

--- a/runtime/ui/src/v2/settings/RoutingLine.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLine.tsx
@@ -1,0 +1,88 @@
+/**
+ * How one task is routed, under its name in the Models ledger
+ * (routing-and-evals spec §6).
+ *
+ * Set text, like every other status here: the bar, the preference, and who
+ * that picks today. `change` reveals the two choices in place; nothing is a
+ * slider and nothing is a modal, because a bar is one of five numbers a
+ * lawyer would ever pick and a preference is one of three words.
+ */
+import { useState } from 'react';
+import type { RoutingTask } from '../../api/types';
+
+export interface RoutingLineProps {
+  task: string;
+  routing: RoutingTask | undefined;
+  defaults: { minScore: number; prefer: string };
+  busy: boolean;
+  onChange(change: { minScore?: number; prefer?: string; pinned?: string | null }): void;
+}
+
+/** The bars worth offering: below 0.5 is not a bar, above 0.9 nothing clears. */
+export const BARS = [0.5, 0.6, 0.7, 0.8, 0.9] as const;
+export const PREFERENCES = ['quality', 'cost', 'latency'] as const;
+
+export function RoutingLine({ task, routing, defaults, busy, onChange }: RoutingLineProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const bar = routing?.minScore ?? defaults.minScore;
+  const prefer = routing?.prefer ?? defaults.prefer;
+  const picked = routing?.picked;
+
+  return (
+    <span className="v2-routing">
+      <span className="v2-routing-facts">
+        bar {bar.toFixed(2)} · by {prefer}
+        {routing?.pinned === undefined ? '' : ` · pinned ${routing.pinned}`}
+      </span>
+      {picked === undefined ? null : (
+        <span className="v2-routing-picked" title={`picked for ${task}: ${picked.reason}`}>
+          {' · '}
+          picks {picked.providerId}
+        </span>
+      )}
+      {' · '}
+      <button type="button" className="v2-link v2-routing-act" aria-expanded={open} onClick={() => setOpen(o => !o)}>
+        {open ? 'done' : 'change'}
+      </button>
+      {open ? (
+        <span className="v2-routing-choices">
+          <span className="v2-routing-choice" role="group" aria-label={`Bar for ${task}`}>
+            bar{' '}
+            {BARS.map(b => (
+              <button
+                key={b}
+                type="button"
+                className={b === bar ? 'v2-link v2-routing-on' : 'v2-link'}
+                disabled={busy}
+                aria-pressed={b === bar}
+                onClick={() => onChange({ minScore: b })}
+              >
+                {b.toFixed(1)}
+              </button>
+            ))}
+          </span>
+          <span className="v2-routing-choice" role="group" aria-label={`Preference for ${task}`}>
+            by{' '}
+            {PREFERENCES.map(p => (
+              <button
+                key={p}
+                type="button"
+                className={p === prefer ? 'v2-link v2-routing-on' : 'v2-link'}
+                disabled={busy}
+                aria-pressed={p === prefer}
+                onClick={() => onChange({ prefer: p })}
+              >
+                {p}
+              </button>
+            ))}
+          </span>
+          {routing?.pinned === undefined ? null : (
+            <button type="button" className="v2-link v2-routing-act" disabled={busy} onClick={() => onChange({ pinned: null })}>
+              unpin
+            </button>
+          )}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/runtime/ui/src/v2/settings/RoutingLine.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLine.tsx
@@ -15,6 +15,8 @@ export interface RoutingLineProps {
   routing: RoutingTask | undefined;
   defaults: { minScore: number; prefer: string };
   busy: boolean;
+  /** What went wrong with this task's last change, shown on its own line. */
+  error?: string | undefined;
   onChange(change: { minScore?: number; prefer?: string; pinned?: string | null }): void;
 }
 
@@ -22,7 +24,7 @@ export interface RoutingLineProps {
 export const BARS = [0.5, 0.6, 0.7, 0.8, 0.9] as const;
 export const PREFERENCES = ['quality', 'cost', 'latency'] as const;
 
-export function RoutingLine({ task, routing, defaults, busy, onChange }: RoutingLineProps): JSX.Element {
+export function RoutingLine({ task, routing, defaults, busy, error, onChange }: RoutingLineProps): JSX.Element {
   const [open, setOpen] = useState(false);
   const bar = routing?.minScore ?? defaults.minScore;
   const prefer = routing?.prefer ?? defaults.prefer;
@@ -83,6 +85,12 @@ export function RoutingLine({ task, routing, defaults, busy, onChange }: Routing
           )}
         </span>
       ) : null}
+      {error === undefined ? null : (
+        <span className="v2-routing-error" role="alert">
+          {' '}
+          not changed: {error}
+        </span>
+      )}
     </span>
   );
 }


### PR DESCRIPTION
The scoreboard could already pick a model. Nothing in the app could change how it picks: the bar, the preference and any pin lived only in `practice/routing.yaml`. This is the editing surface PR #71 deferred.

**The endpoint.** `GET /routing` returns the defaults and, per task, its bar, preference, pin, and the provider that task would get today — computed by asking the router itself, so the ledger shows the consequence of a setting rather than the setting alone. `PUT /routing` writes one task's change under the settings lock and drops the cached routing view, so the next step routes on the new numbers.

**The surface.** In Settings › Models each task carries a line of set text under its name:

```
review   8 fixtures
bar 0.70 · by quality · picks fake/fake · change
```

`change` reveals the five bars and the three preferences in place, and offers `unpin` when the task is pinned. No slider and no modal: a bar is one of five numbers a lawyer would ever pick, and a preference is one of three words. The line reloads after a scoring run, so a new score moves the pick you can see.

**Checks.** Two route tests and two UI tests. Full suites green (1182 runtime, 546 UI), both typechecks clean. Verified on a throwaway vault with a hand-written results file and `--fake`: raising the bar to 0.8 wrote `min_score: 0.8` to `practice/routing.yaml`, switching to cost re-read as `review 0.90 · by cost`, and the pick tracked the scoreboard throughout.