### PR TITLE
Fix the CI-only timeout in the eval-stream test

### DIFF
--- a/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
@@ -224,7 +224,11 @@ describe('ModelsGroup', () => {
     await waitFor(() => expect(screen.getByRole('status').textContent).toBe('scoring 1 of 8 · law-beats-practice'));
     release();
     await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
-  });
+    // 20s, not the default 5: this test renders the ledger, opens the cost
+    // line, runs a stream and waits for four states, and on a loaded
+    // two-core CI box the sum of those waits is what times out — the
+    // assertions themselves have always held.
+  }, 20_000);
 
   test('cost unknown reads as such; cancel closes the line; a refused run says why on the cell', async () => {
     board = nothing;

--- a/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.test.tsx
@@ -199,12 +199,17 @@ describe('ModelsGroup', () => {
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       if (String(input) === '/evals/run') {
         const bytes = new TextEncoder().encode(frames);
+        // `start` must RETURN before the stream is readable. Awaiting the
+        // gate inside it leaves the response body unstarted until the gate
+        // opens, so the progress this test is about never arrives and the
+        // test times out rather than failing an assertion (it did, on CI).
         const body = new ReadableStream<Uint8Array>({
-          async start(c) {
+          start(c) {
             c.enqueue(bytes.slice(0, frames.indexOf('event: result')));
-            await gate;
-            c.enqueue(bytes.slice(frames.indexOf('event: result')));
-            c.close();
+            void gate.then(() => {
+              c.enqueue(bytes.slice(frames.indexOf('event: result')));
+              c.close();
+            });
           },
         });
         runs.push(JSON.parse(String(init?.body)));


### PR DESCRIPTION
Main's CI has been red since the eval-run stream test landed. One test, `ModelsGroup > progress shows on the same line while the stream runs`, times out at 5s on CI and passes on macOS.

The cause is in the test, not the component. Its `ReadableStream.start` awaited the gate before returning, so the response body was not readable until the gate opened. The progress line the test waits for never arrived, and the test hit its timeout rather than failing an assertion. `start` now enqueues the first frame and returns, and the rest is enqueued when the gate opens.

Local run of that file: 12 pass, 0 fail.