### PR TITLE
Fix the half-screen hole under "Add a provider"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+- Settings › Providers: the empty half-screen between "Add a provider" and the picker is gone. The guided-start rows lay a paragraph beside a button, and the paragraph's 24rem was being read as a HEIGHT in the one row that stacks — a 384px hole in the middle of the page.
+
 Conversations that keep working (web-ui spec §3.1)
 
 - A conversation no longer stops because you looked at something else. Switching to another conversation while counsel is still working used to abort the step — the answer thrown away and the run recorded `abandoned`, which is what two of the runs in this vault's own ledger are. The step now runs to the end whether or not you are watching, and its answer is there when you come back.

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1049,7 +1049,12 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-provider-data a { color: inherit; text-decoration: underline; text-decoration-color: var(--border-strong); }
 .providers-table .providers-data { color: var(--fg-muted); white-space: nowrap; }
 .v2-setup-more { margin: 10px 0 0; font-size: 12.5px; color: var(--fg-muted); }
+/* The guided-start rows are a ROW: the paragraph takes 24rem of width
+   beside the button (`.v2-guided-start p`). This one is a column, where
+   that same `flex-basis` is a HEIGHT — which left a 384px hole between the
+   sentence and the picker. */
 .v2-add-provider { flex-direction: column; align-items: stretch; }
+.v2-add-provider > p { flex: 0 0 auto; }
 .v2-add-provider-row { display: flex; gap: 10px; align-items: flex-end; }
 .v2-add-provider-row .v2-combo { flex: 1 1 24rem; }
 .v2-add-provider-note { margin: 6px 0 0; font-size: 12.5px; }


### PR DESCRIPTION
Settings › Providers had an empty half-screen between the "Add a provider" sentence and the picker.

`.v2-guided-start p` is `flex: 1 1 24rem` — the paragraph takes 24rem of *width* beside its button, which is right for the two guided-start rows that lay out in a line. `.v2-add-provider` overrides the direction to `column`, and in a column that same `flex-basis` is a *height*: the paragraph was 384px tall and the picker sat at the bottom of the hole.

Measured, not eyeballed: the block was 438px with a 384px paragraph, and is 96px with a 42px one, with the picker 12px under the text.

No test — happy-dom does not lay out, so this class of bug is only visible in a browser. Verified in the running app against the real vault.