### PR TITLE
The settings icon is a gear, not a sun

### DIFF
--- a/runtime/ui/src/v2/icons.tsx
+++ b/runtime/ui/src/v2/icons.tsx
@@ -4,9 +4,19 @@
 
 import type { ReactNode } from 'react';
 
-function Icon({ children }: { children: ReactNode }): JSX.Element {
+function Icon({ children, round = false }: { children: ReactNode; round?: boolean }): JSX.Element {
   return (
-    <svg className="v2-nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth={1.4} aria-hidden="true">
+    <svg
+      className="v2-nav-icon"
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.4}
+      // A many-cornered outline needs its joins rounded, or every tooth
+      // grows a spike where two strokes meet at an acute angle.
+      {...(round ? { strokeLinejoin: 'round' as const } : {})}
+      aria-hidden="true"
+    >
       {children}
     </svg>
   );
@@ -36,11 +46,20 @@ export function VaultIcon(): JSX.Element {
   );
 }
 
+/**
+ * A gear. The old icon was a ring with eight radiating spokes, which is the
+ * glyph every other app uses for BRIGHTNESS — it read as a light/dark
+ * toggle, not as settings.
+ *
+ * Six teeth, not eight: at 16px the teeth have to stay separate, and the
+ * rail's other three icons are four-to-six-point outlines that a denser
+ * gear would out-weigh.
+ */
 export function SettingsIcon(): JSX.Element {
   return (
-    <Icon>
-      <circle cx="8" cy="8" r="2.4" />
-      <path d="M8 1.5v2M8 12.5v2M1.5 8h2M12.5 8h2M3.4 3.4l1.4 1.4M11.2 11.2l1.4 1.4M12.6 3.4l-1.4 1.4M4.8 11.2l-1.4 1.4" />
+    <Icon round>
+      <path d="M 6.76 3.67 L 6.50 1.98 L 9.50 1.98 L 9.24 3.67 A 4.5 4.5 0 0 1 11.13 4.76 L 12.46 3.69 L 13.96 6.29 L 12.37 6.91 A 4.5 4.5 0 0 1 12.37 9.09 L 13.96 9.71 L 12.46 12.31 L 11.13 11.24 A 4.5 4.5 0 0 1 9.24 12.33 L 9.50 14.02 L 6.50 14.02 L 6.76 12.33 A 4.5 4.5 0 0 1 4.87 11.24 L 3.54 12.31 L 2.04 9.71 L 3.63 9.09 A 4.5 4.5 0 0 1 3.63 6.91 L 2.04 6.29 L 3.54 3.69 L 4.87 4.76 A 4.5 4.5 0 0 1 6.76 3.67 Z" />
+      <circle cx="8" cy="8" r="2.1" />
     </Icon>
   );
 }


### PR DESCRIPTION
A ring with eight radiating spokes is the glyph every other app uses for brightness, so in the rail it read as a light/dark toggle.

Six teeth rather than eight: at 16px the teeth have to stay separate, and Home, Chat and Vault are four-to-six-point outlines that a denser gear would out-weigh. Rendered all three weights beside the real rail before picking.

`Icon` gained a `round` flag — a many-cornered outline grows a spike at every acute join without `stroke-linejoin: round`.