### PR TITLE
A routing ledger: what actually ran

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ reconstructed from git history. New entries are prepended automatically by
 
 The routing ledger (routing-and-evals spec §6)
 
-- Settings › Models now ends with **what ran**: every step, newest first, with the conversation it belongs to, the task, the model it got, why it got it, what it took and cost, and your mark. The scoreboard says how models do on fixtures and the line under each task says how that task is meant to route; this is the only place that says what actually happened.
+- Settings › Models now ends with **what ran**: the last hundred steps, newest first, with the conversation it belongs to, the task, the model it got, why it got it, what it took and cost, and your mark. The scoreboard says how models do on fixtures and the line under each task says how that task is meant to route; this is the only place that says what actually happened.
 - `GET /routing/ledger?limit=` serves it, reading the run records the runtime already keeps. A run from before routing recorded a reason shows none rather than a guess.
 
 ## [0.14.0] — 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to Counsel OS are documented in this file. The format follow
 reconstructed from git history. New entries are prepended automatically by
 `scripts/release.sh`.
 
+## [Unreleased]
+
+The routing ledger (routing-and-evals spec §6)
+
+- Settings › Models now ends with **what ran**: every step, newest first, with the conversation it belongs to, the task, the model it got, why it got it, what it took and cost, and your mark. The scoreboard says how models do on fixtures and the line under each task says how that task is meant to route; this is the only place that says what actually happened.
+- `GET /routing/ledger?limit=` serves it, reading the run records the runtime already keeps. A run from before routing recorded a reason shows none rather than a guess.
+
 ## [0.14.0] — 2026-09-02
 
 routing from your own scores

--- a/runtime/src/loop/run-record.test.ts
+++ b/runtime/src/loop/run-record.test.ts
@@ -4,7 +4,7 @@ import { mkdirSync, mkdtempSync, readdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { writeRunLog } from './run-log';
-import { finishRun, listRuns, readRun, runRecordPath, startRun, type RunRecord } from './run-record';
+import { finishRun, listRuns, readRun, readRuns, runRecordPath, startRun, type RunRecord } from './run-record';
 
 let vaultRoot: string;
 
@@ -193,5 +193,37 @@ describe('listRuns', () => {
 
   test('a tenant that would escape the runs directory is refused', () => {
     expect(() => listRuns(vaultRoot, '../../etc', randomUUID())).toThrow('invalid tenant');
+  });
+});
+
+describe('readRuns', () => {
+  test('every thread, newest first, and `limit` takes the NEWEST that many', () => {
+    // The slice has to happen after the sort. Slicing first would keep every
+    // other assertion here green while the ledger showed an arbitrary page.
+    const ids = ['10:00', '10:04', '10:01', '10:03', '10:02'].map(hm => {
+      const rec = record({ startedAt: `2026-08-29T${hm}:00.000Z`, message: hm });
+      startRun(vaultRoot, rec);
+      return rec;
+    });
+    expect(readRuns(vaultRoot, 'default').map(r => r.message)).toEqual(['10:04', '10:03', '10:02', '10:01', '10:00']);
+    expect(readRuns(vaultRoot, 'default', { limit: 2 }).map(r => r.message)).toEqual(['10:04', '10:03']);
+    expect(readRuns(vaultRoot, 'default', { limit: 99 })).toHaveLength(5);
+    // And one thread's, still newest first.
+    expect(readRuns(vaultRoot, 'default', { threadId: ids[1]!.threadId }).map(r => r.message)).toEqual(['10:04']);
+  });
+
+  test('a limit reads only a window of the directory, not all of it', () => {
+    // 200 records, a limit of 1: the newest is still returned, and the read
+    // is bounded — this runs on the runtime's only thread while a step may
+    // be streaming.
+    for (let i = 0; i < 200; i++) {
+      startRun(vaultRoot, record({ startedAt: `2026-08-29T10:${String(i % 60).padStart(2, '0')}:${String(Math.floor(i / 60)).padStart(2, '0')}.000Z`, message: `run-${i}` }));
+    }
+    const newest = readRuns(vaultRoot, 'default')[0]!;
+    expect(readRuns(vaultRoot, 'default', { limit: 1 })).toEqual([newest]);
+  });
+
+  test('a tenant with no runs at all is an empty list', () => {
+    expect(readRuns(vaultRoot, 'default')).toEqual([]);
   });
 });

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -188,6 +188,19 @@ export function listAllRuns(vaultRoot: string, tenant: Tenant): RunRecord[] {
  * of its own — an id that names no thread simply matches nothing.
  */
 export function listRuns(vaultRoot: string, tenant: Tenant, threadId: string): RunRecord[] {
+  return readRuns(vaultRoot, tenant, { threadId });
+}
+
+/**
+ * Every run this tenant has, newest first — one thread's, or all of them
+ * (the routing ledger).
+ *
+ * A record's name is its run id, which carries no date, so ordering means
+ * reading them. They are small files and the caller passes a `limit`, but
+ * the read is over the whole directory either way: if that ever matters,
+ * the fix is an index, not a smaller read.
+ */
+export function readRuns(vaultRoot: string, tenant: Tenant, opts: { threadId?: string; limit?: number } = {}): RunRecord[] {
   const dir = runsDir(vaultRoot, tenant);
   let names: string[];
   try {
@@ -203,10 +216,12 @@ export function listRuns(vaultRoot: string, tenant: Tenant, threadId: string): R
     // a crashed write left mid-rename.
     if (!name.endsWith('.json')) continue;
     const rec = readRecordAt(join(dir, name));
-    if (rec !== null && rec.threadId === threadId) runs.push(rec);
+    if (rec === null) continue;
+    if (opts.threadId !== undefined && rec.threadId !== opts.threadId) continue;
+    runs.push(rec);
   }
   // Newest first. `startedAt` is an ISO string, so it sorts lexically; the
   // run id breaks ties so the order is stable rather than readdir's.
   runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt) || b.runId.localeCompare(a.runId));
-  return runs;
+  return opts.limit === undefined ? runs : runs.slice(0, opts.limit);
 }

--- a/runtime/src/loop/run-record.ts
+++ b/runtime/src/loop/run-record.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readdirSync, readFileSync, renameSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { Tenant, Usage } from '../core/types';
 import { runFilePath, runsDir, type ToolCallLog } from './run-log';
@@ -164,22 +164,7 @@ export function readRun(vaultRoot: string, tenant: Tenant, runId: string): RunRe
  * whole period, not one thread. Same file rules as `listRuns`.
  */
 export function listAllRuns(vaultRoot: string, tenant: Tenant): RunRecord[] {
-  const dir = runsDir(vaultRoot, tenant);
-  let names: string[];
-  try {
-    names = readdirSync(dir);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
-    throw err;
-  }
-  const runs: RunRecord[] = [];
-  for (const name of names) {
-    if (!name.endsWith('.json')) continue;
-    const rec = readRecordAt(join(dir, name));
-    if (rec !== null) runs.push(rec);
-  }
-  runs.sort((a, b) => b.startedAt.localeCompare(a.startedAt) || b.runId.localeCompare(a.runId));
-  return runs;
+  return readRuns(vaultRoot, tenant);
 }
 
 /**
@@ -195,10 +180,16 @@ export function listRuns(vaultRoot: string, tenant: Tenant, threadId: string): R
  * Every run this tenant has, newest first — one thread's, or all of them
  * (the routing ledger).
  *
- * A record's name is its run id, which carries no date, so ordering means
- * reading them. They are small files and the caller passes a `limit`, but
- * the read is over the whole directory either way: if that ever matters,
- * the fix is an index, not a smaller read.
+ * A record's name is its run id, which carries no date, so the newest
+ * cannot be picked by name. With a `limit` the file's mtime orders the
+ * CANDIDATES and only those are read: a `stat` is a syscall, a record is
+ * kilobytes of JSON, and this runs on the runtime's only thread while a
+ * step may be streaming in another tab. Without a limit every record is
+ * read, which is what the retro wants.
+ *
+ * The mtime is a proxy — a record is rewritten when its step finishes and
+ * when it is marked — so the candidate window is deliberately wider than
+ * the limit, and `startedAt` still decides the order that is returned.
  */
 export function readRuns(vaultRoot: string, tenant: Tenant, opts: { threadId?: string; limit?: number } = {}): RunRecord[] {
   const dir = runsDir(vaultRoot, tenant);
@@ -209,12 +200,31 @@ export function readRuns(vaultRoot: string, tenant: Tenant, opts: { threadId?: s
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
     throw err;
   }
+  // Records only: this leaves out `<runId>.log.jsonl` and any `.json.tmp`
+  // a crashed write left mid-rename.
+  let files = names.filter(name => name.endsWith('.json'));
+
+  if (opts.limit !== undefined && files.length > opts.limit) {
+    // Four times the limit, and never fewer than fifty: a run marked long
+    // after it finished, or one thread's runs among many, still has room to
+    // fall inside the window.
+    const window = Math.max(50, opts.limit * 4);
+    if (files.length > window) {
+      const stamped: Array<{ name: string; at: number }> = [];
+      for (const name of files) {
+        try {
+          stamped.push({ name, at: statSync(join(dir, name)).mtimeMs });
+        } catch {
+          // Gone between the readdir and the stat: not a run any more.
+        }
+      }
+      stamped.sort((a, b) => b.at - a.at);
+      files = stamped.slice(0, window).map(s => s.name);
+    }
+  }
 
   const runs: RunRecord[] = [];
-  for (const name of names) {
-    // Records only: this leaves out `<runId>.log.jsonl` and any `.json.tmp`
-    // a crashed write left mid-rename.
-    if (!name.endsWith('.json')) continue;
+  for (const name of files) {
     const rec = readRecordAt(join(dir, name));
     if (rec === null) continue;
     if (opts.threadId !== undefined && rec.threadId !== opts.threadId) continue;

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -2143,7 +2143,33 @@ Rationale: see practice/standards/acme-special-terms.md.
 
     expect((await call(app, 'GET', '/routing/ledger?limit=0')).status).toBe(400);
     expect((await call(app, 'GET', '/routing/ledger?limit=x')).status).toBe(400);
+    expect((await call(app, 'GET', '/routing/ledger?limit=501')).status).toBe(400);
+    expect((await call(app, 'GET', '/routing/ledger')).status).toBe(200);
     expect((await call(app, 'GET', '/routing/ledger', { token: null })).status).toBe(401);
+  });
+
+  test('the ledger carries what ran, never what was said', async () => {
+    // The omission IS the feature: this is one table over every matter in
+    // the vault, and Settings is the pane most likely to be on a screen
+    // someone else can see.
+    const app = appWith([new FakeModelProvider([{ text: 'The cap is far below the fees.' }])], { evals: evalsDeps() });
+    // Untitled on purpose: an untitled thread's derived title is the first
+    // line of the lawyer's own message.
+    const created = await call(app, 'POST', '/threads', { body: {} });
+    const id = ((await created.json()) as { id: string }).id;
+    await step(app, id, { message: 'Zephyr Robotics wants a $50,000 cap on the Acme deal.', task: 'review' });
+
+    const body = await (await call(app, 'GET', '/routing/ledger')).text();
+    for (const secret of ['Zephyr', 'Acme', '$50,000', 'far below the fees']) expect(body).not.toContain(secret);
+    const { runs } = JSON.parse(body) as { runs: Array<Record<string, unknown>> };
+    expect(Object.keys(runs[0]!).sort()).toEqual(['at', 'durationMs', 'provider', 'routeReason', 'runId', 'status', 'task', 'taskSource', 'thread', 'threadId']);
+    expect(runs[0]!.thread).toBe('');
+
+    // A thread the lawyer named does show its name.
+    const named = await newThread(app);
+    await step(app, named, { message: 'And this.' });
+    const after = (await (await call(app, 'GET', '/routing/ledger')).json()) as { runs: Array<{ thread: string }> };
+    expect(after.runs[0]!.thread).toBe('a thread');
   });
 
   test('PUT /routing refuses a body that is not a routing change', async () => {

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -2115,6 +2115,37 @@ Rationale: see practice/standards/acme-special-terms.md.
     expect(unpinned.tasks['review']).toMatchObject({ minScore: 0.5, prefer: 'cost' });
   });
 
+  test('GET /routing/ledger says what ran, in what thread, on what model and why', async () => {
+    const app = appWith([new FakeModelProvider([{ text: 'one' }, { text: 'two' }])], { evals: evalsDeps() });
+    const first = await newThread(app);
+    await call(app, 'PATCH', `/threads/${first}`, { body: { title: 'Acme cap' } });
+    const { res } = await step(app, first, { message: 'Review this.', task: 'review' });
+    expect(res.status).toBe(200);
+    const runId = res.headers.get('x-run-id')!;
+    await call(app, 'POST', `/threads/${first}/turns/${runId}/mark`, { body: { mark: 'useful' } });
+    await new Promise(r => setTimeout(r, 2));
+    const second = await newThread(app);
+    await step(app, second, { message: 'And this.' });
+
+    const ledger = await call(app, 'GET', '/routing/ledger?limit=10');
+    expect(ledger.status).toBe(200);
+    const { runs } = (await ledger.json()) as {
+      runs: Array<{ runId: string; thread: string; task?: string; provider: string; routeReason?: { kind: string; text: string }; mark?: string; status: string }>;
+    };
+    // Every thread's runs, newest first — the question the scoreboard and
+    // the Models group cannot answer.
+    expect(runs).toHaveLength(2);
+    expect(runs[1]!.runId).toBe(runId);
+    expect(runs[1]).toMatchObject({ thread: 'Acme cap', task: 'review', provider: 'fake/fake', mark: 'useful', status: 'done' });
+    // Scoring is on for this app, and nothing has scored `review` yet.
+    expect(runs[1]!.routeReason).toEqual({ kind: 'no-score', text: 'no score yet' });
+    expect(runs[0]!.thread).not.toBe('Acme cap');
+
+    expect((await call(app, 'GET', '/routing/ledger?limit=0')).status).toBe(400);
+    expect((await call(app, 'GET', '/routing/ledger?limit=x')).status).toBe(400);
+    expect((await call(app, 'GET', '/routing/ledger', { token: null })).status).toBe(401);
+  });
+
   test('PUT /routing refuses a body that is not a routing change', async () => {
     const app = appWith([new FakeModelProvider([{ text: 'x' }])], { evals: evalsDeps() });
     expect((await call(app, 'PUT', '/routing', { body: { task: '' } })).status).toBe(400);

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -743,8 +743,18 @@ export function createApp(deps: ServerDeps): App {
     const limit = raw === null ? 50 : Number(raw);
     if (!Number.isInteger(limit) || limit < 1 || limit > 500) throw new HttpError(400, 'limit must be a whole number from 1 to 500');
     const runs = readRuns(deps.vaultRoot, deps.tenant, { limit });
-    // The thread's title, so a row reads as work rather than as a uuid.
-    const titles = new Map((await deps.store.list(deps.tenant)).map(h => [h.id, h.title ?? ''] as const));
+    // The title of the threads in THIS page, not of every thread the vault
+    // holds — and as stored, never derived. An untitled thread's derived
+    // title is the first line of the lawyer's own message, which belongs in
+    // the conversation rail, not in a table of every matter at once.
+    const titles = new Map<string, string>();
+    for (const id of new Set(runs.map(r => r.threadId))) {
+      try {
+        titles.set(id, (await deps.store.header(deps.tenant, id, { derive: false })).title ?? '');
+      } catch {
+        // A thread deleted since its run: the row still says what ran.
+      }
+    }
     return json({
       runs: runs.map(r => ({
         runId: r.runId,

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -5,7 +5,7 @@ import { MatterStaysLocalError, RouterError } from '../core/types';
 import { DEFAULT_STEP_TIMEOUT_MS, runStep, type CounselLoopDeps, policyForOptions, resolveStepProvider } from '../loop/counsel-loop';
 import { pendingProposals } from '../loop/pending-proposals';
 import { applyProposal } from '../loop/proposals';
-import { finishRun, listRuns, readRun, type RunRecord } from '../loop/run-record';
+import { finishRun, listRuns, readRun, readRuns, type RunRecord } from '../loop/run-record';
 import { DOCX_CONTENT_TYPE, docxToMarkdown, isDocxPath, NotADocxError, openDocx, UnsafeXmlError } from '../docx';
 import { assertSafeXml } from '../docx/safety';
 import { BASE_URL_RULE, isAllowedBaseURL, readRegistry, RegistryFile } from '../providers/registry';
@@ -727,6 +727,41 @@ export function createApp(deps: ServerDeps): App {
   const evalScoreboard = (): Response => {
     const counts = fixtureCounts(evalLoaded().map(l => ({ task: taskOf(l), set: sourceKindOf(l), runnable: runnable(l) })));
     return json(scoreboard(readResults(deps.vaultRoot, { since: null }), counts));
+  };
+
+  /**
+   * The routing ledger: what actually ran, newest first, with the model it
+   * got and the reason it got it.
+   *
+   * The scoreboard says how models do on fixtures and the Models group says
+   * how each task is meant to route. Neither answers "what happened", which
+   * is the question you ask after a morning's work — and it is the only way
+   * to find out whether the rule and the practice agree.
+   */
+  const routingLedger = async (url: URL): Promise<Response> => {
+    const raw = url.searchParams.get('limit');
+    const limit = raw === null ? 50 : Number(raw);
+    if (!Number.isInteger(limit) || limit < 1 || limit > 500) throw new HttpError(400, 'limit must be a whole number from 1 to 500');
+    const runs = readRuns(deps.vaultRoot, deps.tenant, { limit });
+    // The thread's title, so a row reads as work rather than as a uuid.
+    const titles = new Map((await deps.store.list(deps.tenant)).map(h => [h.id, h.title ?? ''] as const));
+    return json({
+      runs: runs.map(r => ({
+        runId: r.runId,
+        threadId: r.threadId,
+        thread: titles.get(r.threadId) ?? '',
+        at: r.startedAt,
+        status: r.status,
+        provider: r.provider,
+        ...(r.task === undefined ? {} : { task: r.task }),
+        ...(r.taskSource === undefined ? {} : { taskSource: r.taskSource }),
+        ...(r.routeReason === undefined ? {} : { routeReason: r.routeReason }),
+        ...(r.policy === undefined ? {} : { policy: r.policy }),
+        ...(r.costUsd === undefined ? {} : { costUsd: r.costUsd }),
+        ...(r.durationMs === undefined ? {} : { durationMs: r.durationMs }),
+        ...(r.mark === undefined ? {} : { mark: r.mark.mark }),
+      })),
+    });
   };
 
   /**
@@ -1553,6 +1588,8 @@ export function createApp(deps: ServerDeps): App {
         if (second === 'draft') return await fixtureDraft(req);
         if (second === 'save') return await fixtureSave(req);
       }
+
+      if (segments.length === 2 && first === 'routing' && second === 'ledger' && method === 'GET') return await routingLedger(url);
 
       if (segments.length === 1 && first === 'routing') {
         if (method === 'GET') return routingGet();

--- a/runtime/src/threads/store.ts
+++ b/runtime/src/threads/store.ts
@@ -215,12 +215,20 @@ export class ThreadStore {
     return this.presentHeader(tenant, header);
   }
 
-  /** The header alone, presented — for a caller that needs the thread's
-   * matter or task before it has any reason to read the log. */
-  async header(tenant: Tenant, id: string): Promise<ThreadHeader> {
+  /**
+   * The header alone, presented — for a caller that needs the thread's
+   * matter or task before it has any reason to read the log.
+   *
+   * `derive: false` returns the header AS STORED, so an untitled thread
+   * stays untitled rather than borrowing its first user message. A caller
+   * that shows titles somewhere the message itself would not belong wants
+   * that, and it costs no log read either.
+   */
+  async header(tenant: Tenant, id: string, opts: { derive?: boolean } = {}): Promise<ThreadHeader> {
     this.validateTenant(tenant);
     this.validateId(id);
-    return this.presentHeader(tenant, this.readHeader(tenant, id));
+    const header = this.readHeader(tenant, id);
+    return opts.derive === false ? header : this.presentHeader(tenant, header);
   }
 
   async get(tenant: Tenant, id: string): Promise<{ header: ThreadHeader; events: ThreadEvent[] }> {

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -9,7 +9,7 @@
 import { parseSseChunk } from './sse';
 import { clearToken, readToken } from './token';
 import { reportUnauthorized } from './unauthorized';
-import type { EvalStreamEvent, FixtureDraft, RoutingView, RunMark, SavedFixture, StepBody, StreamEvent, TaskSource } from './types';
+import type { EvalStreamEvent, FixtureDraft, LedgerRun, RoutingView, RunMark, SavedFixture, StepBody, StreamEvent, TaskSource } from './types';
 
 /** A request that came back with a status the caller has to reason about.
  * `body` is the parsed JSON when there was any — 409 on approve carries the
@@ -353,6 +353,11 @@ export async function saveFixture(input: {
   overwrite?: boolean;
 }): Promise<SavedFixture> {
   return fetchJson<SavedFixture>('/fixtures/save', { method: 'POST', body: JSON.stringify(input) });
+}
+
+/** What ran, newest first (routing-and-evals spec §6). */
+export async function readRoutingLedger(limit = 50): Promise<LedgerRun[]> {
+  return (await fetchJson<{ runs: LedgerRun[] }>(`/routing/ledger?limit=${limit}`)).runs;
 }
 
 /** Change one task's bar, preference or pin; the answer is the fresh view. */

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -665,3 +665,22 @@ export interface SavedFixture {
    * were about. */
   dropped: string[];
 }
+
+/** One row of the routing ledger (`GET /routing/ledger`): a run that
+ * happened, and what it got. */
+export interface LedgerRun {
+  runId: string;
+  threadId: string;
+  /** The conversation's title, so a row reads as work rather than a uuid. */
+  thread: string;
+  at: string;
+  status: string;
+  provider: string;
+  task?: string;
+  taskSource?: TaskSource;
+  routeReason?: { kind: string; text: string };
+  policy?: 'stays-local';
+  costUsd?: number;
+  durationMs?: number;
+  mark?: 'useful' | 'not-right';
+}

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1114,3 +1114,17 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-fixture-files > li { padding: 1px 0; }
 .v2-fixture-dropped { text-decoration: line-through; color: var(--fg-faint); }
 .v2-fixture-why { margin: 0.1rem 0; color: var(--fg-faint); }
+
+/* The routing ledger: what actually ran (routing-and-evals spec §6). Set
+   text and hairlines, like the scoreboard above it. */
+.v2-models-sub { font: 600 11px/1.6 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 1.2rem 0 0.4rem; }
+.v2-ledger { width: 100%; border-collapse: collapse; font: 12.5px/1.7 var(--sans); }
+.v2-ledger th { text-align: left; font: 600 10.5px/1.6 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-faint); padding: 0 0.8rem 2px 0; border-bottom: 1px solid var(--rule); }
+.v2-ledger td { padding: 2px 0.8rem 2px 0; border-bottom: 1px solid var(--rule-faint, var(--rule)); vertical-align: baseline; }
+.v2-ledger-when { color: var(--fg-muted); white-space: nowrap; }
+.v2-ledger-thread { color: var(--fg-faint); }
+.v2-ledger td:nth-child(2) { max-width: 34ch; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.v2-ledger-why { color: var(--fg-muted); }
+.v2-ledger-num { color: var(--fg-muted); white-space: nowrap; }
+.v2-ledger-unfinished td { color: var(--fg-faint); }
+.v2-ledger-quiet { font: 12.5px/1.7 var(--sans); color: var(--fg-faint); margin: 0.4rem 0 0; }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1117,7 +1117,8 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 
 /* The routing ledger: what actually ran (routing-and-evals spec §6). Set
    text and hairlines, like the scoreboard above it. */
-.v2-models-sub { font: 600 11px/1.6 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-muted); margin: 1.2rem 0 0.4rem; }
+/* `.runin` already sets the small-caps run-in; this only spaces it. */
+.v2-models-sub { margin: 1.2rem 0 0.4rem; }
 .v2-ledger { width: 100%; border-collapse: collapse; font: 12.5px/1.7 var(--sans); }
 .v2-ledger th { text-align: left; font: 600 10.5px/1.6 var(--sans); letter-spacing: 0.08em; text-transform: uppercase; color: var(--fg-faint); padding: 0 0.8rem 2px 0; border-bottom: 1px solid var(--rule); }
 .v2-ledger td { padding: 2px 0.8rem 2px 0; border-bottom: 1px solid var(--rule-faint, var(--rule)); vertical-align: baseline; }

--- a/runtime/ui/src/v2/settings/ModelsGroup.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.tsx
@@ -1,5 +1,6 @@
 import { readRouting, setRouting } from '../../api/client';
 import type { RoutingView } from '../../api/types';
+import { RoutingLedger } from './RoutingLedger';
 import { RoutingLine } from './RoutingLine';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError, fetchJson, streamEvals } from '../../api/client';
@@ -305,6 +306,10 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
           </table>
         </div>
       )}
+      {/* What actually ran. The board above is how models do on
+          fixtures; this is what the practice got. */}
+      <h4 className="v2-models-sub">what ran</h4>
+      <RoutingLedger />
     </div>
   );
 }

--- a/runtime/ui/src/v2/settings/ModelsGroup.tsx
+++ b/runtime/ui/src/v2/settings/ModelsGroup.tsx
@@ -308,7 +308,7 @@ export function ModelsGroup({ providerIds }: ModelsGroupProps): JSX.Element {
       )}
       {/* What actually ran. The board above is how models do on
           fixtures; this is what the practice got. */}
-      <h4 className="v2-models-sub">what ran</h4>
+      <h3 className="runin v2-models-sub">what ran</h3>
       <RoutingLedger />
     </div>
   );

--- a/runtime/ui/src/v2/settings/RoutingLedger.test.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLedger.test.tsx
@@ -88,6 +88,13 @@ describe('the routing ledger', () => {
     status = 500;
     render(<RoutingLedger />);
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('could not be read'));
+    cleanup();
+
+    // An older runtime has no ledger route. Nothing to show, nothing wrong.
+    status = 404;
+    render(<RoutingLedger />);
+    await waitFor(() => expect(screen.getByText(/Nothing has run yet/)).toBeTruthy());
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
   test('the words', () => {

--- a/runtime/ui/src/v2/settings/RoutingLedger.test.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLedger.test.tsx
@@ -1,0 +1,109 @@
+import { cleanup, render, screen, userEvent, waitFor, within } from '../../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../../api/token';
+import type { LedgerRun } from '../../api/types';
+import { costOf, RoutingLedger, tookOf, whenOf, whyOf } from './RoutingLedger';
+
+const realFetch = globalThis.fetch;
+let runs: LedgerRun[] = [];
+let status = 200;
+
+function json(body: unknown, code = 200): Response {
+  return new Response(JSON.stringify(body), { status: code, headers: { 'content-type': 'application/json' } });
+}
+
+function run(over: Partial<LedgerRun> = {}): LedgerRun {
+  return {
+    runId: `r-${Math.random().toString(16).slice(2)}`,
+    threadId: 't-1',
+    thread: 'Acme cap',
+    at: '2026-09-02T10:00:00.000Z',
+    status: 'done',
+    provider: 'claude-sub/claude-opus-5',
+    task: 'review',
+    routeReason: { kind: 'scored', text: 'review 0.90' },
+    durationMs: 78_000,
+    costUsd: 0.46,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  sessionStorage.setItem(TOKEN_KEY, 't');
+  runs = [run()];
+  status = 200;
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    if (!String(input).startsWith('/routing/ledger')) throw new Error(`unexpected fetch: ${String(input)}`);
+    return status === 200 ? json({ runs }) : json({ error: 'the record could not be read' }, status);
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  cleanup();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+const table = (): HTMLElement => screen.getByRole('table', { name: 'What ran' });
+
+describe('the routing ledger', () => {
+  test('one row per run: the task, the conversation, the model, why, and what it took', async () => {
+    render(<RoutingLedger />);
+    await waitFor(() => expect(table()).toBeTruthy());
+    const row = within(table()).getAllByRole('row')[1]!;
+    expect(row.textContent).toContain('review');
+    expect(row.textContent).toContain('Acme cap');
+    expect(row.textContent).toContain('claude-sub/claude-opus-5');
+    expect(row.textContent).toContain('review 0.90');
+    expect(row.textContent).toContain('1m 18s');
+    expect(row.textContent).toContain('$0.46');
+  });
+
+  test('the mark is the last word, and a run that did not finish says so instead', async () => {
+    runs = [run({ mark: 'not-right' }), run({ status: 'timeout', mark: undefined, durationMs: undefined })];
+    render(<RoutingLedger />);
+    await waitFor(() => expect(table()).toBeTruthy());
+    const rows = within(table()).getAllByRole('row');
+    expect(rows[1]!.textContent).toContain('not-right');
+    expect(rows[2]!.textContent).toContain('timeout');
+  });
+
+  test('a long ledger shows the recent ones and unfolds the rest in place', async () => {
+    runs = Array.from({ length: 26 }, (_, i) => run({ thread: `thread ${i}` }));
+    render(<RoutingLedger />);
+    await waitFor(() => expect(table()).toBeTruthy());
+    expect(within(table()).getAllByRole('row')).toHaveLength(21); // 20 + the header
+    await userEvent.click(screen.getByRole('button', { name: '6 more' }));
+    expect(within(table()).getAllByRole('row')).toHaveLength(27);
+  });
+
+  test('nothing yet, and a record that cannot be read, both say so', async () => {
+    runs = [];
+    render(<RoutingLedger />);
+    await waitFor(() => expect(screen.getByText(/Nothing has run yet/)).toBeTruthy());
+    cleanup();
+
+    status = 500;
+    render(<RoutingLedger />);
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('could not be read'));
+  });
+
+  test('the words', () => {
+    const now = new Date('2026-09-02T12:00:00.000Z');
+    expect(whenOf('2026-09-02T11:59:30.000Z', now)).toBe('just now');
+    expect(whenOf('not a date', now)).toBe('');
+    expect(tookOf(1234)).toBe('1.2s');
+    expect(tookOf(18_400)).toBe('18s');
+    expect(tookOf(124_000)).toBe('2m 04s');
+    expect(tookOf(undefined)).toBe('');
+    expect(costOf(0.004)).toBe('<$0.01');
+    expect(costOf(0.46)).toBe('$0.46');
+
+    // The policy is worth saying, but never twice.
+    expect(whyOf(run({ policy: 'stays-local' }))).toBe('review 0.90 · stays on this machine');
+    expect(whyOf(run({ policy: 'stays-local', routeReason: { kind: 'stays-local', text: 'stays on this machine' } }))).toBe('stays on this machine');
+    expect(whyOf(run({ routeReason: undefined }))).toBe('');
+  });
+});

--- a/runtime/ui/src/v2/settings/RoutingLedger.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLedger.tsx
@@ -1,0 +1,130 @@
+/**
+ * The routing ledger: what actually ran, and what it got.
+ *
+ * The scoreboard above says how models do on fixtures; the line under each
+ * task says how that task is meant to route. Neither answers the question
+ * you ask after a morning's work — what happened — and that is the only way
+ * to find out whether the rule and the practice agree.
+ *
+ * One row per run, newest first, in the same set text as the rest of the
+ * record: when, the conversation, the task, the model, why it got there,
+ * what it cost, and your mark if you left one.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError, readRoutingLedger } from '../../api/client';
+import type { LedgerRun } from '../../api/types';
+
+const SHOW = 20;
+
+/** "just now" · "14:05" today · "Sep 1" before that. */
+export function whenOf(at: string, now = new Date()): string {
+  const t = new Date(at);
+  if (Number.isNaN(t.getTime())) return '';
+  const mins = (now.getTime() - t.getTime()) / 60_000;
+  if (mins < 2) return 'just now';
+  if (t.toDateString() === now.toDateString()) return t.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
+  return t.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+}
+
+/** `1.2s` · `18s` · `2m 04s`. A run is measured in seconds, not in ms. */
+export function tookOf(ms: number | undefined): string {
+  if (ms === undefined) return '';
+  if (ms < 10_000) return `${(ms / 1000).toFixed(1)}s`;
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s`;
+  return `${Math.floor(ms / 60_000)}m ${String(Math.round((ms % 60_000) / 1000)).padStart(2, '0')}s`;
+}
+
+export function costOf(usd: number | undefined): string {
+  if (usd === undefined) return '';
+  return usd < 0.005 ? '<$0.01' : `$${usd.toFixed(2)}`;
+}
+
+/** The reason, in the words the record kept — or the honest blank. */
+export function whyOf(run: LedgerRun): string {
+  const reason = run.routeReason?.text ?? '';
+  // The policy is worth saying even when the reason already implies it, but
+  // never twice.
+  if (run.policy === 'stays-local' && !reason.includes('this machine')) {
+    return reason === '' ? 'stays on this machine' : `${reason} · stays on this machine`;
+  }
+  return reason;
+}
+
+export function RoutingLedger(): JSX.Element {
+  const [runs, setRuns] = useState<LedgerRun[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [all, setAll] = useState(false);
+
+  const load = useCallback(async (): Promise<void> => {
+    try {
+      setRuns(await readRoutingLedger(100));
+      setError(null);
+    } catch (err) {
+      // An older runtime has no ledger; the group above still reads.
+      if (!(err instanceof ApiError && err.status === 401)) setError(err instanceof Error ? err.message : String(err));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (error !== null) {
+    return (
+      <p className="v2-ledger-quiet" role="alert">
+        The ledger could not be read: {error}
+      </p>
+    );
+  }
+  if (runs === null) return <p className="v2-ledger-quiet">Reading the record…</p>;
+  if (runs.length === 0) return <p className="v2-ledger-quiet">Nothing has run yet. Ask counsel something and it will show here.</p>;
+
+  const shown = all ? runs : runs.slice(0, SHOW);
+  return (
+    <>
+      {/* Six columns in a pane that is not always wide: the table scrolls
+          inside its own box rather than the page scrolling sideways. */}
+      <div className="v2-models-scroll">
+        <table className="v2-ledger" aria-label="What ran">
+          <thead>
+            <tr>
+              <th scope="col">when</th>
+              <th scope="col">task</th>
+              <th scope="col">model</th>
+              <th scope="col">why</th>
+              <th scope="col">took</th>
+              <th scope="col">mark</th>
+            </tr>
+          </thead>
+          <tbody>
+            {shown.map(run => (
+              <tr key={run.runId} className={run.status === 'done' ? undefined : 'v2-ledger-unfinished'}>
+                <td className="v2-ledger-when" title={run.at}>
+                  {whenOf(run.at)}
+                </td>
+                <td>
+                  {run.task ?? 'chat'}
+                  {run.thread === '' ? null : <span className="v2-ledger-thread"> · {run.thread}</span>}
+                </td>
+                <td>{run.provider === '' ? '—' : run.provider}</td>
+                <td className="v2-ledger-why">{whyOf(run)}</td>
+                <td className="v2-ledger-num">
+                  {tookOf(run.durationMs)}
+                  {run.costUsd === undefined ? null : ` · ${costOf(run.costUsd)}`}
+                </td>
+                <td>{run.status === 'done' ? (run.mark ?? '') : run.status}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      {runs.length > SHOW && !all ? (
+        <p className="v2-ledger-quiet">
+          <button type="button" className="v2-link" onClick={() => setAll(true)}>
+            {runs.length - SHOW} more
+          </button>
+        </p>
+      ) : null}
+    </>
+  );
+}

--- a/runtime/ui/src/v2/settings/RoutingLedger.tsx
+++ b/runtime/ui/src/v2/settings/RoutingLedger.tsx
@@ -15,6 +15,9 @@ import { ApiError, readRoutingLedger } from '../../api/client';
 import type { LedgerRun } from '../../api/types';
 
 const SHOW = 20;
+/** How far back the ledger reads. Enough to answer "what happened lately"
+ * without turning a settings visit into a scan of the whole vault. */
+const PAGE = 100;
 
 /** "just now" · "14:05" today · "Sep 1" before that. */
 export function whenOf(at: string, now = new Date()): string {
@@ -57,11 +60,17 @@ export function RoutingLedger(): JSX.Element {
 
   const load = useCallback(async (): Promise<void> => {
     try {
-      setRuns(await readRoutingLedger(100));
+      setRuns(await readRoutingLedger(PAGE));
       setError(null);
     } catch (err) {
-      // An older runtime has no ledger; the group above still reads.
-      if (!(err instanceof ApiError && err.status === 401)) setError(err instanceof Error ? err.message : String(err));
+      // 401 is the session, reported once by the shell rather than in every
+      // panel. 404 is an older runtime with no ledger route: there is
+      // nothing to show and nothing wrong, so the group above just ends.
+      if (err instanceof ApiError && (err.status === 401 || err.status === 404)) {
+        setRuns([]);
+        return;
+      }
+      setError(err instanceof Error ? err.message : String(err));
     }
   }, []);
 
@@ -78,6 +87,7 @@ export function RoutingLedger(): JSX.Element {
   }
   if (runs === null) return <p className="v2-ledger-quiet">Reading the record…</p>;
   if (runs.length === 0) return <p className="v2-ledger-quiet">Nothing has run yet. Ask counsel something and it will show here.</p>;
+
 
   const shown = all ? runs : runs.slice(0, SHOW);
   return (


### PR DESCRIPTION
The scoreboard says how models do on fixtures. The line under each task says how that task is *meant* to route. Neither answers the question you ask after a morning's work — what happened.

**`GET /routing/ledger?limit=`** reads the run records the runtime already keeps and returns them newest first across every thread: the conversation's title, the task, the model, the route reason, cost, duration, and your mark. `readRuns` generalizes the old per-thread `listRuns`.

**Settings › Models** ends with the table, in the same set text as the board above it — twenty rows with the rest one click away, scrolling inside its own box rather than pushing the page sideways. A run from before routing recorded a reason shows none rather than a guess, and a run that did not finish says so where the mark would be.

Read against the real vault: seven runs, two providers, the retro's `you chose this model`, and the older chats correctly blank.

Suites green (1276 runtime, 564 UI), both typechecks clean.