### PR TITLE
A provider you add can actually be set up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Adding a provider actually works now
 - **The key moved onto the provider block**, above the model. It is the first thing a hosted provider needs and the reason its model list can answer, so it sits where the provider is rather than folded inside a row.
 - A key can be pasted before anything is saved. It used to say "save the row, then paste the key here" — advice that could not be followed.
 - Pasting a key re-asks that provider for its models, instead of leaving you to find the `refresh` link.
+- **A key set up on a new provider is still there after you save it.** The catalog prefills every row with the vendor's own address, and that was being read as "this row points somewhere else" — so the key was filed one way while the provider was being set up and looked for another way the moment it saved. It was accepted and then unreadable, and the same key had to be pasted twice. Nine vendors were affected, Moonshot and Cloudflare and Hugging Face among them.
+- The page can now see a key it stored for a provider that has no model yet, so it says so and offers to remove it, rather than reading "not set" and inviting a second paste.
+- Adding a provider you already have says so, instead of making a second row that could not be filled in.
+- Azure, Bedrock and Vertex get their block too, with their region or project on it — those fields are what tell the listing where to ask.
 
 Providers, and the model each one runs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+Adding a provider actually works now
+
+- A provider you add gets its **block straight away**, with its key and its model picker on it. Before this it appeared only as a stub down in "Rows you added", and the two things it needed were impossible to do in either order: the row would not save without a model, and the vendor would not list its models without a key.
+- **The key moved onto the provider block**, above the model. It is the first thing a hosted provider needs and the reason its model list can answer, so it sits where the provider is rather than folded inside a row.
+- A key can be pasted before anything is saved. It used to say "save the row, then paste the key here" — advice that could not be followed.
+- Pasting a key re-asks that provider for its models, instead of leaving you to find the `refresh` link.
+
 Providers, and the model each one runs
 
 - Settings now shows one block per **provider** — Claude, ChatGPT, Ollama, anything you add — with the model as a picker on that block. You choose a provider, then you choose a model. The list comes from the provider itself, so it is what they offer today rather than a list we hard-coded.

--- a/runtime/src/providers/secrets.test.ts
+++ b/runtime/src/providers/secrets.test.ts
@@ -283,6 +283,22 @@ describe('secret fields — several secrets as ONE store item (providers spec §
     }
   });
 
+  test('a key pasted for one host is never handed to another', () => {
+    // A row pointed at a private gateway, credentialled, then pointed back
+    // at the vendor. The legacy full-id fallback would have handed the
+    // gateway's token to Moonshot.
+    const store = memoryStore();
+    const proxy = { baseURL: 'https://proxy.example/v1' };
+    store.set(keyIdFor('moonshot/kimi-k2', proxy), 'PROXY-TOKEN');
+    expect(readKey(store, 'moonshot/kimi-k2', proxy)).toBe('PROXY-TOKEN');
+    const preset = { baseURL: vendorFor('moonshot')!.defaultBaseURL! };
+    expect(readKey(store, 'moonshot/kimi-k2', preset)).toBeNull();
+    // A row that names no address of its own still migrates: that item
+    // cannot have been written for some other host.
+    const legacy = memoryStore({ 'openai/gpt-5.6': 'sk-old' });
+    expect(readKey(legacy, 'openai/gpt-5.6')).toBe('sk-old');
+  });
+
   test('two OpenAI-compatible rows on different hosts never share a key', () => {
     // The failure this guards: paste the firm's key on one row, a vendor's
     // key on the other, and a shared item would send the firm's key to the

--- a/runtime/src/providers/secrets.test.ts
+++ b/runtime/src/providers/secrets.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { allVendors, vendorFor } from './vendors';
 import {
   decodeSecretFields,
   defaultRunner,
@@ -242,10 +243,44 @@ describe('secret fields — several secrets as ONE store item (providers spec §
     expect(keyIdFor('bedrock/m')).toBe('bedrock/m');
     expect(keyIdFor('azure/deployment')).toBe('azure/deployment');
     expect(keyIdFor('vertex/gemini-3-pro')).toBe('vertex/gemini-3-pro');
-    // And any row that overrides the endpoint at all: a region, a proxy, a
-    // private gateway. DashScope's own note says its keys are per region.
+    // A row pointing somewhere ELSE: a region, a proxy, a private gateway.
+    // DashScope's own note says its keys are per region.
     expect(keyIdFor('dashscope/qwen-max', { baseURL: 'https://dashscope.aliyuncs.com/compatible-mode/v1' })).toBe('dashscope/qwen-max');
     expect(keyIdFor('openai/gpt-5.6', { baseURL: '' })).toBe('openai');
+  });
+
+  test('the preset URL the catalog prefills is not an override — a key set up on a row is still there after it saves', () => {
+    // `catalogRow` prefills every preset row with the vendor's OWN address.
+    // Counting that as "the row moved the endpoint" filed the key under the
+    // bare prefix while the row was pending and under the full id the moment
+    // it saved: pasted, accepted, then unreadable, and the same key had to
+    // be pasted again.
+    const preset = vendorFor('moonshot')!.defaultBaseURL!;
+    expect(preset).not.toBe('');
+    expect(keyIdFor('moonshot/', {})).toBe('moonshot');
+    expect(keyIdFor('moonshot/kimi-k2', { baseURL: preset })).toBe('moonshot');
+    // Trailing slashes are the same address.
+    expect(keyIdFor('moonshot/kimi-k2', { baseURL: `${preset}/` })).toBe('moonshot');
+    // Somewhere else really is somewhere else.
+    expect(keyIdFor('moonshot/kimi-k2', { baseURL: 'https://proxy.example/v1' })).toBe('moonshot/kimi-k2');
+
+    // The round trip a lawyer actually makes: paste on the pending row,
+    // then save the row.
+    const store = memoryStore();
+    store.set(keyIdFor('moonshot/', {}), 'sk-moonshot');
+    expect(readKey(store, 'moonshot/kimi-k2', { baseURL: preset })).toBe('sk-moonshot');
+  });
+
+  test('every preset the catalog prefills survives that round trip', () => {
+    // One test rather than nine: any preset vendor whose row is created with
+    // its own base URL must read its key back after the save.
+    const store = memoryStore();
+    for (const vendor of allVendors()) {
+      if (vendor.defaultBaseURL === undefined || vendor.auth !== 'apikey') continue;
+      if (vendor.fields !== undefined || vendor.baseURLFields !== undefined || vendor.locality === 'by-baseURL') continue;
+      store.set(keyIdFor(`${vendor.prefix}/`, {}), `sk-${vendor.prefix}`);
+      expect(readKey(store, `${vendor.prefix}/a-model`, { baseURL: vendor.defaultBaseURL })).toBe(`sk-${vendor.prefix}`);
+    }
   });
 
   test('two OpenAI-compatible rows on different hosts never share a key', () => {

--- a/runtime/src/providers/secrets.ts
+++ b/runtime/src/providers/secrets.ts
@@ -280,8 +280,13 @@ export function keyStateFor(id: string, keyEnv: string | undefined, store: Secre
  * - `cloudflare` puts `{account_id}` in its base URL; the token is per
  *   account. `azure`, `bedrock` and `vertex` carry a resource, an AWS
  *   account and a GCP project on the row.
- * - Any row that overrides `baseURL` at all: a region (DashScope's keys are
- *   per region), a proxy, a private endpoint.
+ * - Any row that points somewhere OTHER than the vendor's own address: a
+ *   region (DashScope's keys are per region), a proxy, a private endpoint.
+ *   Carrying the vendor's own preset URL is not pointing elsewhere — the
+ *   catalog prefills it on every row it creates, and treating that as an
+ *   override filed the key under the bare prefix while the row was still
+ *   being set up and under the full id the moment it saved. The key was
+ *   stranded: pasted, accepted, and then unreadable.
  *
  * Getting this wrong sends one tenant's credential to another tenant's
  * host, so the default is the narrow one: share a key only where the
@@ -291,11 +296,15 @@ export function keyIdFor(id: string, entry: { baseURL?: string } = {}): string {
   const vendor = vendorFor(prefixOf(id));
   if (vendor === undefined) return id;
   const rowDecidesWhere =
-    vendor.fields !== undefined ||
-    vendor.baseURLFields !== undefined ||
-    vendor.locality === 'by-baseURL' ||
-    (entry.baseURL !== undefined && entry.baseURL.trim() !== '');
+    vendor.fields !== undefined || vendor.baseURLFields !== undefined || vendor.locality === 'by-baseURL' || movedElsewhere(vendor, entry.baseURL);
   return rowDecidesWhere ? id : prefixOf(id);
+}
+
+/** Whether a row's base URL points somewhere other than the vendor's own. */
+function movedElsewhere(vendor: { defaultBaseURL?: string }, baseURL: string | undefined): boolean {
+  const given = (baseURL ?? '').trim().replace(/\/+$/, '');
+  if (given === '') return false;
+  return given !== (vendor.defaultBaseURL ?? '').trim().replace(/\/+$/, '');
 }
 
 /**

--- a/runtime/src/providers/secrets.ts
+++ b/runtime/src/providers/secrets.ts
@@ -318,7 +318,13 @@ export function readKey(store: SecretStore | undefined, id: string, entry: { bas
   try {
     const own = store.get(filed);
     if (own !== null) return own;
-    return filed === id ? null : store.get(id);
+    // The legacy item an older install wrote under the full id — but ONLY
+    // for a row that names no address of its own. A row that does may have
+    // been pointed at a private gateway when that key was pasted, and
+    // pointed back at the vendor since; handing the gateway's credential to
+    // the vendor is not a migration, it is a leak.
+    if (filed === id || (entry.baseURL ?? '').trim() !== '') return null;
+    return store.get(id);
   } catch {
     return null;
   }

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -36,7 +36,7 @@ import {
   testProvider,
   TestBody,
   type RuntimeState,
-  type SettingsDeps, providerView, keyContext, putProviderKey, deleteProviderKey, KeyBody } from './settings';
+  type SettingsDeps, providerView, keyContext, putProviderKey, deleteProviderKey, providerKeyState, KeyBody } from './settings';
 import { sseFromEvents, type StreamEvent } from './sse';
 import { confirmationMessage, estimateCost, needsConfirmation, type Pricing } from '../evals/cost';
 import { defaultBenchmarksDir, FIXTURE_SETS, loadFixtures, sourceKindOf } from '../evals/fixture';
@@ -1631,6 +1631,7 @@ export function createApp(deps: ServerDeps): App {
 
       if (segments.length >= 3 && first === 'providers' && segments[segments.length - 1] === 'key') {
         const id = segments.slice(1, -1).map(s => decodeURIComponent(s)).join('/');
+        if (method === 'GET') return providerKeyState(deps, id);
         if (method === 'PUT') return await putKey(req, id);
         if (method === 'DELETE') return await deleteKey(id);
       }

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -613,7 +613,14 @@ export function createApp(deps: ServerDeps): App {
     // URL that does not match the saved row's goes out unauthenticated: it
     // is a row being typed, which has no key yet anyway.
     const keyEnv = entry?.apiKeyEnv ?? vendor.keyEnv;
-    const madeUp = queryBase !== null && queryBase.trim() !== '' && queryBase.trim() !== (entry?.baseURL ?? '').trim();
+    // The vendor's OWN address is not made up. A provider still being set
+    // up has no registry row, and its row carries the preset the catalog
+    // prefilled — comparing against the row alone suppressed the key for
+    // every preset vendor, which is exactly the case a key was just pasted
+    // to unblock.
+    const known = [entry?.baseURL, vendor.defaultBaseURL].map(u => (u ?? '').trim().replace(/\/+$/, '')).filter(u => u !== '');
+    const asked = (queryBase ?? '').trim().replace(/\/+$/, '');
+    const madeUp = asked !== '' && !known.includes(asked);
     const stored = madeUp ? null : readKey(deps.settings.secrets, entry?.id ?? id, entry ?? {});
     const apiKey = stored ?? (madeUp ? undefined : keyEnv === undefined ? undefined : env[keyEnv]);
     const cacheKey = discoveryCache.key(prefix, baseURL);

--- a/runtime/src/server/settings.test.ts
+++ b/runtime/src/server/settings.test.ts
@@ -429,6 +429,29 @@ describe('provider keys (providers spec §5)', () => {
     expect((await call(h.app, 'GET', '/providers/ollama/gemma4:e4b/key')).status).toBe(404);
   });
 
+  test('a row-filed key: set up after the row, and removed completely', async () => {
+    // `openai-compatible` shares its prefix with every unknown host, so its
+    // key is filed against the ROW. It can only be pasted once the row
+    // exists — otherwise it lands under the bare prefix and is looked for
+    // under the row, which stranded it where no delete could reach.
+    const h = harness({ contents: GOOGLE });
+    const id = 'openai-compatible/local-llm';
+    expect((await call(h.app, 'PUT', '/settings', { providers: [{ id, baseURL: 'https://llm.firm.internal/v1' }] })).status).toBe(200);
+    expect((await call(h.app, 'PUT', `/providers/${id}/key`, { value: 'sk-firm' })).status).toBe(204);
+    // Filed against the row, and the runtime reads it back there.
+    expect(h.secrets?.get(id)).toBe('sk-firm');
+    expect(h.secrets?.get('openai-compatible')).toBeNull();
+    const view = await settings(h.app);
+    expect((view.effective.providers.find(p => p.id === id) as { keySet?: unknown }).keySet).toBe(true);
+
+    // Remove takes every copy, including a vendor-level orphan an earlier
+    // version could leave behind.
+    h.secrets?.set('openai-compatible', 'sk-orphan');
+    expect((await call(h.app, 'DELETE', `/providers/${id}/key`)).status).toBe(204);
+    expect(h.secrets?.get(id)).toBeNull();
+    expect(h.secrets?.get('openai-compatible')).toBeNull();
+  });
+
   test('a runtime with no store answers 503 and reports secrets: null', async () => {
     const h = harness({ contents: GOOGLE, secrets: null });
     expect((await call(h.app, 'PUT', '/providers/google/gemini-2.5-pro/key', { value: 'k' })).status).toBe(503);

--- a/runtime/src/server/settings.test.ts
+++ b/runtime/src/server/settings.test.ts
@@ -405,6 +405,30 @@ describe('provider keys (providers spec §5)', () => {
     expect(h.secrets?.get('openrouter')).toBe('or-key');
   });
 
+  test('GET asks whether a provider has a key, for one that is not loaded yet', async () => {
+    // `/settings` speaks only for LOADED providers, and one being set up has
+    // no model, so nothing there speaks for it. Without this the page could
+    // not see a key it had just stored: it read "not set", offered no way to
+    // remove it, and invited the same key to be pasted again.
+    const h = harness({ contents: GOOGLE });
+    const state = async (id: string): Promise<unknown> => (await (await call(h.app, 'GET', `/providers/${id}/key`)).json());
+    expect(await state('google')).toEqual({ keySet: false });
+
+    expect((await call(h.app, 'PUT', '/providers/google/key', { value: 'AIza-1' })).status).toBe(204);
+    expect(await state('google')).toEqual({ keySet: true });
+    // The same answer for a model of that vendor, since the key is filed
+    // under the vendor.
+    expect(await state('google/gemini-2.5-pro')).toEqual({ keySet: true });
+    // Never the value itself.
+    expect(JSON.stringify(await state('google'))).not.toContain('AIza-1');
+
+    expect((await call(h.app, 'DELETE', '/providers/google/key')).status).toBe(204);
+    expect(await state('google')).toEqual({ keySet: false });
+
+    // A provider that takes no key has no key state to report.
+    expect((await call(h.app, 'GET', '/providers/ollama/gemma4:e4b/key')).status).toBe(404);
+  });
+
   test('a runtime with no store answers 503 and reports secrets: null', async () => {
     const h = harness({ contents: GOOGLE, secrets: null });
     expect((await call(h.app, 'PUT', '/providers/google/gemini-2.5-pro/key', { value: 'k' })).status).toBe(503);

--- a/runtime/src/server/settings.ts
+++ b/runtime/src/server/settings.ts
@@ -155,6 +155,25 @@ function redactAll(text: string, values: string[]): string {
   return values.reduce((t, v) => redact(t, v), text);
 }
 
+/**
+ * `GET /providers/:id/key` — whether there IS one. Never the value.
+ *
+ * `/settings` speaks only for LOADED providers, and a provider being set up
+ * has no model yet, so nothing is loaded for it. Without this, a key pasted
+ * on a new provider was stored and then invisible: the page went on saying
+ * "not set", offered no way to remove it, and invited the same key to be
+ * pasted a second time.
+ */
+export function providerKeyState(ctx: SettingsContext, id: string): Response {
+  if (!takesKey(id)) return Response.json({ error: `${id} does not take an API key` }, { status: 404 });
+  const vendor = vendorFor(prefixOf(id));
+  const keys = keyContext(ctx);
+  const keySet = isEnterprise(vendor)
+    ? enterpriseKeyState(id, keys)
+    : keyStateFor(id, keyEnvFor(id, keys.registry), keys.store, keys.env, rowOf(id, keys.registry));
+  return Response.json({ keySet });
+}
+
 /** `DELETE /providers/:id/key` — idempotent; the registry reloads so the
  * provider falls back to the environment or to no key. */
 export function deleteProviderKey(ctx: SettingsContext, id: string): Response {

--- a/runtime/src/server/settings.ts
+++ b/runtime/src/server/settings.ts
@@ -140,8 +140,7 @@ export function putProviderKey(ctx: SettingsContext, id: string, input: KeyBodyD
   return new Response(null, { status: 204 });
 }
 
-/** Every OTHER row of this vendor whose key `readKey` would fall back to.
- * Only for a vendor-filed key: a row-filed one is nobody else's. */
+/** Every OTHER row of this vendor whose key `readKey` could fall back to. */
 function siblingIds(ctx: SettingsContext, id: string): string[] {
   try {
     const rows = readRegistry(ctx.settings.file).providers ?? [];
@@ -186,10 +185,12 @@ export function deleteProviderKey(ctx: SettingsContext, id: string): Response {
     // OTHER row that shares the vendor's key — `readKey` falls back to
     // those, so leaving one behind would hand the key straight back on the
     // next call, with the page still saying the key was removed.
-    const filed = keyIdFor(id, entryFor(ctx, id));
-    store.delete(filed);
-    store.delete(id);
-    if (filed !== id) for (const sibling of siblingIds(ctx, id)) store.delete(sibling);
+    // Every place this provider's key could be: what it is filed under, the
+    // vendor item, this row's own legacy item, and every sibling row's
+    // legacy item that `readKey` could fall back to. A row-filed key used to
+    // leave the vendor item behind, where no later delete could reach it —
+    // the sweep only ran when the two differed the other way round.
+    for (const gone of new Set([keyIdFor(id, entryFor(ctx, id)), prefixOf(id), id, ...siblingIds(ctx, id)])) store.delete(gone);
   } catch (err) {
     return Response.json({ error: message(err) }, { status: 500 });
   }

--- a/runtime/ui/src/api/client.ts
+++ b/runtime/ui/src/api/client.ts
@@ -6,6 +6,7 @@
  * call carries the bearer token; a 401 is reported once, centrally, so the
  * app can show the spec §5 message instead of each caller inventing its own.
  */
+import type { KeyState } from './types';
 import { parseSseChunk } from './sse';
 import { clearToken, readToken } from './token';
 import { reportUnauthorized } from './unauthorized';
@@ -66,7 +67,7 @@ export async function signOut(): Promise<void> {
 /** `PUT /providers/<id>/key` (providers spec §5): the one request that
  * carries a key. Slashes in the id are path segments. 204 on success. */
 export async function setProviderKey(id: string, value: string): Promise<void> {
-  await fetchJson<void>(`/providers/${id.split('/').map(encodeURIComponent).join('/')}/key`, {
+  await fetchJson<void>(`${keyPath(id)}`, {
     method: 'PUT',
     body: JSON.stringify({ value }),
   });
@@ -110,7 +111,26 @@ export async function setVaultOutcomes(outcomes: boolean): Promise<boolean> {
 }
 
 export async function deleteProviderKey(id: string): Promise<void> {
-  await fetchJson<void>(`/providers/${id.split('/').map(encodeURIComponent).join('/')}/key`, { method: 'DELETE' });
+  await fetchJson<void>(keyPath(id), { method: 'DELETE' });
+}
+
+/** Whether a provider has a key, without loading it. Used while a provider
+ * is being set up: `/settings` speaks only for loaded ones. */
+export async function getProviderKeyState(id: string): Promise<KeyState> {
+  return (await fetchJson<{ keySet: KeyState }>(keyPath(id))).keySet;
+}
+
+/**
+ * `/providers/<id>/key`. Empty segments are DROPPED: a provider being set
+ * up is `openai/`, which would otherwise build `/providers/openai//key` —
+ * the server tolerates it, and any proxy or router in front of it need not.
+ */
+function keyPath(id: string): string {
+  const segments = id
+    .split('/')
+    .filter(s => s !== '')
+    .map(encodeURIComponent);
+  return `/providers/${segments.join('/')}/key`;
 }
 
 /** Best-effort body parse. A failure here must not mask the status code —

--- a/runtime/ui/src/v2/settings/EnterpriseFields.test.tsx
+++ b/runtime/ui/src/v2/settings/EnterpriseFields.test.tsx
@@ -118,9 +118,14 @@ describe('EnterpriseFields (providers spec §3 step 5)', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('go together'));
   });
 
-  test('an unsaved row and a runtime with no store each say what to do instead', () => {
-    render(<EnterpriseFields id="azure/dep" rowKey="r5" vendorName="Azure OpenAI" fields={[{ name: 'resourceName', label: 'Resource name', secret: false, required: true }, { name: 'apiKey', label: 'API key', secret: true, required: true }]} extra={{}} onExtraChange={() => {}} keySet={undefined} where="keychain" onChanged={() => {}} />);
-    expect(screen.getByText(/save the row, then paste the credentials here/)).toBeTruthy();
+  test('a provider not set up yet can still take its credentials — that is the order the work happens in', () => {
+    // It used to say "save the row, then paste the credentials here", which
+    // could not be done: the row will not save without a model, and the
+    // vendor will not list its models without credentials to sign the
+    // request with.
+    render(<EnterpriseFields id="azure/" rowKey="r5" vendorName="Azure OpenAI" fields={[{ name: 'resourceName', label: 'Resource name', secret: false, required: true }, { name: 'apiKey', label: 'API key', secret: true, required: true }]} extra={{}} onExtraChange={() => {}} keySet={undefined} where="keychain" onChanged={() => {}} />);
+    expect(screen.getByRole('button', { name: 'paste credentials' })).toBeTruthy();
+    expect(screen.getByText('not set')).toBeTruthy();
     expect(screen.getByLabelText('Resource name')).toBeTruthy();
     cleanup();
     render(<EnterpriseFields id="azure/dep" rowKey="r6" vendorName="Azure OpenAI" fields={[]} extra={{}} onExtraChange={() => {}} keySet={false} where={null} onChanged={() => {}} />);

--- a/runtime/ui/src/v2/settings/EnterpriseFields.test.tsx
+++ b/runtime/ui/src/v2/settings/EnterpriseFields.test.tsx
@@ -118,15 +118,15 @@ describe('EnterpriseFields (providers spec §3 step 5)', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('go together'));
   });
 
-  test('a provider not set up yet can still take its credentials — that is the order the work happens in', () => {
-    // It used to say "save the row, then paste the credentials here", which
-    // could not be done: the row will not save without a model, and the
-    // vendor will not list its models without credentials to sign the
-    // request with.
+  test('a provider being set up shows its fields, and says what has to happen before the credentials', () => {
+    // The fields are what the provider IS, so they are always editable. The
+    // credentials are filed against this row and can only be pasted once it
+    // exists — so the note says the order, rather than "save the row" with
+    // no way to save it.
     render(<EnterpriseFields id="azure/" rowKey="r5" vendorName="Azure OpenAI" fields={[{ name: 'resourceName', label: 'Resource name', secret: false, required: true }, { name: 'apiKey', label: 'API key', secret: true, required: true }]} extra={{}} onExtraChange={() => {}} keySet={undefined} where="keychain" onChanged={() => {}} />);
-    expect(screen.getByRole('button', { name: 'paste credentials' })).toBeTruthy();
-    expect(screen.getByText('not set')).toBeTruthy();
     expect(screen.getByLabelText('Resource name')).toBeTruthy();
+    expect(screen.getByText(/fill in the fields above and save this provider/)).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'paste credentials' })).toBeNull();
     cleanup();
     render(<EnterpriseFields id="azure/dep" rowKey="r6" vendorName="Azure OpenAI" fields={[]} extra={{}} onExtraChange={() => {}} keySet={false} where={null} onChanged={() => {}} />);
     expect(screen.getByText(/no key store; set them in the environment/)).toBeTruthy();

--- a/runtime/ui/src/v2/settings/EnterpriseFields.tsx
+++ b/runtime/ui/src/v2/settings/EnterpriseFields.tsx
@@ -34,7 +34,7 @@ function whereWord(where: EnterpriseFieldsProps['where']): string {
   return 'a file only you can read';
 }
 
-function statusWord(keySet: KeyState): string {
+function statusWord(keySet: KeyState | undefined): string {
   if (keySet === true) return 'set';
   if (keySet === 'env') return 'from the environment';
   if (keySet === 'default-chain') return 'default credentials on this machine';
@@ -126,11 +126,13 @@ export function EnterpriseFields({ id, vendorName, fields, extra, onExtraChange,
           </div>
         ))}
       </div>
-      {keySet === undefined ? (
-        <p className="v2-key muted" role="note">
-          <span className="v2-tag">credentials</span> save the row, then paste the credentials here.
-        </p>
-      ) : where === null ? (
+      {/* `keySet` is absent while the provider is not loaded — a row being
+          set up. It used to say "save the row, then paste the credentials
+          here", which could not be done: the row will not save without a
+          model, and the vendor will not list its models without credentials
+          to sign the request. Credentials are filed against the row, so
+          they can go first, and they have to. */}
+      {where === null ? (
         <p className="v2-key muted" role="note">
           <span className="v2-tag">credentials</span> {statusWord(keySet)} · this runtime has no key store; set them in the environment.
         </p>

--- a/runtime/ui/src/v2/settings/EnterpriseFields.tsx
+++ b/runtime/ui/src/v2/settings/EnterpriseFields.tsx
@@ -126,13 +126,15 @@ export function EnterpriseFields({ id, vendorName, fields, extra, onExtraChange,
           </div>
         ))}
       </div>
-      {/* `keySet` is absent while the provider is not loaded — a row being
-          set up. It used to say "save the row, then paste the credentials
-          here", which could not be done: the row will not save without a
-          model, and the vendor will not list its models without credentials
-          to sign the request. Credentials are filed against the row, so
-          they can go first, and they have to. */}
-      {where === null ? (
+      {/* The FIELDS above are always editable — they are what this provider
+          is, and they have to be filled in first. The credentials are filed
+          against this row, so they can only be pasted once the row exists;
+          until then this says what to do, in that order. */}
+      {keySet === undefined ? (
+        <p className="v2-key muted" role="note">
+          <span className="v2-tag">credentials</span> fill in the fields above and save this provider, then paste the credentials.
+        </p>
+      ) : where === null ? (
         <p className="v2-key muted" role="note">
           <span className="v2-tag">credentials</span> {statusWord(keySet)} · this runtime has no key store; set them in the environment.
         </p>

--- a/runtime/ui/src/v2/settings/KeyControl.test.tsx
+++ b/runtime/ui/src/v2/settings/KeyControl.test.tsx
@@ -62,10 +62,32 @@ describe('KeyControl', () => {
     await waitFor(() => expect(screen.getByRole('alert').textContent).toContain('refused'));
   });
 
-  test('an unsaved row and a runtime with no store each say what to do instead', () => {
-    render(<KeyControl id="google/gemini-2.5-pro" keySet={undefined} where="keychain" onChanged={() => {}} />);
-    expect(screen.getByText(/save the row, then paste the key here/)).toBeTruthy();
-    cleanup();
+  test('a provider not saved yet can still take its key — that is the order the work happens in', async () => {
+    // It used to say "save the row, then paste the key here", which could
+    // not be done: the row would not save without a model, and the vendor
+    // would not list its models without the key. The key is filed under the
+    // provider, so it goes first.
+    const puts: Array<{ url: string }> = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      puts.push({ url: String(input) });
+      return new Response(null, { status: 204 });
+    }) as unknown as typeof fetch;
+    let changed = 0;
+    render(<KeyControl id="google/" keySet={undefined} where="keychain" onChanged={() => (changed += 1)} />);
+    await userEvent.click(screen.getByRole('button', { name: 'paste a key' }));
+    const user = userEvent.setup({ document });
+    await user.type(screen.getByLabelText('Paste the key for google/'), 'AIza-test');
+    await user.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(changed).toBe(1));
+    expect(puts[0]!.url).toContain('/providers/google');
+    // And it says the key is set, though `/settings` cannot know yet: it
+    // speaks only for loaded providers, and this one has no model.
+    await waitFor(() => expect(screen.getByText('set')).toBeTruthy());
+    globalThis.fetch = realFetch;
+  });
+
+  test('a runtime with no store says what to do instead', () => {
     render(<KeyControl id="google/gemini-2.5-pro" keySet={false} where={null} onChanged={() => {}} />);
     expect(screen.getByText(/no key store; set it in the environment/)).toBeTruthy();
     expect(screen.queryByRole('button', { name: 'paste a key' })).toBeNull();

--- a/runtime/ui/src/v2/settings/KeyControl.test.tsx
+++ b/runtime/ui/src/v2/settings/KeyControl.test.tsx
@@ -65,25 +65,47 @@ describe('KeyControl', () => {
   test('a provider not saved yet can still take its key — that is the order the work happens in', async () => {
     // It used to say "save the row, then paste the key here", which could
     // not be done: the row would not save without a model, and the vendor
-    // would not list its models without the key. The key is filed under the
-    // provider, so it goes first.
-    const puts: Array<{ url: string }> = [];
+    // would not list its models without the key.
+    const calls: Array<{ url: string; method: string }> = [];
     const realFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      puts.push({ url: String(input) });
+    let stored = false;
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      const method = init?.method ?? 'GET';
+      calls.push({ url, method });
+      if (method === 'GET') return new Response(JSON.stringify({ keySet: stored }), { headers: { 'content-type': 'application/json' } });
+      if (method === 'PUT') stored = true;
+      if (method === 'DELETE') stored = false;
       return new Response(null, { status: 204 });
     }) as unknown as typeof fetch;
+
     let changed = 0;
     render(<KeyControl id="google/" keySet={undefined} where="keychain" onChanged={() => (changed += 1)} />);
+    // It ASKS the runtime rather than guessing: a key set on an earlier
+    // visit has to show, or it can never be removed.
+    await waitFor(() => expect(calls.some(c => c.method === 'GET')).toBe(true));
+    // No empty path segment: `openai/` must not build `/providers/openai//key`.
+    expect(calls[0]!.url).toBe('/providers/google/key');
+
     await userEvent.click(screen.getByRole('button', { name: 'paste a key' }));
     const user = userEvent.setup({ document });
-    await user.type(screen.getByLabelText('Paste the key for google/'), 'AIza-test');
+    await user.type(screen.getByLabelText('Paste the key for google'), 'AIza-test');
     await user.click(screen.getByRole('button', { name: 'Save' }));
     await waitFor(() => expect(changed).toBe(1));
-    expect(puts[0]!.url).toContain('/providers/google');
-    // And it says the key is set, though `/settings` cannot know yet: it
-    // speaks only for loaded providers, and this one has no model.
+    expect(calls.some(c => c.method === 'PUT' && c.url === '/providers/google/key')).toBe(true);
+
+    // And now it reads as set, with a way to take it back off again.
     await waitFor(() => expect(screen.getByText('set')).toBeTruthy());
+    expect(screen.getByRole('button', { name: 'remove' })).toBeTruthy();
+    globalThis.fetch = realFetch;
+  });
+
+  test('a key already stored for a provider being set up is shown, not asked for again', async () => {
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = (async () => new Response(JSON.stringify({ keySet: true }), { headers: { 'content-type': 'application/json' } })) as unknown as typeof fetch;
+    render(<KeyControl id="google/" keySet={undefined} where="keychain" onChanged={() => {}} />);
+    await waitFor(() => expect(screen.getByText('set')).toBeTruthy());
+    expect(screen.getByRole('button', { name: 'remove' })).toBeTruthy();
     globalThis.fetch = realFetch;
   });
 

--- a/runtime/ui/src/v2/settings/KeyControl.tsx
+++ b/runtime/ui/src/v2/settings/KeyControl.tsx
@@ -33,14 +33,19 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
   const [value, setValue] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // A key pasted against a provider that is not loaded yet IS stored — it is
+  // filed under the provider, not under the row — but `/settings` speaks
+  // only for loaded providers, so `keySet` stays absent and the line would
+  // go on reading "not set" straight after a successful save.
+  const [justSet, setJustSet] = useState(false);
 
-  if (keySet === undefined) {
-    return (
-      <p className="v2-key muted" role="note">
-        <span className="v2-tag">key</span> save the row, then paste the key here.
-      </p>
-    );
-  }
+  // `keySet` is absent while the provider is not loaded yet — a row you
+  // just added. It used to say "save the row, then paste the key here",
+  // which could not be done: the row would not save without a model, and
+  // the vendor would not list its models without the key. The key is filed
+  // under the provider, not under the row, so it can be pasted first — and
+  // it has to be, because it is what makes the model list answer.
+  const unsaved = keySet === undefined;
   if (where === null) {
     return (
       <p className="v2-key muted" role="note">
@@ -58,6 +63,7 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
       await setProviderKey(id, trimmed);
       setValue('');
       setEditing(false);
+      setJustSet(true);
       onChanged();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) return;
@@ -72,6 +78,7 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
     setError(null);
     try {
       await deleteProviderKey(id);
+      setJustSet(false);
       onChanged();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) return;
@@ -81,20 +88,21 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
     }
   };
 
-  const status = keySet === true ? 'set' : keySet === 'env' ? 'from the environment' : 'not set';
+  const isSet = keySet === true || (unsaved && justSet);
+  const status = isSet ? 'set' : keySet === 'env' ? 'from the environment' : 'not set';
 
   return (
     <div className="v2-key" role="group" aria-label={`Key for ${id}`}>
       <p className="v2-key-line">
         <span className="v2-tag">key</span>
-        <span className={keySet === true ? 'v2-key-state v2-key-set' : 'v2-key-state'}>{status}</span>
+        <span className={isSet ? 'v2-key-state v2-key-set' : 'v2-key-state'}>{status}</span>
         {editing ? null : (
           <>
             {' · '}
             <button type="button" className="v2-link" onClick={() => setEditing(true)} disabled={busy}>
-              {keySet === true ? 'replace' : 'paste a key'}
+              {isSet ? 'replace' : 'paste a key'}
             </button>
-            {keySet === true ? (
+            {isSet ? (
               <>
                 {' · '}
                 <button type="button" className="v2-link" onClick={() => void remove()} disabled={busy}>

--- a/runtime/ui/src/v2/settings/KeyControl.tsx
+++ b/runtime/ui/src/v2/settings/KeyControl.tsx
@@ -1,5 +1,5 @@
-import { useState } from 'react';
-import { ApiError, deleteProviderKey, setProviderKey } from '../../api/client';
+import { useCallback, useEffect, useState } from 'react';
+import { ApiError, deleteProviderKey, getProviderKeyState, setProviderKey } from '../../api/client';
 import type { KeyState } from '../../api/types';
 
 export interface KeyControlProps {
@@ -33,19 +33,27 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
   const [value, setValue] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  // A key pasted against a provider that is not loaded yet IS stored — it is
-  // filed under the provider, not under the row — but `/settings` speaks
-  // only for loaded providers, so `keySet` stays absent and the line would
-  // go on reading "not set" straight after a successful save.
-  const [justSet, setJustSet] = useState(false);
-
-  // `keySet` is absent while the provider is not loaded yet — a row you
-  // just added. It used to say "save the row, then paste the key here",
-  // which could not be done: the row would not save without a model, and
-  // the vendor would not list its models without the key. The key is filed
-  // under the provider, not under the row, so it can be pasted first — and
-  // it has to be, because it is what makes the model list answer.
+  // `/settings` speaks only for LOADED providers, and one being set up has
+  // no model yet, so `keySet` is absent for it. Ask the runtime directly:
+  // guessing from what this component itself just did was a lie the moment
+  // the block re-mounted — a key it had accepted read as "not set", with no
+  // way offered to remove it.
+  const [asked, setAsked] = useState<KeyState | undefined>(undefined);
   const unsaved = keySet === undefined;
+  const reask = useCallback((): void => {
+    if (!unsaved) return;
+    void getProviderKeyState(id)
+      .then(setAsked)
+      .catch(() => setAsked(undefined));
+  }, [id, unsaved]);
+  useEffect(reask, [reask]);
+
+  // It used to say "save the row, then paste the key here", which could not
+  // be done: the row would not save without a model, and the vendor would
+  // not list its models without the key. The key is filed under the
+  // provider, so it can be pasted first — and it has to be, because it is
+  // what makes the model list answer.
+  const state = unsaved ? asked : keySet;
   if (where === null) {
     return (
       <p className="v2-key muted" role="note">
@@ -63,7 +71,7 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
       await setProviderKey(id, trimmed);
       setValue('');
       setEditing(false);
-      setJustSet(true);
+      reask();
       onChanged();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) return;
@@ -78,7 +86,7 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
     setError(null);
     try {
       await deleteProviderKey(id);
-      setJustSet(false);
+      reask();
       onChanged();
     } catch (err) {
       if (err instanceof ApiError && err.status === 401) return;
@@ -88,11 +96,11 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
     }
   };
 
-  const isSet = keySet === true || (unsaved && justSet);
-  const status = isSet ? 'set' : keySet === 'env' ? 'from the environment' : 'not set';
+  const isSet = state === true;
+  const status = isSet ? 'set' : state === 'env' ? 'from the environment' : state === 'default-chain' ? 'from this machine' : 'not set';
 
   return (
-    <div className="v2-key" role="group" aria-label={`Key for ${id}`}>
+    <div className="v2-key" role="group" aria-label={`Key for ${id.replace(/\/$/, "")}`}>
       <p className="v2-key-line">
         <span className="v2-tag">key</span>
         <span className={isSet ? 'v2-key-state v2-key-set' : 'v2-key-state'}>{status}</span>
@@ -133,7 +141,7 @@ export function KeyControl({ id, keySet, getKey, where, onChanged }: KeyControlP
             type="password"
             autoComplete="off"
             spellCheck={false}
-            aria-label={`Paste the key for ${id}`}
+            aria-label={`Paste the key for ${id.replace(/\/$/, "")}`}
             placeholder="paste the key"
             value={value}
             onChange={event => setValue(event.target.value)}

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -142,6 +142,26 @@ describe('SettingsPage', () => {
     expect(screen.getByText('id is required')).toBeTruthy();
   });
 
+  test('a provider you already have is not added twice', async () => {
+    // One block per provider means one row per provider. A second row of a
+    // vendor you have folds into the same block, so it had no model picker
+    // and no key of its own — nothing on it could be filled in, and saving
+    // it wrote an id with no model into the file.
+    const ollama: ProviderInfo = { ...fakeProvider, id: 'ollama/gemma4:e4b', auth: 'local', locality: 'local' };
+    install(() => json(view), { ...view, effective: { ...view.effective, providers: [fakeProvider, ollama] } });
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByRole('list', { name: 'Providers you can use' })).toBeTruthy());
+    const before = screen.getAllByLabelText('Id').length;
+
+    const user = userEvent.setup({ document });
+    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'Local runners · Ollama');
+    await user.keyboard('{Escape}');
+    await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+    await waitFor(() => expect(screen.getByText(/You already have Ollama/)).toBeTruthy());
+    expect(screen.getAllByLabelText('Id')).toHaveLength(before);
+  });
+
   test('a blank row leads with the one field it needs', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
@@ -616,7 +636,16 @@ describe('the enterprise vendors in Settings (providers spec §3 step 5)', () =>
     // The field set sits under the row: project empty, location defaulted.
     expect((screen.getByLabelText('Project') as HTMLInputElement).value).toBe('');
     expect((screen.getByLabelText('Location') as HTMLInputElement).value).toBe('us-central1');
-    expect(screen.getByText(/save the row, then paste the credentials here/)).toBeTruthy();
+    // The provider gets its block at once, with its field set on it — the
+    // fields are what tell the listing where to ask, so they come before
+    // the model. (This runtime has no secret store, so the credentials line
+    // says so rather than offering a paste.)
+    const block = within(screen.getByRole('list', { name: 'Providers you can use' }))
+      .getAllByRole('listitem')
+      .find(li => (li.textContent ?? '').includes('Vertex'))!;
+    expect(within(block).getByText(/not set up yet/)).toBeTruthy();
+    expect(within(block).getByLabelText('Project')).toBeTruthy();
+    expect(within(block).getByText(/no key store; set them in the environment/)).toBeTruthy();
     // No secret input is drawn, and no key-variable field for this row.
     expect(screen.queryByLabelText('Service account JSON (optional)')).toBeNull();
     expect(puts).toHaveLength(0);

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -645,7 +645,7 @@ describe('the enterprise vendors in Settings (providers spec §3 step 5)', () =>
       .find(li => (li.textContent ?? '').includes('Vertex'))!;
     expect(within(block).getByText(/not set up yet/)).toBeTruthy();
     expect(within(block).getByLabelText('Project')).toBeTruthy();
-    expect(within(block).getByText(/no key store; set them in the environment/)).toBeTruthy();
+    expect(within(block).getByText(/fill in the fields above and save this provider/)).toBeTruthy();
     // No secret input is drawn, and no key-variable field for this row.
     expect(screen.queryByLabelText('Service account JSON (optional)')).toBeNull();
     expect(puts).toHaveLength(0);

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -150,6 +150,8 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
   const [busy, setBusy] = useState(false);
   /** The catalog picker's text (providers spec §3). */
   const [pick, setPick] = useState('');
+  /** The provider whose key last changed, so its model list is re-asked. */
+  const [relist, setRelist] = useState<{ prefix: string; n: number } | null>(null);
 
   // The one the runtime is running, which is not always the one in the file.
   const effectiveIds = view.effective.providers.map(p => p.id);
@@ -278,6 +280,33 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     });
   };
 
+  /**
+   * A provider's key, on its block.
+   *
+   * It used to sit in the raw row, under the fold, and said "save the row,
+   * then paste the key" — which could not be done: the row would not save
+   * without a model, and the vendor would not list models without the key.
+   * The key is the FIRST thing a hosted provider needs, so it belongs where
+   * the provider is.
+   */
+  const keyControlFor = (id: string): JSX.Element | null => {
+    const vendor = vendorFor(prefixOf(id));
+    if (vendor === undefined || vendor.connection !== 'API key') return null;
+    const live = view.effective.providers.find(p => p.id === id);
+    return (
+      <KeyControl
+        id={id}
+        keySet={live === undefined ? undefined : (live.keySet ?? false)}
+        {...(vendor.getKey === undefined ? {} : { getKey: vendor.getKey })}
+        where={view.secrets === undefined || view.secrets === null ? null : view.secrets.where}
+        onChanged={() => {
+          setRelist(prev => ({ prefix: prefixOf(id), n: (prev?.n ?? 0) + 1 }));
+          void refresh();
+        }}
+      />
+    );
+  };
+
   // A `tasks.*` message with no row to sit on still has to be shown; it
   // joins the general notices by the Save button.
   const orphanedTaskMessages = unplacedTaskMessages(errors, form.routes);
@@ -306,6 +335,11 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           baseURLOf={baseURLOf}
           onMakeDefault={id => void save({ default: id })}
           fileIds={new Set(form.providers.map(r => r.id.trim()))}
+          // A provider you just added is not loaded yet, so nothing in
+          // `effective` speaks for it. Its block comes from the form row.
+          pendingIds={form.providers.map(r => r.id.trim()).filter(id => id !== '' && !effectiveIds.includes(id))}
+          renderKey={group => keyControlFor(group.id)}
+          relist={relist}
           onPickModel={pickModel}
         />
         <FieldError message={errors['default']} />
@@ -503,24 +537,6 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
                   errors={fieldErrors}
                   keySet={live === undefined ? undefined : (live.keySet ?? false)}
                   {...(rowVendor.setup === undefined ? {} : { setup: rowVendor.setup })}
-                  where={view.secrets === undefined || view.secrets === null ? null : view.secrets.where}
-                  onChanged={() => void refresh()}
-                />
-              );
-            })()}
-            {/* The key itself (providers spec §5): set text under the row,
-                for vendors that take one. It is never part of the form —
-                the row saves the endpoint, the key goes to the store. */}
-            {(() => {
-              const id = row.id.trim();
-              const vendor = vendorFor(prefixOf(id));
-              if (vendor === undefined || vendor.connection !== 'API key') return null;
-              const live = view.effective.providers.find(p => p.id === id);
-              return (
-                <KeyControl
-                  id={id}
-                  keySet={live === undefined ? undefined : (live.keySet ?? false)}
-                  {...(vendor.getKey === undefined ? {} : { getKey: vendor.getKey })}
                   where={view.secrets === undefined || view.secrets === null ? null : view.secrets.where}
                   onChanged={() => void refresh()}
                 />

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import type { Health as HealthData, SettingsErrorBody, SettingsView } from '../.
 import { Health } from '../../settings/Health';
 import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
-import { dataLineFor, isEnterpriseVendor, makesLine, pickerLabel, prefixOf, searchVendors, vendorByPickerLabel, vendorFor } from '../vendors';
+import { dataLineFor, isEnterpriseVendor, keyBelongsToRow, makesLine, pickerLabel, prefixOf, searchVendors, vendorByPickerLabel, vendorFor } from '../vendors';
 import { EnterpriseFields } from './EnterpriseFields';
 import { KeyControl } from './KeyControl';
 import { YourModels } from './YourModels';
@@ -298,6 +298,22 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     const vendor = vendorFor(prefixOf(id));
     if (vendor === undefined) return null;
     const live = view.effective.providers.find(p => p.id === id);
+    // A key filed against the ROW cannot be pasted before the row exists:
+    // the address or the account fields decide WHERE it is filed, and until
+    // they are saved it would land under the vendor and be looked for under
+    // the row. Pasted, accepted, and then unreadable. Everything else — the
+    // vendors whose address the catalog fixes, which is most of them — takes
+    // its key straight away.
+    // An enterprise vendor is row-filed too, but its FIELDS have to stay
+    // editable — they are what the provider is. `EnterpriseFields` shows
+    // them and says, in place of the paste, what has to happen first.
+    if (live === undefined && vendor.connection !== 'fields' && keyBelongsToRow(vendor)) {
+      return (
+        <p className="v2-key muted" role="note">
+          <span className="v2-tag">key</span> give this provider its address below and save it, then paste the key.
+        </p>
+      );
+    }
     // An enterprise vendor's credentials are a field set, not one key — and
     // its non-secret fields (a region, a resource) are what tell the listing
     // where to ask, so they belong on the block too.

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -240,6 +240,11 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     return false;
   };
 
+  /** Whether this vendor already has a block — loaded, or a row waiting to
+   * be saved. */
+  const haveVendor = (prefix: string): boolean =>
+    effectiveIds.some(id => prefixOf(id) === prefix) || form.providers.some(r => prefixOf(r.id.trim()) === prefix);
+
   /** A saved row's base URL for a vendor, so a local runner's model list is
    * asked for at the address that row names rather than the preset. */
   const baseURLOf = (prefix: string): string | undefined => {
@@ -291,8 +296,35 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
    */
   const keyControlFor = (id: string): JSX.Element | null => {
     const vendor = vendorFor(prefixOf(id));
-    if (vendor === undefined || vendor.connection !== 'API key') return null;
+    if (vendor === undefined) return null;
     const live = view.effective.providers.find(p => p.id === id);
+    // An enterprise vendor's credentials are a field set, not one key — and
+    // its non-secret fields (a region, a resource) are what tell the listing
+    // where to ask, so they belong on the block too.
+    if (vendor.connection === 'fields' && vendor.fields !== undefined) {
+      const index = form.providers.findIndex(r => prefixOf(r.id.trim()) === prefixOf(id));
+      if (index === -1) return null;
+      const row = form.providers[index]!;
+      return (
+        <EnterpriseFields
+          id={id}
+          rowKey={row.key}
+          vendorName={vendor.name}
+          fields={vendor.fields}
+          extra={row.extra}
+          onExtraChange={(name, value) => patchRowExtra(index, name, value)}
+          errors={Object.fromEntries(vendor.fields.map(f => [f.name, errors[`providers.${index}.extra.${f.name}`]]))}
+          keySet={live === undefined ? undefined : (live.keySet ?? false)}
+          {...(vendor.setup === undefined ? {} : { setup: vendor.setup })}
+          where={view.secrets === undefined || view.secrets === null ? null : view.secrets.where}
+          onChanged={() => {
+            setRelist(prev => ({ prefix: prefixOf(id), n: (prev?.n ?? 0) + 1 }));
+            void refresh();
+          }}
+        />
+      );
+    }
+    if (vendor.connection !== 'API key') return null;
     return (
       <KeyControl
         id={id}
@@ -338,6 +370,7 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           // A provider you just added is not loaded yet, so nothing in
           // `effective` speaks for it. Its block comes from the form row.
           pendingIds={form.providers.map(r => r.id.trim()).filter(id => id !== '' && !effectiveIds.includes(id))}
+          extraOf={prefix => form.providers.find(r => prefixOf(r.id.trim()) === prefix)?.extra}
           renderKey={group => keyControlFor(group.id)}
           relist={relist}
           onPickModel={pickModel}
@@ -373,6 +406,17 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
               onClick={() => {
                 const v = vendorByPickerLabel(pick);
                 if (v === undefined) return;
+                // One block per provider means one row per provider. A
+                // second row of a vendor you already have was a stub with
+                // no block of its own (the block folds by vendor), no model
+                // picker and no key — nothing on it could be filled in, and
+                // saving it wrote an id with no model into the file.
+                if (haveVendor(v.prefix)) {
+                  setGeneral([`You already have ${v.label ?? v.name}. Choose its model on its own row above.`]);
+                  setPick('');
+                  return;
+                }
+                setGeneral([]);
                 patch({ providers: [...form.providers, catalogRow(v)] });
                 setPick('');
               }}
@@ -515,31 +559,6 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
                     </>
                   )}
                 </p>
-              );
-            })()}
-            {/* An enterprise vendor's field set (providers spec §3 step 5):
-                the non-secret fields save with the row; the secret ones go
-                to the store as one item, never through the form. */}
-            {(() => {
-              if (!isEnterpriseVendor(rowVendor)) return null;
-              const id = row.id.trim();
-              const live = view.effective.providers.find(p => p.id === id);
-              const fieldErrors: Record<string, string | undefined> = {};
-              for (const f of rowVendor.fields) fieldErrors[f.name] = errors[`providers.${index}.extra.${f.name}`];
-              return (
-                <EnterpriseFields
-                  id={id}
-                  rowKey={row.key}
-                  vendorName={rowVendor.name}
-                  fields={rowVendor.fields}
-                  extra={row.extra}
-                  onExtraChange={(name, value) => patchRowExtra(index, name, value)}
-                  errors={fieldErrors}
-                  keySet={live === undefined ? undefined : (live.keySet ?? false)}
-                  {...(rowVendor.setup === undefined ? {} : { setup: rowVendor.setup })}
-                  where={view.secrets === undefined || view.secrets === null ? null : view.secrets.where}
-                  onChanged={() => void refresh()}
-                />
               );
             })()}
             <button

--- a/runtime/ui/src/v2/settings/YourModels.test.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.test.tsx
@@ -240,3 +240,41 @@ describe('which model a block stands for', () => {
     expect(new Set(names).size).toBe(2);
   });
 });
+
+describe('a provider you have added but not saved', () => {
+  test('gets a block of its own, so its key and model have somewhere to go', () => {
+    // Without this it appeared only as a stub in "Rows you added", with no
+    // model picker and no key — and neither could be supplied in either
+    // order: the row will not save without a model, and the vendor will not
+    // list models without a key.
+    const groups = groupProviders([], '', new Set(), ['openai/']);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.prefix).toBe('openai');
+    expect(groups[0]!.pending).toBe(true);
+    expect(groups[0]!.model).toBe('');
+    // It cannot answer yet, so it is never offered as the one that does.
+    expect(groups[0]!.reach.usable).toBe(false);
+    expect(groups[0]!.reach.blocked).toBe('pick a model to finish');
+  });
+
+  test('a provider already loaded does not get a second block', () => {
+    const loaded = [provider({ id: 'openai/gpt-5.6', auth: 'apikey', locality: 'cloud', keySet: true })];
+    const groups = groupProviders(loaded, '', new Set(['openai/gpt-5.6']), ['openai/']);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.model).toBe('gpt-5.6');
+    expect(groups[0]!.pending).toBeUndefined();
+  });
+
+  test('a local provider says where it runs even before it is saved', () => {
+    expect(groupProviders([], '', new Set(), ['ollama/'])[0]!.reach.how).toBe('on this machine');
+    expect(groupProviders([], '', new Set(), ['openai/'])[0]!.reach.how).toBe('not set up yet');
+  });
+
+  test('an id that is only a slash is not a provider', () => {
+    expect(groupProviders([], '', new Set(), ['/x'])).toEqual([]);
+  });
+
+  test('the same pending vendor twice is still one block', () => {
+    expect(groupProviders([], '', new Set(), ['openai/', 'openai/'])).toHaveLength(1);
+  });
+});

--- a/runtime/ui/src/v2/settings/YourModels.test.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.test.tsx
@@ -128,6 +128,7 @@ describe('choosing a model on a provider block', () => {
         busy={false}
         baseURLOf={() => undefined}
         fileIds={new Set(['xai/grok-4'])}
+        pendingIds={[]}
         onMakeDefault={() => {}}
         onPickModel={async (id, model) => {
           picks.push({ id, model });

--- a/runtime/ui/src/v2/settings/YourModels.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.tsx
@@ -32,6 +32,18 @@ export interface YourModelsProps {
   /** The ids this practice's own file names, so a saved row is shown over a
    * built-in of the same vendor. */
   fileIds: ReadonlySet<string>;
+  /** Rows added but not saved yet. A provider you just picked gets its
+   * block AT ONCE — its key and its model are chosen on the block, and
+   * before this it had neither: the row could not be saved without a model,
+   * and the vendor would not list models without a key. */
+  pendingIds: readonly string[];
+  /** The key control for a provider, supplied by the page (this component
+   * knows nothing about the settings view). */
+  renderKey?(group: ProviderGroup): JSX.Element | null;
+  /** A provider whose key just changed, and a counter so the same provider
+   * twice still counts. Its model list is re-asked: the key is usually the
+   * whole reason the vendor would not answer. */
+  relist?: { prefix: string; n: number } | null;
   onMakeDefault(id: string): void;
   /**
    * Run a provider on a different model. `id` is the block's OWN current id,
@@ -113,6 +125,8 @@ export interface ProviderGroup {
   /** The full id of that model, which is what the default and the routes
    * actually name. */
   id: string;
+  /** Added, not saved. It cannot answer or be the default yet. */
+  pending?: boolean;
 }
 
 /**
@@ -132,7 +146,12 @@ export interface ProviderGroup {
  * The others stay loaded and stay nameable by a task route; they are just
  * not a second block to read past.
  */
-export function groupProviders(providers: ProviderInfo[], defaultId: string, fileIds: ReadonlySet<string> = new Set()): ProviderGroup[] {
+export function groupProviders(
+  providers: ProviderInfo[],
+  defaultId: string,
+  fileIds: ReadonlySet<string> = new Set(),
+  pendingIds: readonly string[] = [],
+): ProviderGroup[] {
   const groups = new Map<string, { group: ProviderGroup; rank: number }>();
   for (const p of providers) {
     const prefix = prefixOf(p.id);
@@ -142,16 +161,33 @@ export function groupProviders(providers: ProviderInfo[], defaultId: string, fil
     if (existing !== undefined && existing.rank <= rank) continue;
     groups.set(prefix, { rank, group: { prefix, name: vendor, reach: reachOf(p), model, id: p.id } });
   }
+  // A provider added but not saved has no loaded model to speak for it. It
+  // still gets a block: the block is where its key and its model are set,
+  // and both have to happen before there is anything to save.
+  for (const id of pendingIds) {
+    const prefix = prefixOf(id);
+    if (prefix === '' || groups.has(prefix)) continue;
+    const { vendor, model } = nameOf(id);
+    groups.set(prefix, { rank: 3, group: { prefix, name: vendor, reach: pendingReach(prefix), model, id, pending: true } });
+  }
   return [...groups.values()].map(entry => entry.group);
 }
 
-export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, fileIds, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
-  if (providers.length === 0) {
+/** What an unsaved provider still needs, from the catalog alone. */
+function pendingReach(prefix: string): Reach {
+  const connection = vendorFor(prefix)?.connection;
+  const how = connection === 'local' ? 'on this machine' : connection === 'subscription' ? 'your subscription' : 'not set up yet';
+  return { how, usable: false, blocked: 'pick a model to finish' };
+}
+
+export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, fileIds, pendingIds, renderKey, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
+  const groups = groupProviders(providers, defaultId, fileIds, pendingIds);
+  if (groups.length === 0) {
     return <p className="muted">No provider is set up. Add one below.</p>;
   }
   return (
     <ul className="v2-yours" aria-label="Providers you can use">
-      {groupProviders(providers, defaultId, fileIds).map(group => (
+      {groups.map(group => (
         <ProviderBlock
           key={group.prefix}
           group={group}
@@ -159,6 +195,8 @@ export function YourModels({ providers, defaultId, builtinDefault, busy, baseURL
           builtinDefault={builtinDefault}
           busy={busy}
           baseURL={baseURLOf(group.prefix)}
+          {...(renderKey === undefined ? {} : { renderKey })}
+          relistN={relist != null && relist.prefix === group.prefix ? relist.n : 0}
           onMakeDefault={onMakeDefault}
           onPickModel={onPickModel}
         />
@@ -173,16 +211,27 @@ interface ProviderBlockProps {
   builtinDefault: boolean;
   busy: boolean;
   baseURL: string | undefined;
+  renderKey?(group: ProviderGroup): JSX.Element | null;
+  relistN: number;
   onMakeDefault(id: string): void;
   onPickModel(id: string, model: string): Promise<boolean>;
 }
 
-function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
+function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, renderKey, relistN, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
   // A prefix the catalog does not know (`serve --fake`, a hand-edited id)
   // has nowhere to ask, so do not ask.
   const known = vendorFor(group.prefix) !== undefined;
   const { result, loading, refresh } = useModels(known ? group.prefix : null, baseURL);
   const models = result?.models ?? [];
+  // Ask again when this provider's key changes: "No key for OpenAI yet" is
+  // the commonest reason the list is empty, and having pasted one, nobody
+  // should have to find a `refresh` link to see the models it just bought.
+  useEffect(() => {
+    if (relistN > 0) refresh();
+    // `refresh` is stable for a given prefix; re-running on its identity
+    // would re-ask on every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [relistN]);
   // The combo reports every KEYSTROKE, so the text is held here and saved
   // only when it is really chosen: `onSelect` (picked from the list) or the
   // field being left (a model the list does not carry).
@@ -267,6 +316,10 @@ function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, onMake
           </button>
         </p>
       </div>
+      {/* The key belongs to the PROVIDER, so it belongs on the provider's
+          block — and it has to come before the model, because most vendors
+          will not list their models without it. */}
+      {renderKey?.(group) ?? null}
     </li>
   );
 }

--- a/runtime/ui/src/v2/settings/YourModels.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.tsx
@@ -29,6 +29,10 @@ export interface YourModelsProps {
   /** A saved row's base URL for this vendor, so a local runner's model list
    * is asked for at the right address. */
   baseURLOf(prefix: string): string | undefined;
+  /** An enterprise row's non-secret fields (a Bedrock region, an Azure
+   * resource). They name WHERE to ask, so without them that vendor's
+   * listing can only answer with an error. */
+  extraOf?(prefix: string): Record<string, string> | undefined;
   /** The ids this practice's own file names, so a saved row is shown over a
    * built-in of the same vendor. */
   fileIds: ReadonlySet<string>;
@@ -180,7 +184,7 @@ function pendingReach(prefix: string): Reach {
   return { how, usable: false, blocked: 'pick a model to finish' };
 }
 
-export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, fileIds, pendingIds, renderKey, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
+export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, extraOf, fileIds, pendingIds, renderKey, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
   const groups = groupProviders(providers, defaultId, fileIds, pendingIds);
   if (groups.length === 0) {
     return <p className="muted">No provider is set up. Add one below.</p>;
@@ -195,6 +199,7 @@ export function YourModels({ providers, defaultId, builtinDefault, busy, baseURL
           builtinDefault={builtinDefault}
           busy={busy}
           baseURL={baseURLOf(group.prefix)}
+          extra={extraOf?.(group.prefix)}
           {...(renderKey === undefined ? {} : { renderKey })}
           relistN={relist != null && relist.prefix === group.prefix ? relist.n : 0}
           onMakeDefault={onMakeDefault}
@@ -211,25 +216,33 @@ interface ProviderBlockProps {
   builtinDefault: boolean;
   busy: boolean;
   baseURL: string | undefined;
+  extra: Record<string, string> | undefined;
   renderKey?(group: ProviderGroup): JSX.Element | null;
   relistN: number;
   onMakeDefault(id: string): void;
   onPickModel(id: string, model: string): Promise<boolean>;
 }
 
-function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, renderKey, relistN, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
+function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, extra, renderKey, relistN, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
   // A prefix the catalog does not know (`serve --fake`, a hand-edited id)
   // has nowhere to ask, so do not ask.
   const known = vendorFor(group.prefix) !== undefined;
-  const { result, loading, refresh } = useModels(known ? group.prefix : null, baseURL);
+  const { result, loading, refresh } = useModels(known ? group.prefix : null, baseURL, extra ?? {});
   const models = result?.models ?? [];
   // Ask again when this provider's key changes: "No key for OpenAI yet" is
   // the commonest reason the list is empty, and having pasted one, nobody
   // should have to find a `refresh` link to see the models it just bought.
+  // Seeded with what it is mounted at, so a block re-mounted after a key
+  // change does not fire an extra listing on top of `useModels`' own first
+  // load — the counter lives on the page and outlives any one block.
+  const seenRelist = useRef(relistN);
   useEffect(() => {
-    if (relistN > 0) refresh();
-    // `refresh` is stable for a given prefix; re-running on its identity
-    // would re-ask on every render.
+    if (relistN === seenRelist.current) return;
+    seenRelist.current = relistN;
+    refresh();
+    // `refresh` is EXCLUDED deliberately: `useModels` returns a new closure
+    // on every render, so listing it here is an endless fetch loop. This
+    // effect is driven by the counter alone.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [relistN]);
   // The combo reports every KEYSTROKE, so the text is held here and saved

--- a/runtime/ui/src/v2/vendors-parity.test.ts
+++ b/runtime/ui/src/v2/vendors-parity.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'bun:test';
+import { allVendors, vendorFor as runtimeVendor } from '../../../src/providers/vendors';
+import { VENDORS, addableVendors, keyBelongsToRow, vendorFor } from './vendors';
+
+/**
+ * The UI catalog is a hand-kept COPY of the runtime's (its own header says
+ * so: "a change there is a change here"). Two facts in it are load-bearing
+ * for credentials, and a one-character drift in either would be silent:
+ *
+ * - the base URL, because whether a row's address matches the vendor's own
+ *   decides whether its key is filed under the vendor or under the row;
+ * - which vendors are row-filed at all, because the page uses its own copy
+ *   of that rule to decide whether a key can be pasted yet.
+ */
+describe('the UI catalog agrees with the runtime', () => {
+  test('every vendor the UI offers exists in the runtime, at the same address', () => {
+    for (const v of VENDORS) {
+      const real = runtimeVendor(v.prefix);
+      if (real === undefined) {
+        // A display-only alias for an id an older file might carry
+        // (`codex`). It must not be offerable, or the runtime would refuse
+        // the row it created.
+        expect(addableVendors().map(a => a.prefix), `${v.prefix} is unknown to the runtime but can be added`).not.toContain(v.prefix);
+        continue;
+      }
+      const uiURL = (v.baseURL ?? '').trim();
+      if (uiURL === '') continue;
+      expect(real.defaultBaseURL, `${v.prefix}: base URL drifted between the catalogs`).toBe(uiURL);
+    }
+  });
+
+  test('the two catalogs agree on which vendors file their key against the row', () => {
+    // `keyBelongsToRow` (UI) must match `keyIdFor`'s rule (runtime), or the
+    // page offers a paste that cannot be filed where it will be read.
+    for (const real of allVendors()) {
+      const ui = vendorFor(real.prefix);
+      if (ui === undefined) continue;
+      const runtimeSaysRow = real.fields !== undefined || real.baseURLFields !== undefined || real.locality === 'by-baseURL';
+      expect(keyBelongsToRow(ui), `${real.prefix}: the catalogs disagree about key scope`).toBe(runtimeSaysRow);
+    }
+  });
+});

--- a/runtime/ui/src/v2/vendors.ts
+++ b/runtime/ui/src/v2/vendors.ts
@@ -168,6 +168,19 @@ export function prefixOf(id: string): string {
   return slash === -1 ? id : id.slice(0, slash);
 }
 
+/**
+ * Whether this vendor's key is filed against the ROW rather than the vendor.
+ *
+ * Mirrors `keyIdFor` in `runtime/src/providers/secrets.ts`, and is checked
+ * against it by a parity test. It matters here for one reason: a row-filed
+ * key cannot be pasted until the thing that decides where it is filed — the
+ * row's own address, or its account fields — is known and saved. Pasted
+ * before that, it lands in one place and is looked for in another.
+ */
+export function keyBelongsToRow(v: VendorRow): boolean {
+  return v.connection === 'fields' || v.baseURLFields !== undefined || v.prefix === 'openai-compatible';
+}
+
 export function vendorFor(prefix: string): VendorRow | undefined {
   return VENDORS.find(v => v.prefix === prefix);
 }


### PR DESCRIPTION
Walking the flow in a browser, it deadlocked.

Pick OpenAI from the catalog, press **Add**, and the provider appeared only as a stub down in "Rows you added" — `openai/`, no model, its key control reading *"save the row, then paste the key here"*. That cannot be done in either order:

- the row will not save without a model (the server refuses an id with no model half), and
- OpenAI will not list its models without a key.

The previous PR removed the row's own model picker on the grounds that the provider block owned model choice. But a provider with nothing loaded had no block — so it had neither.

### The fix

`groupProviders` now takes the pending rows as well. A provider added but not saved gets a block built from the form, reading **not set up yet · pick a model to finish**. Choosing a model there saves the row, and the block becomes an ordinary one.

The **key control moves onto the block**, above the model — it is the first thing a hosted provider needs and the reason its list can answer at all, so it belongs where the provider is rather than folded inside a raw row. It no longer refuses to work before a save: keys are filed under the provider now, so there is nothing to wait for. (`PUT /providers/openai//key` and `/providers/openai/key` both file under `openai` — checked against a live server.)

Two follow-ons that would otherwise be papercuts:

- `/settings` speaks only for **loaded** providers, so a key pasted against a provider with no model yet is stored and still reports `keySet: undefined`. The control would have gone on reading "not set" right after a successful save; it now remembers what it just did.
- Pasting a key **re-asks that provider for its models**. "No key for OpenAI yet" is the commonest reason a list is empty, and having just supplied one, nobody should have to hunt for a `refresh` link.

### Verified

End to end on a throwaway `COUNSEL_OS_HOME`, so no real config was touched: add OpenAI → the block appears immediately with `128 models listed` and `key not set · paste a key · get a key`. Adding a provider that is already loaded (Ollama) folds into its existing block rather than making a second one.

623 UI tests, 1287 runtime tests, both typechecks clean.