### PR TITLE
Conversations keep working when you look away

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+Conversations that keep working (web-ui spec §3.1)
+
+- A conversation no longer stops because you looked at something else. Switching to another conversation while counsel is still working used to abort the step — the answer thrown away and the run recorded `abandoned`, which is what two of the runs in this vault's own ledger are. The step now runs to the end whether or not you are watching, and its answer is there when you come back.
+- Several conversations can be working at once. The rail marks each one that still is, so you can send a review, start something else, and come back to the answer.
+- The runtime always allowed this: its step lock is per conversation, so only two steps in the SAME conversation queue. The limit was the screen.
+
 The routing ledger (routing-and-evals spec §6)
 
 - Settings › Models now ends with **what ran**: the last hundred steps, newest first, with the conversation it belongs to, the task, the model it got, why it got it, what it took and cost, and your mark. The scoreboard says how models do on fixtures and the line under each task says how that task is meant to route; this is the only place that says what actually happened.

--- a/runtime/src/core/fake-provider.test.ts
+++ b/runtime/src/core/fake-provider.test.ts
@@ -38,3 +38,18 @@ describe('FakeModelProvider', () => {
     expect(String((events[1] as any).output)).toMatch(/invalid input/);
   });
 });
+
+test('a scripted step can be made to take time, so one can be caught in flight', async () => {
+  // `--fake` answers instantly, which makes a streaming UI impossible to
+  // watch: two conversations overlapping, a Stop with something to stop.
+  const provider = new FakeModelProvider([{ text: 'slow', delayMs: 40 }]);
+  const t0 = performance.now();
+  const events: string[] = [];
+  for await (const ev of provider.run({ system: '', messages: [{ role: 'user', content: 'go' }], tools: [], tenant: 'default' } as never)) {
+    events.push(ev.type);
+  }
+  expect(performance.now() - t0).toBeGreaterThanOrEqual(35);
+  expect(events).toContain('text');
+  expect(events.at(-1)).toBe('done');
+});
+

--- a/runtime/src/core/fake-provider.ts
+++ b/runtime/src/core/fake-provider.ts
@@ -9,6 +9,10 @@ export interface FakeScript {
   usage?: Usage;
   /** When set, the step ends with this `error` instead of a `done`. */
   error?: string;
+  /** Milliseconds to wait before the answer, so a step can be observed in
+   * flight — two conversations overlapping, a Stop that has something to
+   * stop. Absent (and in every test) the answer is immediate. */
+  delayMs?: number;
 }
 
 export async function runToolDef(tools: ToolDef[], name: string, input: unknown, tenant: string):
@@ -48,6 +52,7 @@ export class FakeModelProvider implements ModelProvider {
       const r = await runToolDef(req.tools, call.name, call.input, req.tenant);
       yield { type: 'tool_result', id, name: call.name, output: r.output, isError: r.isError };
     }
+    if (s.delayMs !== undefined && s.delayMs > 0) await new Promise(resolve => setTimeout(resolve, s.delayMs));
     if (s.text) yield { type: 'text', text: s.text };
     if (s.error) {
       yield { type: 'error', message: s.error };

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1129,3 +1129,11 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-ledger-num { color: var(--fg-muted); white-space: nowrap; }
 .v2-ledger-unfinished td { color: var(--fg-faint); }
 .v2-ledger-quiet { font: 12.5px/1.7 var(--sans); color: var(--fg-faint); margin: 0.4rem 0 0; }
+
+/* A conversation still working while you read another one. A dot, set in
+   the accent, sized to the text it sits before. */
+.v2-thread-running { display: inline-block; width: 6px; height: 6px; margin-right: 6px; border-radius: 50%; background: var(--accent); vertical-align: 1px; }
+@media (prefers-reduced-motion: no-preference) {
+  .v2-thread-running { animation: v2-thread-pulse 1.8s ease-in-out infinite; }
+}
+@keyframes v2-thread-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1130,6 +1130,9 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-ledger-unfinished td { color: var(--fg-faint); }
 .v2-ledger-quiet { font: 12.5px/1.7 var(--sans); color: var(--fg-faint); margin: 0.4rem 0 0; }
 
+/* Said, not shown: for a state whose visual form is a shape. */
+.v2-sr { position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0; overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0; }
+
 /* A conversation still working while you read another one. A dot, set in
    the accent, sized to the text it sits before. */
 .v2-thread-running { display: inline-block; width: 6px; height: 6px; margin-right: 6px; border-radius: 50%; background: var(--accent); vertical-align: 1px; }

--- a/runtime/ui/src/test/dom.ts
+++ b/runtime/ui/src/test/dom.ts
@@ -12,7 +12,8 @@
  * the globals out from under an already-rendered tree.
  */
 import { GlobalRegistrator } from '@happy-dom/global-registrator';
-import { within } from '@testing-library/react';
+import { cleanup as domCleanup, within } from '@testing-library/react';
+import { reset as resetStreams } from '../v2/chat/streams';
 
 declare global {
   var __counselOsDomRegistered: boolean | undefined;
@@ -57,5 +58,18 @@ export const screen: Queries = new Proxy({} as Queries, {
   },
 });
 
-export { act, cleanup, fireEvent, render, waitFor, within } from '@testing-library/react';
+export { act, fireEvent, render, waitFor, within } from '@testing-library/react';
+
+/**
+ * Unmount the tree AND drop any step the stream registry is still holding.
+ *
+ * A running step deliberately outlives the component showing it
+ * (v2/chat/streams.ts) — that is the whole point of it. Module state also
+ * outlives a test FILE, so without this a stream one file left running is
+ * the next file's mystery: its Chat mounts already streaming.
+ */
+export function cleanup(): void {
+  domCleanup();
+  resetStreams();
+}
 export { default as userEvent } from '@testing-library/user-event';

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -160,7 +160,17 @@ export function Rail({
                     <>
                       <button type="button" className="v2-thread-open" onClick={() => onSelect(thread.id)}>
                         <span className="v2-thread-title">
-                          {running.includes(thread.id) ? <span className="v2-thread-running" aria-label="still running" title="still running" /> : null}
+                          {/* The dot is decoration; the words are what a
+                              screen reader hears, and they fold into the
+                              button's own name rather than sitting on an
+                              empty labelled span that may not be announced
+                              at all. */}
+                          {running.includes(thread.id) ? (
+                            <>
+                              <span className="v2-thread-running" aria-hidden="true" />
+                              <span className="v2-sr">still running: </span>
+                            </>
+                          ) : null}
                           {railLabel(thread)}
                         </span>
                         {matter === null ? null : (

--- a/runtime/ui/src/v2/Rail.tsx
+++ b/runtime/ui/src/v2/Rail.tsx
@@ -20,6 +20,9 @@ export interface RailProps {
    * (spec §3.1). */
   collapsed: boolean;
   onSelect: (id: string) => void;
+  /** Threads with a step in flight — one dot each, so work you walked away
+   * from is visible from anywhere. */
+  running?: readonly string[];
   onNew: () => void;
   /** The draft row: navigate back to the draft already live in the chat
    * pane — never a reset. `onNew` starts a draft; this one returns to it. */
@@ -62,6 +65,7 @@ export function Rail({
   health,
   collapsed,
   onSelect,
+  running = [],
   onNew,
   onOpenDraft,
   onDelete,
@@ -155,7 +159,10 @@ export function Rail({
                   ) : (
                     <>
                       <button type="button" className="v2-thread-open" onClick={() => onSelect(thread.id)}>
-                        <span className="v2-thread-title">{railLabel(thread)}</span>
+                        <span className="v2-thread-title">
+                          {running.includes(thread.id) ? <span className="v2-thread-running" aria-label="still running" title="still running" /> : null}
+                          {railLabel(thread)}
+                        </span>
                         {matter === null ? null : (
                           <span className="v2-thread-sub" title={thread.matter}>
                             {matter}

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -365,6 +365,54 @@ describe('Shell', () => {
     expect(document.querySelector('.v2-thread-running')).toBeNull();
   });
 
+  test('a delete that fails leaves the conversation AND its step alone', async () => {
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    streams.open('t-1', 'Review the cap.');
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeTruthy());
+
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      // `json()` here is always 200 — a failure has to be built by hand.
+      if ((init?.method ?? 'GET') === 'DELETE') {
+        return new Response(JSON.stringify({ error: 'the vault went away' }), { status: 500, headers: { 'content-type': 'application/json' } });
+      }
+      return await (base as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Acme NDA term' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    // Cancelling BEFORE the delete threw the step away for a conversation
+    // that still exists: the transcript blanked, with nothing left to stop.
+    // The row is still in the rail — the conversation was not deleted.
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Delete Acme NDA term' })).toBeTruthy());
+    expect(streams.streamOf('t-1')?.status).toBe('running');
+    expect(document.querySelector('.v2-thread-running')).toBeTruthy();
+  });
+
+  test('a step that ends while you are elsewhere still moves the rail', async () => {
+    // The ending belongs to the mounted pane, and when none is on that
+    // thread there is nobody to tell the shell — the finished conversation
+    // kept its stale place and the files it wrote never became chips.
+    let lists = 0;
+    const base = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      if (String(input) === '/threads' && (init?.method ?? 'GET') === 'GET') lists += 1;
+      return await (base as typeof fetch)(input, init);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    streams.open('t-1', 'Review the cap.');
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeTruthy());
+    const before = lists;
+
+    // It ends with the reader on another conversation.
+    streams.forget('t-1');
+    await waitFor(() => expect(lists).toBeGreaterThan(before));
+  });
+
   test('a stale empty list cannot reopen a draft over the thread just created', async () => {
     const fresh: ThreadHeader = {
       id: 't-9',

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -6,6 +6,7 @@ import { routeFromHash, vaultPathFromHash } from '../app';
 import type { Health, SettingsView, Thread, ThreadEvent, ThreadHeader } from '../api/types';
 import { VAULT_CHANGED_EVENT } from './intake';
 import { Shell } from './Shell';
+import * as streams from './chat/streams';
 
 const realFetch = globalThis.fetch;
 const at = '2026-08-30T10:00:00.000Z';
@@ -234,6 +235,134 @@ describe('Shell', () => {
     // Back to the first: the answer is there, not an abandoned run.
     await userEvent.click(screen.getByText('Acme NDA term'));
     await waitFor(() => expect(screen.getByText('the cap is low')).toBeTruthy());
+  }, 20_000);
+
+  test('coming back BEFORE it finishes still lands the answer', async () => {
+    // The ending belongs to whoever is mounted. When the pane that sent had
+    // it, its `load` ran on an unmounted instance and dropped the entry from
+    // under the pane the reader was actually looking at — question and
+    // answer both gone, on a transcript that pane had never reloaded.
+    let openGate!: () => void;
+    const gate = new Promise<void>(resolve => (openGate = resolve));
+    let answered = false;
+    const answeredEvents: ThreadEvent[] = [
+      { t: 'user', at, content: 'Review the cap.' },
+      { t: 'step', at, runId: 'r-9', provider: 'fake/fake' },
+      { type: 'text', at, text: 'the cap is low' },
+      { type: 'done', at, output: null, usage: { inputTokens: 1, outputTokens: 1 } },
+    ];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/steps')) {
+        const body = new ReadableStream<Uint8Array>({
+          start(c) {
+            void gate.then(() => {
+              c.enqueue(new TextEncoder().encode('event: message\ndata: {"type":"text","text":"the cap is low"}\n\n'));
+              c.close();
+              answered = true;
+            });
+          },
+        });
+        return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      }
+      if (url.startsWith('/health')) return json(health);
+      if (url.startsWith('/runs')) return json([]);
+      if (url === '/threads') return json([acme, beta]);
+      if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
+      if (url.startsWith('/proposals')) return json([]);
+      if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
+      if (url.startsWith('/vault/list')) return json([]);
+      if (url.startsWith('/settings')) return json(settings);
+      const match = /^\/threads\/(.+)$/.exec(url);
+      if (match !== null) {
+        const header = match[1] === 't-2' ? beta : acme;
+        return json({ header, events: match[1] === 't-1' && answered ? answeredEvents : [] } satisfies Thread);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.type(screen.getByRole('textbox', { name: 'Message' }), 'Review the cap.');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy());
+
+    // Away and straight back, while it is still working.
+    await userEvent.click(screen.getByText('Beta MSA scope'));
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeTruthy());
+    await userEvent.click(screen.getByText('Acme NDA term'));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy());
+
+    openGate();
+    await waitFor(() => expect(screen.getByText('the cap is low')).toBeTruthy());
+    // And it stays: the sending pane's own reload must not drop it.
+    await new Promise(r => setTimeout(r, 30));
+    expect(screen.getByText('the cap is low')).toBeTruthy();
+    expect(screen.queryByText('No messages yet. Ask counsel something.')).toBeNull();
+  }, 20_000);
+
+  test('a create that lands after you moved on does not take the screen with it', async () => {
+    // The step is no longer aborted on unmount, so `POST /threads` can
+    // finish for a pane that is gone. Taking the selection then put the
+    // rail, the URL and the pane on three different conversations.
+    let openGate!: () => void;
+    const gate = new Promise<void>(resolve => (openGate = resolve));
+    const fresh: ThreadHeader = { id: 't-9', title: 'A brand new one', createdAt: at, updatedAt: at, sessions: {} };
+    let created = false;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url === '/threads' && init?.method === 'POST') {
+        await gate;
+        created = true;
+        return json(fresh);
+      }
+      if (url.endsWith('/steps')) return new Response('', { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      if (url.startsWith('/health')) return json(health);
+      if (url.startsWith('/runs')) return json([]);
+      if (url === '/threads') return json(created ? [fresh, acme, beta] : [acme, beta]);
+      if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
+      if (url.startsWith('/proposals')) return json([]);
+      if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
+      if (url.startsWith('/vault/list')) return json([]);
+      if (url.startsWith('/settings')) return json(settings);
+      const match = /^\/threads\/(.+)$/.exec(url);
+      if (match !== null) return json({ header: match[1] === 't-2' ? beta : acme, events: [] } satisfies Thread);
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.click(screen.getByRole('button', { name: 'New conversation' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'Message' }), 'A brand new one');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    // Away before the create returns.
+    await userEvent.click(screen.getByText('Beta MSA scope'));
+    await waitFor(() => expect(document.querySelector('li.v2-thread[aria-current="true"]')?.textContent).toContain('Beta MSA scope'));
+
+    openGate();
+    await waitFor(() => expect(screen.getByText('A brand new one')).toBeTruthy());
+
+    // The reader is left where they went, and the URL agrees with the pane.
+    expect(document.querySelector('li.v2-thread[aria-current="true"]')?.textContent).toContain('Beta MSA scope');
+    expect(location.hash).toBe('#/chat?thread=t-2');
+    // And the new conversation opens on a click, rather than being stranded.
+    await userEvent.click(screen.getByText('A brand new one'));
+    await waitFor(() => expect(location.hash).toBe('#/chat?thread=t-9'));
+  }, 20_000);
+
+  test('deleting a conversation stops the step it was running', async () => {
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    streams.open('t-1', 'Review the cap.');
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeTruthy());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete Acme NDA term' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    // Not left running against a conversation that no longer exists.
+    await waitFor(() => expect(streams.streamOf('t-1')).toBeNull());
+    expect(document.querySelector('.v2-thread-running')).toBeNull();
   });
 
   test('a stale empty list cannot reopen a draft over the thread just created', async () => {

--- a/runtime/ui/src/v2/Shell.test.tsx
+++ b/runtime/ui/src/v2/Shell.test.tsx
@@ -168,6 +168,74 @@ describe('Shell', () => {
     expect(location.hash).toBe('#/chat?thread=t-2');
   });
 
+  test('a conversation keeps working while you read another one, and its answer survives', async () => {
+    // The bug this fixes: switching conversations re-keyed the chat pane,
+    // which aborted the step and recorded the run `abandoned`. A ninety
+    // second review, thrown away because the lawyer looked at something
+    // else while it worked.
+    let openGate!: () => void;
+    const gate = new Promise<void>(resolve => (openGate = resolve));
+    let answered = false;
+    const answeredEvents: ThreadEvent[] = [
+      { t: 'user', at, content: 'Review the cap.' },
+      { t: 'step', at, runId: 'r-9', provider: 'fake/fake' },
+      { type: 'text', at, text: 'the cap is low' },
+      { type: 'done', at, output: null, usage: { inputTokens: 1, outputTokens: 1 } },
+    ];
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith('/steps')) {
+        const body = new ReadableStream<Uint8Array>({
+          start(c) {
+            void gate.then(() => {
+              c.enqueue(new TextEncoder().encode('event: message\ndata: {"type":"text","text":"the cap is low"}\n\n'));
+              c.close();
+              answered = true;
+            });
+          },
+        });
+        return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+      }
+      if (url.startsWith('/health')) return json(health);
+      if (url.startsWith('/runs')) return json([]);
+      if (url === '/threads') return json([acme, beta]);
+      if (url.startsWith('/vault/overview')) return json({ matters: [], groups: { practice: 0, knowledge: 0, other: 0 } });
+      if (url.startsWith('/proposals')) return json([]);
+      if (url.startsWith('/docket')) return json({ deadlines: [], skipped: 0 });
+      if (url.startsWith('/vault/list')) return json([]);
+      if (url.startsWith('/settings')) return json(settings);
+      const match = /^\/threads\/(.+)$/.exec(url);
+      if (match !== null) {
+        const header = match[1] === 't-2' ? beta : acme;
+        // The server's transcript once the step has finished — which is what
+        // makes the answer survive the walk away.
+        return json({ header, events: match[1] === 't-1' && answered ? answeredEvents : [] } satisfies Thread);
+      }
+      throw new Error(`unexpected fetch: ${url}`);
+    }) as unknown as typeof fetch;
+
+    render(<Shell />);
+    await waitFor(() => expect(chatNode()).toBeTruthy());
+    await userEvent.type(screen.getByRole('textbox', { name: 'Message' }), 'Review the cap.');
+    await userEvent.click(screen.getByRole('button', { name: 'Send' }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Stop' })).toBeTruthy());
+
+    // Walk away mid-step. The rail says that thread is still working, and
+    // THIS conversation's composer is free — it is not the one working.
+    await userEvent.click(screen.getByText('Beta MSA scope'));
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeTruthy());
+    expect(document.querySelector('li.v2-thread[aria-current="true"]')?.textContent).toContain('Beta MSA scope');
+    expect(screen.queryByRole('button', { name: 'Stop' })).toBeNull();
+
+    // The step finishes while nobody is looking at it.
+    openGate();
+    await waitFor(() => expect(document.querySelector('.v2-thread-running')).toBeNull());
+
+    // Back to the first: the answer is there, not an abandoned run.
+    await userEvent.click(screen.getByText('Acme NDA term'));
+    await waitFor(() => expect(screen.getByText('the cap is low')).toBeTruthy());
+  });
+
   test('a stale empty list cannot reopen a draft over the thread just created', async () => {
     const fresh: ThreadHeader = {
       id: 't-9',

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -1,10 +1,11 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import { ApiError, fetchJson } from '../api/client';
 import { bootstrapToken } from '../api/token';
 import { onUnauthorized } from '../api/unauthorized';
 import type { Health, RetroStart, SettingsView, ThreadHeader, ThreadPolicy, VaultOverview } from '../api/types';
 import { parseHash, threadFromHash, vaultPathFromHash, type Route } from '../app';
 import { Chat } from './chat/Chat';
+import * as streams from './chat/streams';
 import { VAULT_CHANGED_EVENT } from './intake';
 import type { ComposerSeed } from './chat/Composer';
 import { Drawer } from './Drawer';
@@ -53,6 +54,10 @@ export function Shell(): JSX.Element {
   const [selected, setSelected] = useState<string | null>(null);
   const [draft, setDraft] = useState(false);
   const [chatKey, setChatKey] = useState(0);
+  /** Which conversations are mid-step. A step outlives the pane that
+   * started it (chat/streams.ts), so this is the only way to see that one
+   * is still working while you read another. */
+  const runningThreads = useSyncExternalStore(streams.subscribe, streams.running, streams.running);
   const [listed, setListed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>({ open: false, path: null });
   const [drawerRevision, setDrawerRevision] = useState(0);
@@ -419,6 +424,7 @@ export function Shell(): JSX.Element {
       <Rail
         route={route}
         threads={threads}
+        running={runningThreads}
         selected={selected}
         draft={draft}
         busy={busy}

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -392,6 +392,10 @@ export function Shell(): JSX.Element {
     setBusy(true);
     setError(null);
     try {
+      // Stop its step first: a deleted conversation's step would otherwise
+      // run to completion against a thread that no longer exists — real
+      // money on a cloud provider, with no screen left that could stop it.
+      streams.cancel(id);
       await fetchJson<void>(`/threads/${encodeURIComponent(id)}`, { method: 'DELETE' });
       const { threads: list } = await loadThreads();
       if (selected === id) {
@@ -462,6 +466,16 @@ export function Shell(): JSX.Element {
                 threadId={draft ? null : selected}
                 health={health}
                 onThreadCreated={header => {
+                  // The create can land after the reader moved on: the step
+                  // is no longer aborted on unmount, so this fires for a
+                  // pane that is gone. Taking the selection then would put
+                  // the rail, the URL and the pane on three different
+                  // conversations. The row still appears — `loadThreads`
+                  // below — and a click opens it.
+                  if (!draftRef.current) {
+                    void loadThreads();
+                    return;
+                  }
                   setSelected(header.id);
                   setDraft(false);
                   // The fragment now names the thread — replaceState, so no

--- a/runtime/ui/src/v2/Shell.tsx
+++ b/runtime/ui/src/v2/Shell.tsx
@@ -58,6 +58,21 @@ export function Shell(): JSX.Element {
    * started it (chat/streams.ts), so this is the only way to see that one
    * is still working while you read another. */
   const runningThreads = useSyncExternalStore(streams.subscribe, streams.running, streams.running);
+  /**
+   * A step that ends while the reader is on ANOTHER conversation has no pane
+   * to tell the shell about it, so the finished thread would keep its stale
+   * place in the rail and the files it wrote would never become chips. The
+   * running set shrinking is that signal.
+   */
+  const wasRunning = useRef(runningThreads.length);
+  useEffect(() => {
+    const shrank = runningThreads.length < wasRunning.current;
+    wasRunning.current = runningThreads.length;
+    if (!shrank) return;
+    void loadThreads();
+    void loadIndex();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runningThreads]);
   const [listed, setListed] = useState(false);
   const [drawer, setDrawer] = useState<DrawerState>({ open: false, path: null });
   const [drawerRevision, setDrawerRevision] = useState(0);
@@ -76,6 +91,10 @@ export function Shell(): JSX.Element {
 
   const draftRef = useRef(draft);
   draftRef.current = draft;
+  /** The mounted pane's identity, for a callback that can arrive from one
+   * that is gone. */
+  const chatKeyRef = useRef(chatKey);
+  chatKeyRef.current = chatKey;
   /** The route as of this render, for the callbacks that must not navigate:
    * `onThreadCreated` (the send may finish after the reader left chat) and
    * `deleteThread` (the rail is global now — delete is reachable from Home). */
@@ -392,11 +411,11 @@ export function Shell(): JSX.Element {
     setBusy(true);
     setError(null);
     try {
-      // Stop its step first: a deleted conversation's step would otherwise
-      // run to completion against a thread that no longer exists — real
-      // money on a cloud provider, with no screen left that could stop it.
-      streams.cancel(id);
       await fetchJson<void>(`/threads/${encodeURIComponent(id)}`, { method: 'DELETE' });
+      // Only once it is really gone: a delete that FAILS leaves the
+      // conversation, and cancelling first would have thrown away the step
+      // and blanked the transcript of a thread that still exists.
+      streams.cancel(id);
       const { threads: list } = await loadThreads();
       if (selected === id) {
         const next = list[0]?.id ?? null;
@@ -463,16 +482,20 @@ export function Shell(): JSX.Element {
             ) : (
               <Chat
                 key={chatKey}
+                pane={chatKey}
                 threadId={draft ? null : selected}
                 health={health}
-                onThreadCreated={header => {
+                onThreadCreated={(header, pane) => {
                   // The create can land after the reader moved on: the step
                   // is no longer aborted on unmount, so this fires for a
                   // pane that is gone. Taking the selection then would put
                   // the rail, the URL and the pane on three different
-                  // conversations. The row still appears — `loadThreads`
-                  // below — and a click opens it.
-                  if (!draftRef.current) {
+                  // conversations. The test is the PANE, not whether the
+                  // shell happens to be on a draft — two drafts can be alive
+                  // at once (Home's ask box mounts a fresh one), and the
+                  // first one's create must not steal the second one's
+                  // screen. The row still appears and a click opens it.
+                  if (pane !== chatKeyRef.current) {
                     void loadThreads();
                     return;
                   }

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { ApiError, fetchJson, streamStep } from '../../api/client';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import * as streams from './streams';
+import { ApiError, fetchJson } from '../../api/client';
 import type { Health, RunRecord, Thread, ThreadEvent, ThreadHeader, ThreadPolicy, VaultFile } from '../../api/types';
 import { proposalFromHash } from '../../app';
-import { applyStepEvent, buildTurns, emptyAssistantTurn, type AssistantTurn, type Turn } from '../../chat/turns';
+import { buildTurns, type Turn } from '../../chat/turns';
 import { createThread, defaultProviderId, titleFor } from '../threads';
 import { relTime } from '../time';
 import { prettifyName, readerModel } from '../vault/frontmatter';
@@ -92,6 +93,10 @@ function matterFallbackTitle(path: string): string {
  * paths, so any load that ends up owning a finished stream hands the
  * composer back.
  */
+/** One object, so `useSyncExternalStore` never sees a new identity for
+ * "no measurements yet". */
+const EMPTY_MS: Record<string, number> = {};
+
 export function Chat({
   threadId: initialThreadId,
   health,
@@ -117,50 +122,38 @@ export function Chat({
   const [runs, setRuns] = useState<RunRecord[]>([]);
   const [loading, setLoading] = useState(initialThreadId !== null);
   const [error, setError] = useState<string | null>(null);
-  const [pending, setPending] = useState<string | null>(null);
-  const [live, setLive] = useState<AssistantTurn | null>(null);
   const [frozen, setFrozen] = useState<Turn[]>([]);
-  /** Milliseconds per tool id for the live turn, measured call → result. */
-  const [liveMs, setLiveMs] = useState<Record<string, number>>({});
 
-  const abort = useRef<AbortController | null>(null);
+  /**
+   * The step in flight is NOT this component's (streams.ts). The shell
+   * re-keys this pane when you switch conversations, and anything held here
+   * went with it — the stream aborted, the run recorded `abandoned`, a
+   * ninety-second review thrown away because you looked at something else
+   * while it worked. The registry owns it; this reads it.
+   */
+  const stream = useSyncExternalStore(streams.subscribe, () => streams.streamOf(idRef.current));
+  const live = stream === null ? null : stream.turn;
+  const pending = stream === null ? null : stream.pending;
+  const liveMs = stream?.ms ?? EMPTY_MS;
   const transcript = useRef<HTMLDivElement | null>(null);
-  const liveRef = useRef<AssistantTurn | null>(null);
-  const pendingRef = useRef<string | null>(null);
-  const started = useRef<Map<string, number>>(new Map());
   const seq = useRef(0);
   /** The send that never reached the server, kept so Retry can run the whole
    * thing again — the create included. Only a draft whose `POST /threads`
    * failed can be in this state; every other error has a thread to reload. */
   const retry = useRef<{ message: string; provider: string } | null>(null);
 
-  const showLive = (next: AssistantTurn | null): void => {
-    liveRef.current = next;
-    setLive(next);
-  };
-  const showPending = (next: string | null): void => {
-    pendingRef.current = next;
-    setPending(next);
-  };
 
   /** Retires a finished stream's turn: dropped (`keep === false`, a load
    * installed a transcript containing it) or parked in `frozen` (`true`,
    * the load failed and the transcript on screen does not have it). Does
-   * nothing while a step is running — the stream owns `live` then. */
+   * nothing while a step is running — the registry owns the turn then. */
   const settle = (keep: boolean): void => {
-    if (abort.current !== null) return;
-    const streamed = liveRef.current;
-    const asked = pendingRef.current;
-    if (streamed === null && asked === null) return;
+    const current = streams.streamOf(idRef.current);
+    if (current === null || current.status === 'running') return;
     if (keep) {
-      setFrozen(current => [
-        ...current,
-        ...(asked === null ? [] : [{ kind: 'user', content: asked } as Turn]),
-        ...(streamed === null ? [] : [streamed]),
-      ]);
+      setFrozen(rest => [...rest, { kind: 'user', content: current.pending } as Turn, current.turn]);
     }
-    showLive(null);
-    showPending(null);
+    streams.forget(idRef.current);
   };
 
   const load = useCallback(async (): Promise<void> => {
@@ -222,7 +215,9 @@ export function Chat({
   // `thread` ran before the slips were committed on a slow runner and
   // never ran again (CI, 2026-09-01).
 
-  useEffect(() => () => abort.current?.abort(), []);
+  // NOT `abort()` on unmount. The pane is re-keyed on every conversation
+  // switch, and aborting here is what threw the answer away.
+
 
   useEffect(() => {
     const el = transcript.current;
@@ -230,99 +225,64 @@ export function Chat({
   }, [thread, live, pending, frozen]);
 
   const send = async (message: string, provider: string): Promise<void> => {
-    // One send at a time. The composer is locked for the whole of it, so this
-    // only catches a caller that got past the UI.
-    if (abort.current !== null) return;
+    // One send at a time IN THIS THREAD. The composer is locked for the whole
+    // of it, so this only catches a caller that got past the UI. Another
+    // thread sending at the same time is the point of the registry.
+    if (streams.streamOf(idRef.current) !== null) return;
 
-    // The controller and the live turn are armed BEFORE the create is
-    // awaited, and the create runs on the same controller. `live` is what
-    // disables the box and arms Stop, so setting it after a `POST /threads`
-    // that can take a network round trip would leave the composer wide open:
-    // a second ⌘⏎ in that window would take the create branch again and open
-    // a second thread, with the first orphaned and never stepped.
-    const controller = new AbortController();
-    abort.current = controller;
-    started.current = new Map();
+    // The entry is opened BEFORE the create is awaited, and the create runs
+    // on its signal. The entry is what disables the box and arms Stop, so
+    // opening it after a `POST /threads` that can take a network round trip
+    // would leave the composer wide open: a second ⌘⏎ in that window would
+    // take the create branch again and open a second thread, with the first
+    // orphaned and never stepped.
+    streams.open(idRef.current, message);
+    const signal = streams.signalOf(idRef.current);
     retry.current = null;
-    setLiveMs({});
     setError(null);
     setRefused(false);
     refusedRef.current = false;
-    showPending(message);
-    showLive(emptyAssistantTurn());
 
     if (idRef.current === null) {
       try {
-        const header = await createThread({ title: titleFor(message) }, controller.signal);
+        const header = await createThread({ title: titleFor(message) }, signal);
+        streams.rename(header.id);
         idRef.current = header.id;
         setThreadId(header.id);
         onThreadCreated?.(header);
       } catch (err) {
         // No step ran and there may be no thread, so there is nothing for
         // `load` to fetch: this is the one path that retires its own turn.
-        // `settle` no-ops while a controller is live, so clear it first.
-        abort.current = null;
-        // The empty assistant turn never became an answer; freezing it would
-        // park a blank bubble in the transcript for good.
-        showLive(null);
-        if (controller.signal.aborted) {
-          // Stop during creation. Nothing was created and nothing was sent,
-          // so nothing is left behind either.
-          showPending(null);
-          return;
-        }
+        const aborted = signal?.aborted === true;
+        streams.forget(null);
+        if (aborted) return; // Stop during creation: nothing was created, nothing sent.
         if (!(err instanceof ApiError && err.status === 401)) setError(`could not start the thread: ${detail(err)}`);
         // The message stays on screen (frozen) and the box is free; `retry`
         // remembers it so the notice's button can run the send again.
+        setFrozen(current => [...current, { kind: 'user', content: message } as Turn]);
         retry.current = { message, provider };
-        settle(true);
         return;
       }
     }
     const id = idRef.current;
 
-    try {
-      await streamStep(
-        id,
-        { message, provider },
-        event => {
-          if (event.type === 'tool_call') started.current.set(event.id, performance.now());
-          if (event.type === 'tool_result') {
-            const callId = event.id;
-            const t0 = started.current.get(callId);
-            if (t0 !== undefined) {
-              const ms = Math.round(performance.now() - t0);
-              setLiveMs(current => ({ ...current, [callId]: ms }));
-            }
-          }
-          const base = liveRef.current ?? emptyAssistantTurn();
-          const tagged = base.runId === undefined && event.runId !== undefined ? { ...base, runId: event.runId } : base;
-          showLive(applyStepEvent(tagged, event));
-        },
-        controller.signal,
-      );
-    } catch (err) {
-      if (!controller.signal.aborted) {
-        // The runtime refused the step for the matter's privacy policy
-        // (409 matter-stays-local): nothing ran, nothing to retry into —
-        // the sentence is the whole answer, without a Retry into cloud.
-        const body = err instanceof ApiError && err.status === 409 ? (err.body as { error?: string; message?: string } | null) : null;
-        if (body !== null && body?.error === 'matter-stays-local') {
-          showLive(null);
-          showPending(null);
-          setError(body.message ?? 'This matter stays on this machine.');
-          setRefused(true);
-          refusedRef.current = true;
-          return;
-        }
-        showLive(applyStepEvent(liveRef.current ?? emptyAssistantTurn(), { type: 'error', message: detail(err) }));
-        setError(detail(err));
-      }
-    } finally {
-      abort.current = null;
-      await load();
-      onThreadTouched?.();
+    // From here the registry owns the step. It finishes whether or not this
+    // pane is still mounted; what follows only runs if it is.
+    await streams.run(id, message, provider);
+    const ended = streams.streamOf(id);
+    if (ended?.refused === true) {
+      // The runtime refused the step for the matter's privacy policy
+      // (409 matter-stays-local): nothing ran, nothing to retry into — the
+      // sentence is the whole answer, without a Retry into cloud.
+      setError(ended.error);
+      setRefused(true);
+      refusedRef.current = true;
+      streams.forget(id);
+      return;
     }
+    if (ended?.error != null) setError(ended.error);
+    await load();
+    onThreadTouched?.();
   };
 
   /**
@@ -342,7 +302,7 @@ export function Chat({
     void send(initialAsk.text, defaultProviderId(health));
   }, [initialAsk]);
 
-  const stop = (): void => abort.current?.abort();
+  const stop = (): void => streams.stop(idRef.current);
   const reload = (): void => void load();
 
   /** A card settled a proposal. The thread is refetched so its proposals

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -19,7 +19,11 @@ export interface ChatProps {
   health: Health;
   /** The draft became a thread. The shell selects it WITHOUT re-keying this
    * component — a remount here would drop the stream in flight. */
-  onThreadCreated?: (header: ThreadHeader) => void;
+  /** Told with the pane's own token, so a create that lands after the
+   * reader moved on can be recognized as belonging to a pane that is gone. */
+  onThreadCreated?: (header: ThreadHeader, pane: number) => void;
+  /** This pane's identity — the shell's remount key. */
+  pane?: number;
   onThreadTouched?: () => void;
   /** A proposal was approved or rejected, on this vault path. */
   onFileDecided?: (path: string) => void;
@@ -101,6 +105,7 @@ export function Chat({
   threadId: initialThreadId,
   health,
   onThreadCreated,
+  pane = 0,
   onThreadTouched,
   onFileDecided,
   onOpenFile,
@@ -134,8 +139,9 @@ export function Chat({
   /** This pane's own draft slot until its thread exists. Per pane, because
    * Home's ask box remounts the chat on a fresh draft: one shared slot would
    * make the new pane read the old one's stream and swallow the ask. */
-  const draftKey = useRef(streams.draftKey());
-  const keyOf = (): string => idRef.current ?? draftKey.current;
+  const draftKey = useRef<string | null>(null);
+  draftKey.current ??= streams.draftKey();
+  const keyOf = (): string => idRef.current ?? draftKey.current!;
   const stream = useSyncExternalStore(streams.subscribe, () => streams.streamOf(keyOf()));
   const live = stream === null ? null : stream.turn;
   const pending = stream === null ? null : stream.pending;
@@ -251,15 +257,15 @@ export function Chat({
     if (idRef.current === null) {
       try {
         const header = await createThread({ title: titleFor(message) }, signal);
-        streams.rename(draftKey.current, header.id);
+        streams.rename(draftKey.current!, header.id);
         idRef.current = header.id;
         setThreadId(header.id);
-        onThreadCreated?.(header);
+        onThreadCreated?.(header, pane);
       } catch (err) {
         // No step ran and there may be no thread, so there is nothing for
         // `load` to fetch: this is the one path that retires its own turn.
         const aborted = signal?.aborted === true;
-        streams.forget(draftKey.current);
+        streams.forget(draftKey.current!);
         if (aborted) return; // Stop during creation: nothing was created, nothing sent.
         if (!(err instanceof ApiError && err.status === 401)) setError(`could not start the thread: ${detail(err)}`);
         // The message stays on screen (frozen) and the box is free; `retry`

--- a/runtime/ui/src/v2/chat/Chat.tsx
+++ b/runtime/ui/src/v2/chat/Chat.tsx
@@ -131,7 +131,12 @@ export function Chat({
    * ninety-second review thrown away because you looked at something else
    * while it worked. The registry owns it; this reads it.
    */
-  const stream = useSyncExternalStore(streams.subscribe, () => streams.streamOf(idRef.current));
+  /** This pane's own draft slot until its thread exists. Per pane, because
+   * Home's ask box remounts the chat on a fresh draft: one shared slot would
+   * make the new pane read the old one's stream and swallow the ask. */
+  const draftKey = useRef(streams.draftKey());
+  const keyOf = (): string => idRef.current ?? draftKey.current;
+  const stream = useSyncExternalStore(streams.subscribe, () => streams.streamOf(keyOf()));
   const live = stream === null ? null : stream.turn;
   const pending = stream === null ? null : stream.pending;
   const liveMs = stream?.ms ?? EMPTY_MS;
@@ -148,12 +153,12 @@ export function Chat({
    * the load failed and the transcript on screen does not have it). Does
    * nothing while a step is running — the registry owns the turn then. */
   const settle = (keep: boolean): void => {
-    const current = streams.streamOf(idRef.current);
+    const current = streams.streamOf(keyOf());
     if (current === null || current.status === 'running') return;
     if (keep) {
       setFrozen(rest => [...rest, { kind: 'user', content: current.pending } as Turn, current.turn]);
     }
-    streams.forget(idRef.current);
+    streams.forget(keyOf());
   };
 
   const load = useCallback(async (): Promise<void> => {
@@ -228,7 +233,7 @@ export function Chat({
     // One send at a time IN THIS THREAD. The composer is locked for the whole
     // of it, so this only catches a caller that got past the UI. Another
     // thread sending at the same time is the point of the registry.
-    if (streams.streamOf(idRef.current) !== null) return;
+    if (streams.streamOf(keyOf()) !== null) return;
 
     // The entry is opened BEFORE the create is awaited, and the create runs
     // on its signal. The entry is what disables the box and arms Stop, so
@@ -236,8 +241,8 @@ export function Chat({
     // would leave the composer wide open: a second ⌘⏎ in that window would
     // take the create branch again and open a second thread, with the first
     // orphaned and never stepped.
-    streams.open(idRef.current, message);
-    const signal = streams.signalOf(idRef.current);
+    streams.open(keyOf(), message);
+    const signal = streams.signalOf(keyOf());
     retry.current = null;
     setError(null);
     setRefused(false);
@@ -246,7 +251,7 @@ export function Chat({
     if (idRef.current === null) {
       try {
         const header = await createThread({ title: titleFor(message) }, signal);
-        streams.rename(header.id);
+        streams.rename(draftKey.current, header.id);
         idRef.current = header.id;
         setThreadId(header.id);
         onThreadCreated?.(header);
@@ -254,7 +259,7 @@ export function Chat({
         // No step ran and there may be no thread, so there is nothing for
         // `load` to fetch: this is the one path that retires its own turn.
         const aborted = signal?.aborted === true;
-        streams.forget(null);
+        streams.forget(draftKey.current);
         if (aborted) return; // Stop during creation: nothing was created, nothing sent.
         if (!(err instanceof ApiError && err.status === 401)) setError(`could not start the thread: ${detail(err)}`);
         // The message stays on screen (frozen) and the box is free; `retry`
@@ -266,24 +271,36 @@ export function Chat({
     }
     const id = idRef.current;
 
-    // From here the registry owns the step. It finishes whether or not this
-    // pane is still mounted; what follows only runs if it is.
+    // From here the registry owns the step, and so does the ENDING: this
+    // pane may be gone by then, and the pane that is mounted has to be the
+    // one that reloads. Doing it here dropped the entry under a returning
+    // pane's feet, blanking a transcript it had never reloaded.
     await streams.run(id, message, provider);
-    const ended = streams.streamOf(id);
-    if (ended?.refused === true) {
+  };
+
+  /**
+   * The step for this thread ended — reload, whoever sent it. Runs in the
+   * mounted pane, which is the only one that can show the result.
+   */
+  useEffect(() => {
+    if (stream === null || stream.status === 'running') return;
+    if (stream.refused) {
       // The runtime refused the step for the matter's privacy policy
       // (409 matter-stays-local): nothing ran, nothing to retry into — the
       // sentence is the whole answer, without a Retry into cloud.
-      setError(ended.error);
+      setError(stream.error);
       setRefused(true);
       refusedRef.current = true;
-      streams.forget(id);
+      streams.forget(keyOf());
       return;
     }
-    if (ended?.error != null) setError(ended.error);
-    await load();
-    onThreadTouched?.();
-  };
+    if (stream.error !== null) setError(stream.error);
+    void (async () => {
+      await load();
+      onThreadTouched?.();
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [stream?.status]);
 
   /**
    * Home's ask box, sent (spec §3.2). The nonce is recorded BEFORE the send,
@@ -302,7 +319,7 @@ export function Chat({
     void send(initialAsk.text, defaultProviderId(health));
   }, [initialAsk]);
 
-  const stop = (): void => streams.stop(idRef.current);
+  const stop = (): void => streams.stop(keyOf());
   const reload = (): void => void load();
 
   /** A card settled a proposal. The thread is refetched so its proposals

--- a/runtime/ui/src/v2/chat/streams.test.ts
+++ b/runtime/ui/src/v2/chat/streams.test.ts
@@ -103,10 +103,11 @@ describe('a step that outlives the pane that started it', () => {
   });
 
   test('a draft keeps its answer when the thread it created gets its id', async () => {
-    streams.open(null, 'A new one.');
-    expect(streams.streamOf(null)?.pending).toBe('A new one.');
-    streams.rename('t-9');
-    expect(streams.streamOf(null)).toBeNull();
+    const key = streams.draftKey();
+    streams.open(key, 'A new one.');
+    expect(streams.streamOf(key)?.pending).toBe('A new one.');
+    streams.rename(key, 't-9');
+    expect(streams.streamOf(key)).toBeNull();
     expect(streams.streamOf('t-9')?.pending).toBe('A new one.');
 
     const run = streams.run('t-9', 'A new one.', 'fake/fake');
@@ -142,5 +143,53 @@ describe('a step that outlives the pane that started it', () => {
   test('running a thread with no entry does nothing at all', async () => {
     await streams.run('t-nope', 'Ask.', 'fake/fake');
     expect(streams.streamOf('t-nope')).toBeNull();
+  });
+});
+
+describe('the edges the UI guards but the module must not assume', () => {
+  test('two draft panes never share a slot', () => {
+    // Home's ask box remounts the chat on a fresh draft while another
+    // draft's create is still in flight. One shared slot made the new pane
+    // read the old one's stream — and swallow its ask.
+    const a = streams.draftKey();
+    const b = streams.draftKey();
+    expect(a).not.toBe(b);
+    streams.open(a, 'The first.');
+    expect(streams.streamOf(b)).toBeNull();
+    streams.open(b, 'The second.');
+    expect(streams.streamOf(a)?.pending).toBe('The first.');
+    expect(streams.streamOf(b)?.pending).toBe('The second.');
+  });
+
+  test('opening twice on one key stops the first rather than orphaning it', async () => {
+    streams.open('t-1', 'First.');
+    const first = streams.run('t-1', 'First.', 'fake/fake');
+    streams.open('t-1', 'Second.');
+    open();
+    await first;
+    // The first controller was aborted, so its stream ended; the entry on
+    // screen is the second send's.
+    expect(streams.streamOf('t-1')?.pending).toBe('Second.');
+  });
+
+  test('cancel stops the step as well as dropping it', async () => {
+    streams.open('t-1', 'Ask.');
+    const run = streams.run('t-1', 'Ask.', 'fake/fake');
+    streams.cancel('t-1');
+    expect(streams.streamOf('t-1')).toBeNull();
+    expect(streams.running()).toEqual([]);
+    open();
+    await run;
+    // Nothing came back to a thread that is gone.
+    expect(streams.streamOf('t-1')).toBeNull();
+  });
+
+  test('forgetting mid-stream leaves nothing behind for the events to land on', async () => {
+    streams.open('t-1', 'Ask.');
+    const run = streams.run('t-1', 'Ask.', 'fake/fake');
+    streams.forget('t-1');
+    open();
+    await run;
+    expect(streams.streamOf('t-1')).toBeNull();
   });
 });

--- a/runtime/ui/src/v2/chat/streams.test.ts
+++ b/runtime/ui/src/v2/chat/streams.test.ts
@@ -1,0 +1,146 @@
+import '../../test/dom';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { clearToken, TOKEN_KEY } from '../../api/token';
+import * as streams from './streams';
+
+const realFetch = globalThis.fetch;
+
+/**
+ * An SSE response whose frames arrive when the gate opens — and which fails
+ * the way a real one does when its signal aborts, so Stop is exercised
+ * rather than assumed.
+ */
+function stream(frames: string[], gate: Promise<void>, signal: AbortSignal | null | undefined): Response {
+  const bytes = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const fail = (): void => controller.error(new DOMException('The operation was aborted.', 'AbortError'));
+      if (signal?.aborted === true) return fail();
+      signal?.addEventListener('abort', fail, { once: true });
+      // `start` RETURNS before the gate: a body that is not readable until
+      // the gate opens never streams at all.
+      void gate.then(() => {
+        if (signal?.aborted === true) return;
+        for (const frame of frames) controller.enqueue(bytes.encode(frame));
+        controller.close();
+      });
+    },
+  });
+  return new Response(body, { status: 200, headers: { 'content-type': 'text/event-stream' } });
+}
+
+const TEXT = 'event: message\ndata: {"type":"text","text":"the cap is low"}\n\n';
+const DONE = 'event: message\ndata: {"type":"done","output":null,"usage":{"inputTokens":1,"outputTokens":1},"runId":"r-1"}\n\n';
+
+let open!: () => void;
+let gate: Promise<void>;
+
+beforeEach(() => {
+  sessionStorage.setItem(TOKEN_KEY, 't');
+  gate = new Promise<void>(resolve => (open = resolve));
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => stream([TEXT, DONE], gate, init?.signal)) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  streams.reset();
+  globalThis.fetch = realFetch;
+  clearToken();
+  sessionStorage.clear();
+});
+
+describe('a step that outlives the pane that started it', () => {
+  test('two conversations run at once, and each keeps its own answer', async () => {
+    streams.open('t-1', 'Review the cap.');
+    streams.open('t-2', 'And the indemnity.');
+    const both = Promise.all([streams.run('t-1', 'Review the cap.', 'fake/fake'), streams.run('t-2', 'And the indemnity.', 'fake/fake')]);
+
+    expect([...streams.running()].sort()).toEqual(['t-1', 't-2']);
+    expect(streams.streamOf('t-1')?.pending).toBe('Review the cap.');
+    expect(streams.streamOf('t-2')?.pending).toBe('And the indemnity.');
+
+    open();
+    await both;
+    expect(streams.running()).toEqual([]);
+    for (const id of ['t-1', 't-2']) {
+      const done = streams.streamOf(id)!;
+      expect(done.status).toBe('done');
+      expect(done.turn.text).toBe('the cap is low');
+    }
+  });
+
+  test('subscribers hear every change, and the running set keeps its identity', async () => {
+    let heard = 0;
+    const off = streams.subscribe(() => (heard += 1));
+    const before = streams.running();
+
+    streams.open('t-1', 'Ask.');
+    expect(heard).toBe(1);
+    expect(streams.running()).not.toBe(before);
+    // Same set, same array: `useSyncExternalStore` compares with Object.is,
+    // and a fresh array on every read is an infinite render loop.
+    const while1 = streams.running();
+    const run = streams.run('t-1', 'Ask.', 'fake/fake');
+    open();
+    await run;
+    expect(heard).toBeGreaterThan(1);
+    streams.open('t-2', 'Ask.');
+    streams.forget('t-2');
+    expect(streams.running()).toEqual([]);
+    expect(while1).toEqual(['t-1']);
+    off();
+  });
+
+  test('stop ends that thread and leaves the other one working', async () => {
+    streams.open('t-1', 'Ask.');
+    streams.open('t-2', 'Ask.');
+    const both = Promise.all([streams.run('t-1', 'Ask.', 'fake/fake'), streams.run('t-2', 'Ask.', 'fake/fake')]);
+    streams.stop('t-1');
+    open();
+    await both;
+    expect(streams.streamOf('t-1')?.status).toBe('stopped');
+    expect(streams.streamOf('t-2')?.status).toBe('done');
+  });
+
+  test('a draft keeps its answer when the thread it created gets its id', async () => {
+    streams.open(null, 'A new one.');
+    expect(streams.streamOf(null)?.pending).toBe('A new one.');
+    streams.rename('t-9');
+    expect(streams.streamOf(null)).toBeNull();
+    expect(streams.streamOf('t-9')?.pending).toBe('A new one.');
+
+    const run = streams.run('t-9', 'A new one.', 'fake/fake');
+    open();
+    await run;
+    expect(streams.streamOf('t-9')?.turn.text).toBe('the cap is low');
+  });
+
+  test('a step the runtime refuses for the matter policy carries its sentence', async () => {
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ error: 'matter-stays-local', message: 'This matter stays on this machine.' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch;
+    streams.open('t-1', 'Ask.');
+    await streams.run('t-1', 'Ask.', 'cloud/model');
+    const ended = streams.streamOf('t-1')!;
+    expect(ended.status).toBe('error');
+    expect(ended.refused).toBe(true);
+    expect(ended.error).toBe('This matter stays on this machine.');
+  });
+
+  test('a step that fails keeps the error on the turn as well as on the entry', async () => {
+    globalThis.fetch = (async () => new Response('nope', { status: 500 })) as unknown as typeof fetch;
+    streams.open('t-1', 'Ask.');
+    await streams.run('t-1', 'Ask.', 'fake/fake');
+    const ended = streams.streamOf('t-1')!;
+    expect(ended.status).toBe('error');
+    expect(ended.error).not.toBeNull();
+    expect(ended.turn.status).toBe('error');
+  });
+
+  test('running a thread with no entry does nothing at all', async () => {
+    await streams.run('t-nope', 'Ask.', 'fake/fake');
+    expect(streams.streamOf('t-nope')).toBeNull();
+  });
+});

--- a/runtime/ui/src/v2/chat/streams.test.ts
+++ b/runtime/ui/src/v2/chat/streams.test.ts
@@ -172,6 +172,22 @@ describe('the edges the UI guards but the module must not assume', () => {
     expect(streams.streamOf('t-1')?.pending).toBe('Second.');
   });
 
+  test('a replaced run cannot stamp its ending on the entry that replaced it', async () => {
+    // `patch` writes by key. A run whose entry was replaced — a second send
+    // on one thread — would otherwise mark the LIVE stream `stopped`, which
+    // in the app unlocks the composer and drops an answer still arriving.
+    streams.open('t-1', 'First.');
+    const first = streams.run('t-1', 'First.', 'fake/fake');
+    streams.open('t-1', 'Second.');
+    const second = streams.run('t-1', 'Second.', 'fake/fake');
+    await first; // the first controller was aborted by the second `open`
+    expect(streams.streamOf('t-1')?.status).toBe('running');
+    expect(streams.running()).toEqual(['t-1']);
+    open();
+    await second;
+    expect(streams.streamOf('t-1')?.status).toBe('done');
+  });
+
   test('cancel stops the step as well as dropping it', async () => {
     streams.open('t-1', 'Ask.');
     const run = streams.run('t-1', 'Ask.', 'fake/fake');

--- a/runtime/ui/src/v2/chat/streams.ts
+++ b/runtime/ui/src/v2/chat/streams.ts
@@ -162,14 +162,20 @@ export async function run(threadId: string, message: string, provider: string): 
   const entry = entries.get(threadId);
   if (entry === undefined) return;
   const { controller, started } = entry;
+  /**
+   * Still ours? `patch` writes by KEY, so a run whose entry has since been
+   * replaced — a second send on the same thread — would stamp its own
+   * ending onto the new entry, marking a live stream `stopped` and dropping
+   * an answer still arriving.
+   */
+  const mine = (): boolean => entries.get(threadId)?.controller === controller;
 
   try {
     await streamStep(
       threadId,
       { message, provider },
       (event: StreamEvent) => {
-        const live = entries.get(threadId);
-        if (live === undefined) return;
+        if (!mine()) return;
         if (event.type === 'tool_call') started.set(event.id, performance.now());
         if (event.type === 'tool_result') {
           const t0 = started.get(event.id);
@@ -181,8 +187,9 @@ export async function run(threadId: string, message: string, provider: string): 
       },
       controller.signal,
     );
-    patch(threadId, { status: 'done' });
+    if (mine()) patch(threadId, { status: 'done' });
   } catch (err) {
+    if (!mine()) return;
     if (controller.signal.aborted) {
       patch(threadId, { status: 'stopped' });
       return;

--- a/runtime/ui/src/v2/chat/streams.ts
+++ b/runtime/ui/src/v2/chat/streams.ts
@@ -64,8 +64,8 @@ export function subscribe(fn: () => void): () => void {
   return () => listeners.delete(fn);
 }
 
-export function streamOf(threadId: string | null): Stream | null {
-  return threadId === null ? (entries.get(DRAFT) ?? null) : (entries.get(threadId) ?? null);
+export function streamOf(key: string): Stream | null {
+  return entries.get(key) ?? null;
 }
 
 /** The threads with a step in flight — the rail's running marks. */
@@ -74,14 +74,23 @@ export function running(): readonly string[] {
 }
 
 /**
- * Where a send lands before its thread exists. `POST /threads` and the step
- * are one act to the reader, and the composer has to lock for both, so the
- * entry is opened under this key and moved once the id comes back.
+ * A key for a pane that has no thread yet. `POST /threads` and the step are
+ * one act to the reader and the composer locks for both, so the entry opens
+ * under this key and is renamed once the id comes back.
+ *
+ * Per PANE, not one global slot: Home's ask box remounts the chat on a
+ * fresh draft, so two drafts can be alive at once, and a shared key would
+ * make the second one read the first one's stream — and swallow its send.
  */
-export const DRAFT = '@draft';
+export function draftKey(): string {
+  return `@draft-${Math.random().toString(36).slice(2)}`;
+}
 
-export function open(threadId: string | null, message: string): void {
-  const key = threadId ?? DRAFT;
+export function open(key: string, message: string): void {
+  // A second open on a live key would orphan the first controller — the
+  // first stream could never be stopped, and its events would land on the
+  // new entry's turn. The UI locks the composer, so this is a backstop.
+  entries.get(key)?.controller.abort();
   entries.set(key, {
     threadId: key,
     pending: message,
@@ -97,26 +106,34 @@ export function open(threadId: string | null, message: string): void {
 }
 
 /** The draft's entry becomes the new thread's. */
-export function rename(threadId: string): void {
-  const draft = entries.get(DRAFT);
-  if (draft === undefined) return;
-  entries.delete(DRAFT);
+export function rename(key: string, threadId: string): void {
+  const draft = entries.get(key);
+  if (draft === undefined || key === threadId) return;
+  entries.delete(key);
   entries.set(threadId, { ...draft, threadId });
   announce();
 }
 
-export function signalOf(threadId: string | null): AbortSignal | undefined {
-  return entries.get(threadId ?? DRAFT)?.controller.signal;
+export function signalOf(key: string): AbortSignal | undefined {
+  return entries.get(key)?.controller.signal;
 }
 
-export function stop(threadId: string | null): void {
-  entries.get(threadId ?? DRAFT)?.controller.abort();
+export function stop(key: string): void {
+  entries.get(key)?.controller.abort();
 }
 
 /** Drop the entry — the pane has reloaded the thread and the server's
- * transcript is now the record. */
-export function forget(threadId: string | null): void {
-  if (entries.delete(threadId ?? DRAFT)) announce();
+ * transcript is now the record. Does NOT abort: by here the step is over. */
+export function forget(key: string): void {
+  if (entries.delete(key)) announce();
+}
+
+/** Stop the step AND drop it: the conversation is gone. Without this a
+ * deleted thread's step runs to completion against a thread that no longer
+ * exists — real money on a cloud provider, with no screen left to stop it. */
+export function cancel(key: string): void {
+  entries.get(key)?.controller.abort();
+  forget(key);
 }
 
 function patch(key: string, change: Partial<Entry>): void {

--- a/runtime/ui/src/v2/chat/streams.ts
+++ b/runtime/ui/src/v2/chat/streams.ts
@@ -1,0 +1,196 @@
+/**
+ * Running steps, keyed by thread — and owned by nobody's component.
+ *
+ * The chat pane is re-keyed when you switch conversations, so anything it
+ * held was thrown away: the old thread's stream was aborted and the run
+ * recorded `abandoned`. That is a real loss — a review that took ninety
+ * seconds, discarded because you looked at something else while it worked.
+ *
+ * A step lives here instead. It starts when the composer sends, keeps
+ * writing whether or not anyone is looking, and finishes into an entry the
+ * pane picks up when it comes back. The runtime already allows this: its
+ * step lock is per thread, so two conversations run at once and only two
+ * steps in ONE conversation queue.
+ *
+ * The entry is deliberately short-lived. It holds the answer as it arrives;
+ * once the pane reloads that thread from the server, the transcript is the
+ * record and the entry is dropped.
+ */
+import { ApiError, streamStep } from '../../api/client';
+import type { StreamEvent } from '../../api/types';
+import { applyStepEvent, emptyAssistantTurn, type AssistantTurn } from '../../chat/turns';
+
+export interface Stream {
+  threadId: string;
+  /** The user's message this step is answering, shown above the answer. */
+  pending: string;
+  /** The answer as it stands. */
+  turn: AssistantTurn;
+  /** Milliseconds per tool id, measured call → result. */
+  ms: Record<string, number>;
+  status: 'running' | 'done' | 'stopped' | 'error';
+  /** Set when the step failed; the pane shows it and offers what it can. */
+  error: string | null;
+  /** The runtime refused the step for the matter's privacy policy: there is
+   * nothing to retry into, so the sentence is the whole answer. */
+  refused: boolean;
+}
+
+interface Entry extends Stream {
+  controller: AbortController;
+  started: Map<string, number>;
+}
+
+const entries = new Map<string, Entry>();
+const listeners = new Set<() => void>();
+
+/**
+ * The running set, as ONE array that only changes identity when the set
+ * does. `useSyncExternalStore` compares snapshots with `Object.is`, so a
+ * getter that builds a fresh array on every render is an infinite loop.
+ */
+let runningIds: string[] = [];
+
+function announce(): void {
+  const next = [...entries.values()].filter(e => e.status === 'running').map(e => e.threadId);
+  if (next.length !== runningIds.length || next.some((id, i) => id !== runningIds[i])) runningIds = next;
+  for (const fn of [...listeners]) fn();
+}
+
+/** Every subscriber hears about every change: there are a handful of them,
+ * and a per-thread channel would still have to tell the rail. */
+export function subscribe(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+export function streamOf(threadId: string | null): Stream | null {
+  return threadId === null ? (entries.get(DRAFT) ?? null) : (entries.get(threadId) ?? null);
+}
+
+/** The threads with a step in flight — the rail's running marks. */
+export function running(): readonly string[] {
+  return runningIds;
+}
+
+/**
+ * Where a send lands before its thread exists. `POST /threads` and the step
+ * are one act to the reader, and the composer has to lock for both, so the
+ * entry is opened under this key and moved once the id comes back.
+ */
+export const DRAFT = '@draft';
+
+export function open(threadId: string | null, message: string): void {
+  const key = threadId ?? DRAFT;
+  entries.set(key, {
+    threadId: key,
+    pending: message,
+    turn: emptyAssistantTurn(),
+    ms: {},
+    status: 'running',
+    error: null,
+    refused: false,
+    controller: new AbortController(),
+    started: new Map(),
+  });
+  announce();
+}
+
+/** The draft's entry becomes the new thread's. */
+export function rename(threadId: string): void {
+  const draft = entries.get(DRAFT);
+  if (draft === undefined) return;
+  entries.delete(DRAFT);
+  entries.set(threadId, { ...draft, threadId });
+  announce();
+}
+
+export function signalOf(threadId: string | null): AbortSignal | undefined {
+  return entries.get(threadId ?? DRAFT)?.controller.signal;
+}
+
+export function stop(threadId: string | null): void {
+  entries.get(threadId ?? DRAFT)?.controller.abort();
+}
+
+/** Drop the entry — the pane has reloaded the thread and the server's
+ * transcript is now the record. */
+export function forget(threadId: string | null): void {
+  if (entries.delete(threadId ?? DRAFT)) announce();
+}
+
+function patch(key: string, change: Partial<Entry>): void {
+  const entry = entries.get(key);
+  if (entry === undefined) return;
+  entries.set(key, { ...entry, ...change });
+  announce();
+}
+
+/** The sentence a failure reads as. */
+export function detailOf(err: unknown): string {
+  if (err instanceof ApiError) return err.message;
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Runs the step, writing into the entry as it goes. Resolves when the step
+ * is over, however it ended — the caller reloads the thread if it is still
+ * on screen, and the entry carries the ending for a caller that is not.
+ *
+ * `open` must have been called first: the composer locks on the entry
+ * existing, and arming that only after `POST /threads` returned would leave
+ * the box live for a second send that opens a second thread.
+ */
+export async function run(threadId: string, message: string, provider: string): Promise<void> {
+  const entry = entries.get(threadId);
+  if (entry === undefined) return;
+  const { controller, started } = entry;
+
+  try {
+    await streamStep(
+      threadId,
+      { message, provider },
+      (event: StreamEvent) => {
+        const live = entries.get(threadId);
+        if (live === undefined) return;
+        if (event.type === 'tool_call') started.set(event.id, performance.now());
+        if (event.type === 'tool_result') {
+          const t0 = started.get(event.id);
+          if (t0 !== undefined) patch(threadId, { ms: { ...entries.get(threadId)!.ms, [event.id]: Math.round(performance.now() - t0) } });
+        }
+        const base = entries.get(threadId)!.turn;
+        const tagged = base.runId === undefined && event.runId !== undefined ? { ...base, runId: event.runId } : base;
+        patch(threadId, { turn: applyStepEvent(tagged, event) });
+      },
+      controller.signal,
+    );
+    patch(threadId, { status: 'done' });
+  } catch (err) {
+    if (controller.signal.aborted) {
+      patch(threadId, { status: 'stopped' });
+      return;
+    }
+    // The runtime refused the step for the matter's privacy policy (409
+    // matter-stays-local): nothing ran and there is nothing to retry into,
+    // so the sentence is the whole answer.
+    const body = err instanceof ApiError && err.status === 409 ? (err.body as { error?: string; message?: string } | null) : null;
+    if (body?.error === 'matter-stays-local') {
+      patch(threadId, { status: 'error', refused: true, error: body.message ?? 'This matter stays on this machine.' });
+      return;
+    }
+    const message = detailOf(err);
+    patch(threadId, {
+      status: 'error',
+      error: message,
+      turn: applyStepEvent(entries.get(threadId)?.turn ?? emptyAssistantTurn(), { type: 'error', message }),
+    });
+  }
+}
+
+/** Tests only: no entry survives one. */
+export function reset(): void {
+  for (const entry of entries.values()) entry.controller.abort();
+  entries.clear();
+  listeners.clear();
+  runningIds = [];
+}


### PR DESCRIPTION
Switching conversations aborted the step. The pane owned it, the shell re-keys the pane on every switch, and unmounting aborted the stream — the answer thrown away and the run recorded `abandoned`. Two of the seven runs in the vault's own ledger are exactly that.

**The step lives in a registry keyed by thread** (`v2/chat/streams.ts`), not in the component showing it. It starts when the composer sends, keeps writing whether or not anyone is looking, and finishes into an entry the pane picks up when it comes back. The entry is dropped once the thread is reloaded, because the server's transcript is then the record.

**Several conversations can work at once**, and the rail marks each one that still is. The runtime always allowed this: its step lock is `tenant/threadId`, so only two steps in the *same* conversation queue. The limit was the screen.

Everything the old code fought for still holds: the entry is opened before `POST /threads` is awaited, so a second ⌘⏎ cannot open a second thread; a draft's entry is renamed onto the new id; Stop, the `matter-stays-local` refusal, the failed-refetch freeze and Retry all work against the registry now.

**Two things worth flagging.** `cleanup()` in the test DOM resets the registry — a step outliving its component is the point, and module state outliving a test *file* would make one file's stream the next file's mystery. And the fake provider gained `delayMs`, so a step can be observed in flight at all.

**Checks.** 7 registry tests, a Shell test that sends, walks away, watches the rail mark, and comes back to the answer. Suites green (1280 runtime, 572 UI), both typechecks clean. Verified live on a throwaway vault: one rail dot for the conversation left running, Stop on the one on screen, and no abandoned runs afterwards.