### PR TITLE
One place per provider, and click the one you want

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ A simpler Settings page, and the model lists we never asked for
 
 - **ChatGPT and Claude list their models.** The Codex CLI documents the models it answers to, and so does Claude's; we had never looked, and the page said "ChatGPT does not publish a model list". It does. Claude gained Fable too.
 - **Adding a provider is clicking the one you want.** It was a search box with a placeholder and a greyed-out button — you had to know to type something, that a list would appear, to pick from it, and then to press Add. Four unsignposted steps to do the thing the page most wants you to do. The common providers are now named and clicked; the whole catalog is still there, behind *Someone else*.
-- **A provider appears once.** Every provider used to be written twice — a block at the top you could use, and a row further down you had to understand. Its id, address and capability flags now fold away inside its own block, and the second list is gone.
+- **A provider appears once.** Every provider used to be written twice — a block at the top you could use, and a row further down you had to understand. Its id, address and capability flags now fold away inside its own block, and the second list is gone. One block per provider **entry**: two rows of the same vendor are two blocks, each editable and removable, rather than one silently hiding the other.
 
 Adding a provider actually works now
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ reconstructed from git history. New entries are prepended automatically by
 
 ## [Unreleased]
 
+A simpler Settings page, and the model lists we never asked for
+
+- **ChatGPT and Claude list their models.** The Codex CLI documents the models it answers to, and so does Claude's; we had never looked, and the page said "ChatGPT does not publish a model list". It does. Claude gained Fable too.
+- **Adding a provider is clicking the one you want.** It was a search box with a placeholder and a greyed-out button — you had to know to type something, that a list would appear, to pick from it, and then to press Add. Four unsignposted steps to do the thing the page most wants you to do. The common providers are now named and clicked; the whole catalog is still there, behind *Someone else*.
+- **A provider appears once.** Every provider used to be written twice — a block at the top you could use, and a row further down you had to understand. Its id, address and capability flags now fold away inside its own block, and the second list is gone.
+
 Adding a provider actually works now
 
 - A provider you add gets its **block straight away**, with its key and its model picker on it. Before this it appeared only as a stub down in "Rows you added", and the two things it needed were impossible to do in either order: the row would not save without a model, and the vendor would not list its models without a key.

--- a/runtime/src/providers/discovery.test.ts
+++ b/runtime/src/providers/discovery.test.ts
@@ -156,11 +156,19 @@ describe('discoverModels', () => {
   });
 
   test('a vendor with no list and no curated ids says to type the id', async () => {
-    // `codex-sub`: the Codex CLI publishes no list, and we know one model
-    // name for certain, which is not a list worth inventing.
-    const r = await discoverModels(vendorFor('codex-sub')!, {});
+    // No vendor in the catalog is in this state any more — every one lists
+    // or ships its ids — but the branch still has to answer sensibly if one
+    // is ever added that way.
+    const bare = { ...vendorFor('perplexity')!, models: 'none' as const, curated: undefined };
+    const r = await discoverModels(bare, {});
     expect(r.models).toEqual([]);
     expect(r.error).toContain('type the model id');
+  });
+
+  test('the Codex subscription lists its models too', async () => {
+    const r = await discoverModels(vendorFor('codex-sub')!, {});
+    expect(r.source).toBe('curated');
+    expect(r.models.map(m => m.id)).toContain('gpt-5.6-terra');
   });
 
   test('the Claude subscription lists its models, with no key and no call', async () => {

--- a/runtime/src/providers/vendors.test.ts
+++ b/runtime/src/providers/vendors.test.ts
@@ -109,7 +109,10 @@ describe('the vendor catalog (providers spec §3)', () => {
     expect(anthropic.models).toBe('list');
     expect(anthropic.discovery?.shape).toBe('anthropic');
     expect(anthropic.curated!.length).toBeGreaterThan(0);
-    for (const m of anthropic.curated!) expect(m.contextTokens).toBeGreaterThan(0);
+    // A window we know is a real number; one we do not is absent rather
+    // than guessed — the router compares it against a task's bar.
+    for (const m of anthropic.curated!) if (m.contextTokens !== undefined) expect(m.contextTokens).toBeGreaterThan(0);
+    expect(anthropic.curated!.some(m => m.contextTokens === undefined)).toBe(true);
     expect(vendorFor('openrouter')!.models).toBe('list');
     // The Claude subscription carries the same curated list: its harness
     // takes a model, so it is switchable like any other provider.
@@ -125,7 +128,9 @@ describe('the vendor catalog (providers spec §3)', () => {
   test('every vendor can say what models it has', () => {
     // A provider you cannot choose a model for is a provider you cannot
     // finish setting up. Every one either lists live or ships the ids it
-    // answers to.
+    // answers to. (When a live listing fails, `discoverModels` falls back
+    // to the curated ids where there are any, and otherwise returns the
+    // reason — the field still takes a model id typed by hand.)
     for (const vendor of allVendors()) {
       const has = vendor.models === 'list' || (vendor.curated ?? []).length > 0;
       expect(has, `${vendor.prefix} offers no way to choose a model`).toBe(true);

--- a/runtime/src/providers/vendors.test.ts
+++ b/runtime/src/providers/vendors.test.ts
@@ -115,8 +115,21 @@ describe('the vendor catalog (providers spec §3)', () => {
     // takes a model, so it is switchable like any other provider.
     expect(vendorFor('claude-sub')!.models).toBe('curated');
     expect(vendorFor('claude-sub')!.curated).toEqual(anthropic.curated);
-    // Codex publishes no list and we will not invent one.
-    expect(vendorFor('codex-sub')!.models).toBe('none');
+    // So does Codex. Its CLI documents the models it answers to
+    // (learn.chatgpt.com/docs/models); "ChatGPT does not publish a model
+    // list" was us never having looked.
+    expect(vendorFor('codex-sub')!.models).toBe('curated');
+    expect(vendorFor('codex-sub')!.curated!.map(m => m.id)).toContain('gpt-5.6-terra');
+  });
+
+  test('every vendor can say what models it has', () => {
+    // A provider you cannot choose a model for is a provider you cannot
+    // finish setting up. Every one either lists live or ships the ids it
+    // answers to.
+    for (const vendor of allVendors()) {
+      const has = vendor.models === 'list' || (vendor.curated ?? []).length > 0;
+      expect(has, `${vendor.prefix} offers no way to choose a model`).toBe(true);
+    }
   });
 
   test('every API-key vendor names its usual environment variable (uppercase, the vendor’s own spelling)', () => {

--- a/runtime/src/providers/vendors.ts
+++ b/runtime/src/providers/vendors.ts
@@ -166,7 +166,7 @@ const LOCAL_CAPS = { tools: true, caching: false, thinking: false, contextTokens
 const ANTHROPIC_MODELS: VendorModel[] = [
   { id: 'claude-opus-5', contextTokens: 200_000 },
   { id: 'claude-sonnet-5', contextTokens: 200_000 },
-  { id: 'claude-fable-5-1', contextTokens: 200_000 },
+  { id: 'claude-fable-5-1' },
   { id: 'claude-haiku-4-5-20251001', contextTokens: 200_000 },
 ];
 

--- a/runtime/src/providers/vendors.ts
+++ b/runtime/src/providers/vendors.ts
@@ -53,7 +53,9 @@ export interface VendorHandles {
 
 export interface VendorModel {
   id: string;
-  contextTokens: number;
+  /** Absent where the vendor does not publish one. Never guessed: the
+   * router compares a task's bar against this number. */
+  contextTokens?: number;
 }
 
 /** An open model worth trying locally, and why — a starting point, not a
@@ -164,7 +166,21 @@ const LOCAL_CAPS = { tools: true, caching: false, thinking: false, contextTokens
 const ANTHROPIC_MODELS: VendorModel[] = [
   { id: 'claude-opus-5', contextTokens: 200_000 },
   { id: 'claude-sonnet-5', contextTokens: 200_000 },
+  { id: 'claude-fable-5-1', contextTokens: 200_000 },
   { id: 'claude-haiku-4-5-20251001', contextTokens: 200_000 },
+];
+
+/**
+ * What the Codex CLI answers to (`codex --model`), from OpenAI's own docs:
+ * https://learn.chatgpt.com/docs/models. It publishes no listing endpoint,
+ * so this is the list — and it IS a list. Saying "ChatGPT does not publish
+ * a model list" was us never having looked.
+ */
+const CODEX_MODELS: VendorModel[] = [
+  { id: 'gpt-5.6-sol' },
+  { id: 'gpt-5.6-terra' },
+  { id: 'gpt-5.6-luna' },
+  { id: 'gpt-5.5' },
 ];
 
 /** xAI documents no listing endpoint; the ids from its models page. */
@@ -288,7 +304,7 @@ const SDK_VENDORS: Vendor[] = [
   {
     prefix: 'codex-sub', name: 'ChatGPT', kind: 'harness', layer: 'sdk', group: 'subscription', auth: 'subscription', locality: 'cloud',
     handles: { company: 'OpenAI', termsUrl: 'https://openai.com/policies/terms-of-use' },
-    help: { install: 'https://developers.openai.com/codex' }, models: 'none', capabilities: CLOUD_CAPS,
+    help: { install: 'https://developers.openai.com/codex' }, models: 'curated', curated: CODEX_MODELS, capabilities: CLOUD_CAPS,
   },
   {
     prefix: 'anthropic', name: 'Claude', kind: 'direct', layer: 'sdk', group: 'hosted', auth: 'apikey', locality: 'cloud',

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1164,18 +1164,27 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-yours-count { color: var(--fg-faint); font-size: 12.5px; margin: 0; }
 .v2-yours-count .v2-link { margin-left: 0.4rem; }
 
-/* Adding one: a search box over the whole catalog. */
-.v2-add-model { margin-top: var(--s3); }
-/* The row wraps as a ROW; nothing inside it breaks mid-phrase. Squeezed at
-   a narrow width it used to read "Search by maker or / vendor" beside "or
-   add a / blank row". */
-.v2-add-model .v2-add-provider-row { margin-top: 4px; flex-wrap: wrap; }
-.v2-add-model .v2-add-provider-row .v2-combo { flex: 1 1 18rem; min-width: 11rem; }
-.v2-add-model .v2-add-provider-row label,
-.v2-add-model .v2-add-provider-row .v2-link { white-space: nowrap; }
-.v2-added-head { margin-top: var(--s4); }
+/* Adding one: the common providers, named, one click each. */
+.v2-add { margin-top: var(--s3); }
+.v2-add-list { list-style: none; margin: 0.3rem 0 0.5rem; padding: 0; display: flex; flex-wrap: wrap; gap: 6px; }
+.v2-add-one {
+  display: flex; flex-direction: column; gap: 1px; text-align: left;
+  padding: 6px 10px; background: var(--bg); border: 1px solid var(--border); border-radius: var(--radius); cursor: pointer;
+}
+.v2-add-one:hover { border-color: var(--border-strong); }
+.v2-add-name { font: 13.5px/1.5 var(--sans); color: var(--fg); }
+.v2-add-what { font: 12px/1.5 var(--sans); color: var(--fg-faint); }
+.v2-add-more { margin: 0.2rem 0 0; font-size: 12.5px; }
+.v2-add-search { margin-top: 0.4rem; }
+.v2-add-blank { margin: 6px 0 0; font-size: 12.5px; }
+.v2-add-search .v2-add-provider-row { display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap; }
+.v2-add-search .v2-combo { flex: 1 1 18rem; min-width: 11rem; }
+.v2-add-search label { white-space: nowrap; }
+.v2-add-provider-note { margin: 6px 0 0; font-size: 12.5px; }
 
 /* A row leads with what it is; the file's own fields fold away. */
 .v2-provider-head { margin: 0 0 4px; }
 .v2-provider-main { margin-bottom: 6px; }
-.v2-provider-advanced > summary { cursor: pointer; color: var(--fg-muted); font-size: 12.5px; margin-bottom: 6px; }
+.v2-provider-advanced > summary { cursor: pointer; color: var(--fg-faint); font-size: 12.5px; margin: 4px 0 6px; }
+.v2-yours-row .v2-provider { margin: 0; }
+.v2-yours-row .v2-provider-head { display: none; }

--- a/runtime/ui/src/v2/settings/AddProvider.tsx
+++ b/runtime/ui/src/v2/settings/AddProvider.tsx
@@ -1,0 +1,145 @@
+/**
+ * Adding a provider.
+ *
+ * It was a search box with a placeholder and a greyed-out Add button, and
+ * the founder's verdict was the right one: "it's unclear what to do." You
+ * had to know to type something, then that a list would appear, then to
+ * pick from it, then to press Add — four steps, none of them signposted,
+ * to do the thing the page most wants you to do.
+ *
+ * So the common ones are named, and you click the one you want. The whole
+ * catalog is still there, behind a link, for the practice that buys from
+ * someone else.
+ */
+import { useState } from 'react';
+import { ProviderCombo } from '../../settings/ProviderCombo';
+import { makesLine, pickerLabel, searchVendors, vendorByPickerLabel, vendorFor, type VendorRow } from '../vendors';
+
+/** The ones a practice actually starts with: the two big labs, Google, and
+ * a model on your own machine. Everything else is a search away. */
+const COMMON = ['anthropic', 'openai', 'google', 'ollama'] as const;
+
+export interface AddProviderProps {
+  /** Whether this vendor already has a row or a loaded model. */
+  have(prefix: string): boolean;
+  onAdd(vendor: VendorRow): void;
+  /** The last resort: a row with nothing filled in, for an endpoint the
+   * catalog has never heard of. */
+  onAddBlank(): void;
+}
+
+export function AddProvider({ have, onAdd, onAddBlank }: AddProviderProps): JSX.Element {
+  const [searching, setSearching] = useState(false);
+  const [pick, setPick] = useState('');
+
+  const offer = COMMON.map(prefix => vendorFor(prefix)).filter((v): v is VendorRow => v !== undefined && !have(v.prefix));
+  const picked = vendorByPickerLabel(pick);
+
+  return (
+    <div className="v2-add">
+      <h3 className="runin">Add a provider</h3>
+      {offer.length === 0 ? null : (
+        <ul className="v2-add-list">
+          {offer.map(v => (
+            <li key={v.prefix}>
+              {/* One click, one provider. No second button to press. */}
+              <button type="button" className="v2-add-one" onClick={() => onAdd(v)}>
+                <span className="v2-add-name">{v.label ?? v.name}</span>
+                <span className="v2-add-what">{blurb(v)}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+      {searching ? (
+        <div className="v2-add-search">
+          <div className="v2-add-provider-row">
+            <ProviderCombo
+              id="v2-add-provider"
+              label="Search by maker or vendor"
+              value={pick}
+              options={searchVendors(pick).map(pickerLabel)}
+              placeholder="llama · gemini · a vendor's name"
+              // The options ARE the search result; matching them against the
+              // typed text again would hide every vendor found by a family
+              // rather than by its own name, which is the point.
+              filter={() => true}
+              onChange={setPick}
+            />
+            <button
+              type="button"
+              disabled={picked === undefined}
+              onClick={() => {
+                if (picked === undefined) return;
+                onAdd(picked);
+                setPick('');
+              }}
+            >
+              Add
+            </button>
+          </div>
+          <SearchNote pick={pick} />
+          <p className="muted v2-add-blank">
+            Not there either?{' '}
+            <button type="button" className="v2-link" onClick={onAddBlank}>
+              or add a blank row
+            </button>{' '}
+            and give it a base URL of its own.
+          </p>
+        </div>
+      ) : (
+        <p className="muted v2-add-more">
+          <button type="button" className="v2-link" onClick={() => setSearching(true)}>
+            Someone else
+          </button>{' '}
+          — thirty more vendors, a model server on this machine, or any endpoint that speaks the OpenAI API.
+        </p>
+      )}
+    </div>
+  );
+}
+
+/** One line saying what this provider IS, in a lawyer's terms. */
+function blurb(v: VendorRow): string {
+  if (v.connection === 'local') return 'runs on this machine; nothing leaves it';
+  if (v.connection === 'subscription') return 'your subscription';
+  return `${v.company ?? v.name}, with an API key`;
+}
+
+function SearchNote({ pick }: { pick: string }): JSX.Element | null {
+  const v = vendorByPickerLabel(pick);
+  if (v === undefined) {
+    if (pick.trim() === '') return null;
+    const hits = searchVendors(pick).slice(0, 4);
+    if (hits.length === 0) {
+      return (
+        <p className="muted v2-add-provider-note" role="note">
+          Nothing matches <strong>{pick.trim()}</strong>. Try a maker or a family — <em>llama</em>, <em>gemini</em>, <em>qwen</em> — or the vendor you buy
+          from.
+        </p>
+      );
+    }
+    return (
+      <p className="muted v2-add-provider-note" role="note">
+        {hits.map(h => `${h.label ?? h.name}${makesLine(h, pick) === null ? '' : ` (${makesLine(h, pick)})`}`).join(' · ')}
+      </p>
+    );
+  }
+  return (
+    <p className="muted v2-add-provider-note" role="note">
+      {v.note === undefined ? null : <>{v.note} </>}
+      {v.getKey === undefined ? null : (
+        <a href={v.getKey} target="_blank" rel="noreferrer">
+          Get a key
+        </a>
+      )}
+      {v.setup === undefined ? null : (
+        <a href={v.setup} target="_blank" rel="noreferrer">
+          How to set up {v.name}
+        </a>
+      )}
+      {v.baseURLFields === undefined ? null : <> Fill in {v.baseURLFields.map(f => `{${f}}`).join(', ')} in the base URL.</>}
+      {v.unverified === true ? <> The base URL was not verified against the vendor’s docs; check it.</> : null}
+    </p>
+  );
+}

--- a/runtime/ui/src/v2/settings/AddProvider.tsx
+++ b/runtime/ui/src/v2/settings/AddProvider.tsx
@@ -43,7 +43,17 @@ export function AddProvider({ have, onAdd, onAddBlank }: AddProviderProps): JSX.
           {offer.map(v => (
             <li key={v.prefix}>
               {/* One click, one provider. No second button to press. */}
-              <button type="button" className="v2-add-one" onClick={() => onAdd(v)}>
+              <button
+                type="button"
+                className="v2-add-one"
+                onClick={() => {
+                  // Clear any half-typed search: it would otherwise sit
+                  // there with another vendor's "Get a key" link beside the
+                  // provider that was just added.
+                  setPick('');
+                  onAdd(v);
+                }}
+              >
                 <span className="v2-add-name">{v.label ?? v.name}</span>
                 <span className="v2-add-what">{blurb(v)}</span>
               </button>

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -74,6 +74,14 @@ afterEach(() => {
   sessionStorage.clear();
 });
 
+/** The model field of the block showing `model`. Two rows of one vendor are
+ * two blocks now, so a label alone is ambiguous. */
+function modelField(label: string, value: string): HTMLInputElement {
+  const found = (screen.getAllByLabelText(label) as HTMLInputElement[]).find(el => el.value === value);
+  if (found === undefined) throw new Error(`no ${label} field showing ${value}`);
+  return found;
+}
+
 /** The full catalog now sits behind "Someone else" — the common providers
  * are named and clicked directly. Tests that search it open it first. */
 async function openCatalog(): Promise<HTMLElement> {
@@ -174,7 +182,7 @@ describe('SettingsPage', () => {
     expect(screen.getAllByLabelText('Id')).toHaveLength(before);
   });
 
-  test('a blank row leads with the one field it needs', async () => {
+  test('a blank row shows the one field it needs, without moving it', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
     await waitFor(() => expect(screen.getByRole('list', { name: 'Providers you can use' })).toBeTruthy());
@@ -185,15 +193,17 @@ describe('SettingsPage', () => {
     const ids = screen.getAllByLabelText('Id');
     expect(ids).toHaveLength(before + 1);
 
-    // There is no vendor to list models for, so the Id field takes the lead
-    // instead of hiding under "the rest of this row" — which left the row
-    // saying "name it below" and pointing at nothing.
+    // Visible because its fold is OPEN, not because the field lives
+    // somewhere else while the vendor is unknown. Moving it once the id
+    // became recognisable remounted the input and dropped focus mid-word.
     const added = ids[ids.length - 1] as HTMLElement;
-    expect(added.closest('.v2-provider-main')).not.toBeNull();
-    expect(added.closest('details')).toBeNull();
-    // A row that DOES name a vendor keeps its id folded away, where it was.
+    const fold = added.closest('details');
+    expect(fold).not.toBeNull();
+    expect((fold as HTMLDetailsElement).open).toBe(true);
+    // A row that names a known vendor keeps its id folded away, where the
+    // rest of its settings are.
     const known = ids[0] as HTMLElement;
-    expect(known.closest('details')).not.toBeNull();
+    expect((known.closest('details') as HTMLDetailsElement).open).toBe(false);
   });
 
   test('a search nobody serves says so, instead of offering everything', async () => {
@@ -523,14 +533,14 @@ describe('SettingsPage, the model picker on a provider row (providers spec §4)'
   test("the row lists the vendor's models with context sizes; a pick rewrites the id; refresh asks again", async () => {
     const { listed } = installWithModels(() => json({ models: [{ id: 'gpt-5.6', contextTokens: 400000 }, { id: 'gpt-5.6-mini', contextTokens: 128000 }], source: 'list' }));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByLabelText('OpenAI model')).toBeTruthy());
-    expect((screen.getByLabelText('OpenAI model') as HTMLInputElement).value).toBe('gpt-5.6');
-    await waitFor(() => expect(screen.getByText(/2 models listed/)).toBeTruthy());
+    await waitFor(() => expect(screen.getAllByLabelText('OpenAI model').length).toBeGreaterThan(0));
+    expect(modelField('OpenAI model', 'gpt-5.6')).toBeTruthy();
+    await waitFor(() => expect(screen.getAllByText(/2 models listed/).length).toBeGreaterThan(0));
     expect(listed).toEqual(['/providers/openai/models']);
 
     // Every provider has a block, so each control is reached through its
     // own — not by document-wide role.
-    const block = screen.getByLabelText('OpenAI model').closest('.v2-yours-model') as HTMLElement;
+    const block = modelField('OpenAI model', 'gpt-5.6').closest('.v2-yours-model') as HTMLElement;
 
     // Choosing from the list applies at once — no separate Save, and no
     // id to retype.
@@ -539,9 +549,13 @@ describe('SettingsPage, the model picker on a provider row (providers spec §4)'
     await waitFor(() => expect(puts).toHaveLength(1));
     expect((puts[0] as { providers: { id: string }[] }).providers[0]!.id).toBe('openai/gpt-5.6-mini');
 
-    await userEvent.click(within(block).getByRole('button', { name: 'refresh' }));
-    await waitFor(() => expect(listed).toHaveLength(2));
-    expect(listed[1]).toBe('/providers/openai/models?refresh=1');
+    // Re-query: a save rebuilds the form from the response, which mints new
+    // row keys and so remounts the blocks — the node captured above is
+    // detached, and clicking it would do nothing. Asking again is what
+    // matters here, not the exact number of listings.
+    const after = modelField('OpenAI model', 'gpt-5.6').closest('.v2-yours-model') as HTMLElement;
+    await userEvent.click(within(after).getByRole('button', { name: 'refresh' }));
+    await waitFor(() => expect(listed.some(u => u === '/providers/openai/models?refresh=1')).toBe(true));
   });
 
   test('only the row that is showing is rewritten, never every row of the vendor', async () => {
@@ -555,9 +569,9 @@ describe('SettingsPage, the model picker on a provider row (providers spec §4)'
     };
     installWithModels(() => json({ models: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }], source: 'list' }), two);
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByLabelText('OpenAI model')).toBeTruthy());
+    await waitFor(() => expect(screen.getAllByLabelText('OpenAI model').length).toBeGreaterThan(0));
 
-    const block = screen.getByLabelText('OpenAI model').closest('.v2-yours-model') as HTMLElement;
+    const block = modelField('OpenAI model', 'gpt-5.6').closest('.v2-yours-model') as HTMLElement;
     await userEvent.click(within(block).getByRole('button', { name: 'Show models' }));
     await userEvent.click(screen.getByText('gpt-5.6-mini'));
 
@@ -586,10 +600,9 @@ describe('SettingsPage, the model picker on a provider row (providers spec §4)'
     };
     installWithModels(() => json({ models: [{ id: 'gpt-5.6' }, { id: 'gpt-5.6-mini' }], source: 'list' }), defaulted);
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByLabelText('OpenAI model')).toBeTruthy());
-    expect((screen.getByLabelText('OpenAI model') as HTMLInputElement).value).toBe('gpt-4o-mini');
-
-    const block = screen.getByLabelText('OpenAI model').closest('.v2-yours-model') as HTMLElement;
+    await waitFor(() => expect(screen.getAllByLabelText('OpenAI model').length).toBeGreaterThan(0));
+    // The row the file names is the one with a block to edit.
+    const block = modelField('OpenAI model', 'gpt-4o-mini').closest('.v2-yours-model') as HTMLElement;
     await userEvent.click(within(block).getByRole('button', { name: 'Show models' }));
     await userEvent.click(screen.getByText('gpt-5.6-mini'));
 
@@ -682,5 +695,67 @@ describe('the Task field (routing-and-evals spec §3)', () => {
     await user.clear(field);
     await user.type(field, 'classify');
     expect(field.value).toBe('classify');
+  });
+});
+
+describe('SettingsPage, adding a provider (the founder’s "it’s unclear what to do")', () => {
+  test('the common providers are named, and one click adds one', async () => {
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await waitFor(() => expect(screen.getByRole('list', { name: 'Providers you can use' })).toBeTruthy());
+    const before = screen.getAllByLabelText('Id').length;
+
+    // No typing, no second button: the thing the page most wants you to do
+    // is one click.
+    await userEvent.click(screen.getByRole('button', { name: /OpenAI/ }));
+
+    const ids = (screen.getAllByLabelText('Id') as HTMLInputElement[]).map(el => el.value);
+    expect(ids).toHaveLength(before + 1);
+    expect(ids).toContain('openai/');
+    // Nothing was saved: a provider is set up on its block first.
+    expect(puts).toHaveLength(0);
+    // And it drops off the offer list, so every remaining choice is one you
+    // can actually make.
+    expect(screen.queryByRole('button', { name: /^OpenAI/ })).toBeNull();
+  });
+
+  test('a blank row can be TYPED into, one field, one focus', async () => {
+    // The block used to be keyed on the row's prefix, which changes with
+    // every keystroke in an Id field — so the block remounted and dropped
+    // focus after each character. Setting the value in one go hid it, which
+    // is why the suite missed it.
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await openCatalog();
+    await userEvent.click(screen.getByRole('button', { name: 'or add a blank row' }));
+
+    const user = userEvent.setup({ document });
+    const ids = screen.getAllByLabelText('Id') as HTMLInputElement[];
+    const blank = ids[ids.length - 1]!;
+    await user.click(blank);
+    await user.keyboard('openai/gpt-5.6');
+
+    const after = screen.getAllByLabelText('Id') as HTMLInputElement[];
+    expect(after[after.length - 1]!.value).toBe('openai/gpt-5.6');
+    expect(document.activeElement).toBe(after[after.length - 1]!);
+  });
+
+  test('a second row of a vendor you have is still editable and removable', async () => {
+    // Folding by vendor hid it entirely: no fields, no Remove, and its
+    // errors had nowhere to render — Save refused with nothing marked.
+    install(() => json(view));
+    render(<SettingsPage health={health} />);
+    await openCatalog();
+    await userEvent.click(screen.getByRole('button', { name: 'or add a blank row' }));
+    await userEvent.click(screen.getByRole('button', { name: 'or add a blank row' }));
+
+    expect(screen.getAllByLabelText('Id')).toHaveLength(3);
+    // Scoped to the providers: a task route has a Remove of its own.
+    const list = screen.getByRole('list', { name: 'Providers you can use' });
+    expect(within(list).getAllByRole('button', { name: /^Remove / })).toHaveLength(3);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+    await waitFor(() => expect(screen.getAllByText('id is required')).toHaveLength(2));
+    expect(puts).toHaveLength(0);
   });
 });

--- a/runtime/ui/src/v2/settings/SettingsPage.test.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.test.tsx
@@ -74,6 +74,17 @@ afterEach(() => {
   sessionStorage.clear();
 });
 
+/** The full catalog now sits behind "Someone else" — the common providers
+ * are named and clicked directly. Tests that search it open it first. */
+async function openCatalog(): Promise<HTMLElement> {
+  const open = screen.queryByRole('combobox', { name: 'Search by maker or vendor' });
+  if (open !== null) return open;
+  // The page may still be loading its settings, so wait for the link
+  // rather than deciding it is absent.
+  await userEvent.click(await waitFor(() => screen.getByRole('button', { name: 'Someone else' })));
+  return await waitFor(() => screen.getByRole('combobox', { name: 'Search by maker or vendor' }));
+}
+
 describe('SettingsPage', () => {
   test('is grouped by what the operator came to do, each group with a purpose line', async () => {
     install(() => json(view));
@@ -127,6 +138,7 @@ describe('SettingsPage', () => {
     // A blank row makes the form invalid. Clicking "use this one" then used
     // to flip the table to the new default and send nothing — and the only
     // message said so from inside a collapsed disclosure.
+    await openCatalog();
     await userEvent.click(screen.getByRole('button', { name: 'or add a blank row' }));
     await userEvent.click(screen.getByRole('button', { name: 'Use Ollama' }));
 
@@ -154,7 +166,7 @@ describe('SettingsPage', () => {
     const before = screen.getAllByLabelText('Id').length;
 
     const user = userEvent.setup({ document });
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'Local runners · Ollama');
+    await user.type(await openCatalog(), 'Local runners · Ollama');
     await user.keyboard('{Escape}');
     await userEvent.click(screen.getByRole('button', { name: 'Add' }));
 
@@ -168,6 +180,7 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByRole('list', { name: 'Providers you can use' })).toBeTruthy());
 
     const before = screen.getAllByLabelText('Id').length;
+    await openCatalog();
     await userEvent.click(screen.getByRole('button', { name: 'or add a blank row' }));
     const ids = screen.getAllByLabelText('Id');
     expect(ids).toHaveLength(before + 1);
@@ -189,7 +202,7 @@ describe('SettingsPage', () => {
     await waitFor(() => expect(screen.getByRole('list', { name: 'Providers you can use' })).toBeTruthy());
 
     const user = userEvent.setup({ document });
-    const box = screen.getByRole('combobox', { name: 'Search by maker or vendor' });
+    const box = await openCatalog();
     // This field's own list: `queryAllByRole('option')` is document-wide,
     // and every other combobox on the page has one too.
     const list = (): HTMLElement[] => Array.from(box.closest('.v2-combo')?.querySelectorAll('[role="option"]') ?? []) as HTMLElement[];
@@ -280,7 +293,7 @@ describe('SettingsPage', () => {
     // `userEvent.setup({ document })`: the direct API infers its document
     // from the element it is handed, and `keyboard` is given none.
     const user = userEvent.setup({ document });
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'llama');
+    await user.type(await openCatalog(), 'llama');
 
     // Meta sells no API; every vendor that serves Llama has to answer to it,
     // or the maker looks absent from the app.
@@ -301,10 +314,10 @@ describe('SettingsPage', () => {
   test('the catalog picker prefills a provider row without saving anything', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Search by maker or vendor' })).toBeTruthy());
+    await openCatalog();
     const user = userEvent.setup({ document });
     const before = (screen.getAllByLabelText('Id') as HTMLInputElement[]).length;
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'Ollama');
+    await user.type(await openCatalog(), 'Ollama');
     await user.keyboard('{Escape}');
     await userEvent.click(screen.getByRole('button', { name: 'Add' }));
     const ids = screen.getAllByLabelText('Id') as HTMLInputElement[];
@@ -394,8 +407,8 @@ describe('SettingsPage, signing out', () => {
 describe('SettingsPage, the vendor catalog (providers spec §3, §6)', () => {
   async function pick(text: string): Promise<void> {
     const user = userEvent.setup({ document });
-    await user.clear(screen.getByRole('combobox', { name: 'Search by maker or vendor' }));
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), text);
+    await user.clear(await openCatalog());
+    await user.type(await openCatalog(), text);
     await user.keyboard('{Escape}');
     await userEvent.click(screen.getByRole('button', { name: 'Add' }));
   }
@@ -403,7 +416,7 @@ describe('SettingsPage, the vendor catalog (providers spec §3, §6)', () => {
   test('the picker covers the catalog in three groups and prefills prefix, key variable and a preset base URL', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Search by maker or vendor' })).toBeTruthy());
+    await openCatalog();
     // No button per vendor: one field, one Add.
     expect(screen.queryByRole('button', { name: 'Add Google Gemini' })).toBeNull();
     expect(screen.getByRole('button', { name: 'Add' })).toBeTruthy();
@@ -423,7 +436,7 @@ describe('SettingsPage, the vendor catalog (providers spec §3, §6)', () => {
   test('each provider row says where its text goes, from its id and base URL', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Search by maker or vendor' })).toBeTruthy());
+    await openCatalog();
     // The fixture's row is an OpenAI-compatible loopback server: local.
     expect(screen.getAllByRole('note').some((el: Element) => el.textContent?.includes('local · nothing leaves this machine'))).toBe(true);
     await pick('Google Gemini');
@@ -435,9 +448,9 @@ describe('SettingsPage, the vendor catalog (providers spec §3, §6)', () => {
   test('an unverified preset says so before it is added', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Search by maker or vendor' })).toBeTruthy());
+    await openCatalog();
     const user = userEvent.setup({ document });
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'SambaNova');
+    await user.type(await openCatalog(), 'SambaNova');
     await user.keyboard('{Escape}');
     expect(screen.getAllByRole('note').some((el: Element) => el.textContent?.includes('not verified'))).toBe(true);
   });
@@ -462,12 +475,12 @@ describe('SettingsPage, provider keys (providers spec §5)', () => {
     expect(screen.getByRole('link', { name: 'get a key' })).toBeTruthy();
     // The ledger's Keys fact.
     expect(screen.getByText('Keychain')).toBeTruthy();
-    // Copy: the purpose line names the Keychain, and mentions the environment once, for headless use only.
-    // The Keychain sentence sits with the rows it is about, not in a
-    // paragraph over the whole group.
-    const added = screen.getByText(/Saved to your providers file/).textContent ?? '';
-    expect(added).toContain('Keychain');
-    expect(added).not.toContain('OPENAI_API_KEY');
+    // Copy: the group's opening line says where providers are saved and
+    // where a key goes, and never sends a lawyer to an environment
+    // variable — that is for headless use only.
+    const opening = screen.getByText(/One key per provider/).textContent ?? '';
+    expect(opening).toContain('Keychain');
+    expect(opening).not.toContain('OPENAI_API_KEY');
   });
 
   test('a runtime without a store: the ledger says so and the row offers no paste', async () => {
@@ -624,12 +637,11 @@ describe('the enterprise vendors in Settings (providers spec §3 step 5)', () =>
   test('the picker lists them under Hosted API · enterprise; adding one prefills the row with its field set and defaults, no key variable', async () => {
     install(() => json(view));
     render(<SettingsPage health={health} />);
-    await waitFor(() => expect(screen.getByRole('combobox', { name: 'Search by maker or vendor' })).toBeTruthy());
+    await openCatalog();
     const user = userEvent.setup({ document });
-    await user.type(screen.getByRole('combobox', { name: 'Search by maker or vendor' }), 'Hosted API · enterprise · Google Vertex AI');
+    await user.type(await openCatalog(), 'Hosted API · enterprise · Google Vertex AI');
     await user.keyboard('{Escape}');
     expect(screen.getByRole('link', { name: 'How to set up Google Vertex AI' })).toBeTruthy();
-    expect(screen.getByText(/they go to your Keychain as one item/)).toBeTruthy();
     await userEvent.click(screen.getByRole('button', { name: 'Add' }));
     const ids = screen.getAllByLabelText('Id') as HTMLInputElement[];
     expect(ids.map(el => el.value)).toContain('vertex/');

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -4,7 +4,7 @@ import type { Health as HealthData, SettingsErrorBody, SettingsView } from '../.
 import { Health } from '../../settings/Health';
 import { ProviderCombo } from '../../settings/ProviderCombo';
 import { ProviderTest } from '../../settings/ProviderTest';
-import { dataLineFor, isEnterpriseVendor, keyBelongsToRow, makesLine, pickerLabel, prefixOf, searchVendors, vendorByPickerLabel, vendorFor } from '../vendors';
+import { dataLineFor, isEnterpriseVendor, keyBelongsToRow, prefixOf, vendorFor } from '../vendors';
 import { EnterpriseFields } from './EnterpriseFields';
 import { KeyControl } from './KeyControl';
 import { AddProvider } from './AddProvider';
@@ -131,26 +131,12 @@ function seedDefault(form: FormState, view: SettingsView): FormState {
   return { ...form, default: effective };
 }
 
-/**
- * The picker's options for a query.
- *
- * An empty box offers the whole catalog. A query that finds nothing offers
- * NOTHING — falling back to everything looked like thirty-odd matches: type
- * `gemini pro` (no vendor's text holds `pro`) and the list answered with
- * every vendor there is, as if all of them served it.
- */
-function searchOptions(query: string): string[] {
-  return searchVendors(query).map(pickerLabel);
-}
-
 function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: SettingsView): void }): JSX.Element {
   const [form, setForm] = useState<FormState>(() => seedDefault(formFromRegistry(view.registry), view));
   const [errors, setErrors] = useState<FieldErrors>({});
   const [general, setGeneral] = useState<string[]>([]);
   const [saved, setSaved] = useState(false);
   const [busy, setBusy] = useState(false);
-  /** The catalog picker's text (providers spec §3). */
-  const [pick, setPick] = useState('');
   /** The provider whose key last changed, so its model list is re-asked. */
   const [relist, setRelist] = useState<{ prefix: string; n: number } | null>(null);
 
@@ -245,13 +231,6 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
    * be saved. */
   const haveVendor = (prefix: string): boolean =>
     effectiveIds.some(id => prefixOf(id) === prefix) || form.providers.some(r => prefixOf(r.id.trim()) === prefix);
-
-  /** A saved row's base URL for a vendor, so a local runner's model list is
-   * asked for at the address that row names rather than the preset. */
-  const baseURLOf = (prefix: string): string | undefined => {
-    const row = form.providers.find(r => prefixOf(r.id.trim()) === prefix && r.baseURL.trim() !== '');
-    return row?.baseURL.trim();
-  };
 
   /**
    * Run a provider on a different model.
@@ -395,11 +374,15 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
       {row.id.trim() === '' ? 'name it below' : <code>{row.id.trim()}</code>}
     </span>
       </p>
-      {rowVendor === undefined ? <div className="v2-provider-main">{idField}</div> : null}
-      <details className="v2-provider-advanced" open={rowHasError}>
+      {/* The Id field NEVER moves. It used to render outside the fold while
+          the vendor was unrecognised and inside it once it was — so typing
+          `openai` into a blank row moved the input to a new parent at the
+          sixth character, remounting it and dropping focus mid-word. The
+          fold just opens instead. */}
+      <details className="v2-provider-advanced" open={rowHasError || rowVendor === undefined}>
     <summary>the rest of this row</summary>
       <div className="v2-provider-grid">
-    {rowVendor === undefined ? null : idField}
+    {idField}
     <div className="field">
       <label htmlFor={`v2-${row.key}-baseurl`}>baseURL</label>
       <input id={`v2-${row.key}-baseurl`} value={row.baseURL} placeholder={enterprise ? 'optional — a private endpoint' : 'https://…'} onChange={e => patchRow(index, { baseURL: e.target.value })} />
@@ -454,12 +437,15 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
       <button
     type="button"
     className="v2-link v2-remove"
+    // Named for the provider, not for its position in the file: this sits
+    // on that provider's own block, where "provider 2" means nothing.
+    aria-label={`Remove ${row.id.trim() === '' ? 'this provider' : row.id.trim()}`}
     onClick={() => {
       patch({ providers: form.providers.filter((_, i) => i !== index) });
       setErrors({});
     }}
       >
-    Remove provider {index + 1}
+    remove this provider
       </button>
     </div>
     );
@@ -490,15 +476,16 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           defaultId={form.default}
           builtinDefault={showingBuiltin}
           busy={busy}
-          baseURLOf={baseURLOf}
           onMakeDefault={id => void save({ default: id })}
-          fileIds={new Set(form.providers.map(r => r.id.trim()))}
-          // A provider you just added is not loaded yet, so nothing in
-          // `effective` speaks for it. Its block comes from the form row.
-          pendingIds={form.providers.map(r => r.id.trim()).filter(id => !effectiveIds.includes(id))}
-          extraOf={prefix => form.providers.find(r => prefixOf(r.id.trim()) === prefix)?.extra}
+          // Every row of the practice's file gets a block — including one
+          // added a moment ago, which nothing in `effective` speaks for yet.
+          rows={form.providers.map(r => ({ key: r.key, id: r.id, baseURL: r.baseURL.trim() === '' ? undefined : r.baseURL, extra: r.extra }))}
+          // BY THE ROW'S KEY, never by its prefix: two rows can share a
+          // vendor, and a block was showing one row's model over another
+          // row's fields — with a Remove button that deleted the provider
+          // you were not looking at.
           renderKey={group => keyControlFor(group.id)}
-          renderDetails={group => providerDetails(form.providers.findIndex(r => prefixOf(r.id.trim()) === group.prefix))}
+          renderDetails={group => providerDetails(form.providers.findIndex(r => r.key === group.rowKey))}
           relist={relist}
           onPickModel={pickModel}
         />

--- a/runtime/ui/src/v2/settings/SettingsPage.tsx
+++ b/runtime/ui/src/v2/settings/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { ProviderTest } from '../../settings/ProviderTest';
 import { dataLineFor, isEnterpriseVendor, keyBelongsToRow, makesLine, pickerLabel, prefixOf, searchVendors, vendorByPickerLabel, vendorFor } from '../vendors';
 import { EnterpriseFields } from './EnterpriseFields';
 import { KeyControl } from './KeyControl';
+import { AddProvider } from './AddProvider';
 import { YourModels } from './YourModels';
 import { ContentGroup } from './ContentGroup';
 import { TASK_IDS } from '../../tasks';
@@ -355,6 +356,115 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
     );
   };
 
+  /**
+   * One provider's own settings: its id, where to reach it, what it can do.
+   *
+   * These live INSIDE that provider's block now. They used to be a second
+   * list further down the page — every provider written twice, once as a
+   * block you could use and once as a row you had to understand — which is
+   * most of what made the page incoherent.
+   */
+  const providerDetails = (index: number): JSX.Element | null => {
+    const row = form.providers[index];
+    if (row === undefined) return null;
+          const rowVendor = vendorFor(prefixOf(row.id.trim()));
+    const enterprise = isEnterpriseVendor(rowVendor);
+    // A row nobody can fix is a row folded shut over its own error.
+    const rowHasError = Object.keys(errors).some(key => key.startsWith(`providers.${index}.`));
+    // The Id field leads the row when there is no vendor to name a
+    // model for: a blank row folded its only usable control away, and
+    // said "give it an id below" pointing at nothing.
+    const idField = (
+      <div className="field">
+    <label htmlFor={`v2-${row.key}-id`}>Id</label>
+    <input id={`v2-${row.key}-id`} value={row.id} placeholder="openai/gpt-5.6" onChange={e => patchRow(index, { id: e.target.value })} />
+    <FieldError message={errors[`providers.${index}.id`]} />
+      </div>
+    );
+    return (
+    <div className="v2-provider" key={row.key}>
+      {/* What this row IS, before what it is made of. The MODEL is
+      not set here any more — it belongs to the provider block
+      above, which is the one place a model gets chosen. What is
+      left is the connection: where to reach it and how to sign
+      in. */}
+      <p className="v2-provider-head">
+    <strong>{rowVendor?.label ?? rowVendor?.name ?? 'A model'}</strong>
+    <span className="muted">
+      {' — '}
+      {row.id.trim() === '' ? 'name it below' : <code>{row.id.trim()}</code>}
+    </span>
+      </p>
+      {rowVendor === undefined ? <div className="v2-provider-main">{idField}</div> : null}
+      <details className="v2-provider-advanced" open={rowHasError}>
+    <summary>the rest of this row</summary>
+      <div className="v2-provider-grid">
+    {rowVendor === undefined ? null : idField}
+    <div className="field">
+      <label htmlFor={`v2-${row.key}-baseurl`}>baseURL</label>
+      <input id={`v2-${row.key}-baseurl`} value={row.baseURL} placeholder={enterprise ? 'optional — a private endpoint' : 'https://…'} onChange={e => patchRow(index, { baseURL: e.target.value })} />
+      <FieldError message={errors[`providers.${index}.baseURL`]} />
+    </div>
+    {/* An enterprise vendor's credentials are fields, not one
+        variable; its field set below names the environment. */}
+    {enterprise ? null : (
+      <div className="field">
+        <label htmlFor={`v2-${row.key}-key`}>key variable (optional)</label>
+        <input id={`v2-${row.key}-key`} value={row.apiKeyEnv} placeholder="only for headless use" onChange={e => patchRow(index, { apiKeyEnv: e.target.value })} />
+        <FieldError message={errors[`providers.${index}.apiKeyEnv`]} />
+      </div>
+    )}
+    <TriField id={`v2-${row.key}-tools`} label="tools" value={row.tools} onChange={value => patchRow(index, { tools: value })} />
+    <TriField id={`v2-${row.key}-caching`} label="caching" value={row.caching} onChange={value => patchRow(index, { caching: value })} />
+    <TriField id={`v2-${row.key}-thinking`} label="thinking" value={row.thinking} onChange={value => patchRow(index, { thinking: value })} />
+    <div className="field">
+      <label htmlFor={`v2-${row.key}-context`}>contextTokens</label>
+      <input id={`v2-${row.key}-context`} type="number" min="1" step="1" value={row.contextTokens} onChange={e => patchRow(index, { contextTokens: e.target.value })} />
+      <FieldError message={errors[`providers.${index}.capabilities.contextTokens`]} />
+    </div>
+    <div className="field">
+      <label htmlFor={`v2-${row.key}-auth`}>auth</label>
+      <select id={`v2-${row.key}-auth`} value={row.auth} onChange={e => patchRow(index, { auth: e.target.value as ProviderRow['auth'] })}>
+        <option value="">default</option>
+        <option value="subscription">subscription</option>
+        <option value="apikey">apikey</option>
+        <option value="local">local</option>
+      </select>
+    </div>
+      </div>
+      </details>
+      {/* Where this row's text goes (providers spec §6): from the id's
+      prefix and, for an OpenAI-compatible server, its base URL. */}
+      {(() => {
+    const line = dataLineFor(row.id.trim(), row.baseURL.trim() === '' ? undefined : row.baseURL.trim());
+    return line === null ? null : (
+      <p className={line.locality === 'local' ? 'v2-provider-data v2-provider-data-local' : 'v2-provider-data'} role="note">
+        {line.text}
+        {line.termsUrl === null ? null : (
+          <>
+            {' · '}
+            <a href={line.termsUrl} target="_blank" rel="noreferrer">
+              their terms
+            </a>
+          </>
+        )}
+      </p>
+    );
+      })()}
+      <button
+    type="button"
+    className="v2-link v2-remove"
+    onClick={() => {
+      patch({ providers: form.providers.filter((_, i) => i !== index) });
+      setErrors({});
+    }}
+      >
+    Remove provider {index + 1}
+      </button>
+    </div>
+    );
+  };
+
   // A `tasks.*` message with no row to sit on still has to be shown; it
   // joins the general notices by the Save button.
   const orphanedTaskMessages = unplacedTaskMessages(errors, form.routes);
@@ -373,7 +483,7 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
         <h2>Providers and models</h2>
         <p className="muted">
           The providers this runtime can call, and the model each one runs. Your Claude and ChatGPT subscriptions and a local Ollama model are set up
-          already; add any others below. One key per provider — every model it sells opens with the same one.
+          already. One key per provider — every model it sells opens with the same one, and it goes to your Keychain, never into your vault.
         </p>
         <YourModels
           providers={view.effective.providers}
@@ -385,9 +495,10 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           fileIds={new Set(form.providers.map(r => r.id.trim()))}
           // A provider you just added is not loaded yet, so nothing in
           // `effective` speaks for it. Its block comes from the form row.
-          pendingIds={form.providers.map(r => r.id.trim()).filter(id => id !== '' && !effectiveIds.includes(id))}
+          pendingIds={form.providers.map(r => r.id.trim()).filter(id => !effectiveIds.includes(id))}
           extraOf={prefix => form.providers.find(r => prefixOf(r.id.trim()) === prefix)?.extra}
           renderKey={group => keyControlFor(group.id)}
+          renderDetails={group => providerDetails(form.providers.findIndex(r => prefixOf(r.id.trim()) === group.prefix))}
           relist={relist}
           onPickModel={pickModel}
         />
@@ -398,198 +509,26 @@ function RegistryForm({ view, onSaved }: { view: SettingsView; onSaved(next: Set
           </p>
         )}
 
-        {/* One field over every vendor and preset — searched by NAME and by
-            the families it serves, so "llama" and "gemini" find something.
-            Picking prefills a row; nothing is saved until the one Save. */}
-        <div className="v2-add-model">
-          <h3 className="runin">Add a provider</h3>
-          <div className="v2-add-provider-row">
-            <ProviderCombo
-              id="v2-add-provider"
-              label="Search by maker or vendor"
-              value={pick}
-              options={searchOptions(pick)}
-              placeholder="llama · gemini · a vendor's name"
-              // The options ARE the search result; matching them against the
-              // typed text again would hide every vendor found by a family
-              // rather than by its own name, which is the point.
-              filter={() => true}
-              onChange={setPick}
-            />
-            <button
-              type="button"
-              disabled={vendorByPickerLabel(pick) === undefined}
-              onClick={() => {
-                const v = vendorByPickerLabel(pick);
-                if (v === undefined) return;
-                // One block per provider means one row per provider. A
-                // second row of a vendor you already have was a stub with
-                // no block of its own (the block folds by vendor), no model
-                // picker and no key — nothing on it could be filled in, and
-                // saving it wrote an id with no model into the file.
-                if (haveVendor(v.prefix)) {
-                  setGeneral([`You already have ${v.label ?? v.name}. Choose its model on its own row above.`]);
-                  setPick('');
-                  return;
-                }
-                setGeneral([]);
-                patch({ providers: [...form.providers, catalogRow(v)] });
-                setPick('');
-              }}
-            >
-              Add
-            </button>
-            <button type="button" className="v2-link" onClick={() => patch({ providers: [...form.providers, emptyRow()] })}>
-              or add a blank row
-            </button>
-          </div>
-          {(() => {
-            const v = vendorByPickerLabel(pick);
-            if (v === undefined) {
-              const hits = searchVendors(pick).slice(0, 4);
-              if (pick.trim() === '') return null;
-              if (hits.length === 0) {
-                return (
-                  <p className="muted v2-add-provider-note" role="note">
-                    Nothing matches <strong>{pick.trim()}</strong>. Search for a maker or a family — <em>llama</em>, <em>gemini</em>, <em>qwen</em> — or the
-                    vendor you buy from. Any server that speaks the OpenAI API works from a blank row.
-                  </p>
-                );
-              }
-              return (
-                <p className="muted v2-add-provider-note" role="note">
-                  {hits.map(h => `${h.label ?? h.name}${makesLine(h, pick) === null ? '' : ` (${makesLine(h, pick)})`}`).join(' · ')}
-                </p>
-              );
+        {/* Click the provider you want. The whole catalog is behind
+            "Someone else" for a practice that buys elsewhere. */}
+        <AddProvider
+          have={haveVendor}
+          onAdd={v => {
+            // One block per provider means one row per provider: a second
+            // row of a vendor you have folds into the same block, so
+            // nothing on it could be filled in.
+            if (haveVendor(v.prefix)) {
+              setGeneral([`You already have ${v.label ?? v.name}. Choose its model on its own row above.`]);
+              return;
             }
-            return (
-              <p className="muted v2-add-provider-note" role="note">
-                {v.note === undefined ? null : <>{v.note} </>}
-                {v.connection === 'API key' ? <>Add the row, save, then paste the key on it — it goes to your Keychain. </> : null}
-                {v.connection === 'fields' ? <>Add the row, fill in its fields, save, then paste the credentials on it — they go to your Keychain as one item. </> : null}
-                {v.getKey === undefined ? null : (
-                  <a href={v.getKey} target="_blank" rel="noreferrer">
-                    Get a key
-                  </a>
-                )}
-                {v.setup === undefined ? null : (
-                  <a href={v.setup} target="_blank" rel="noreferrer">
-                    How to set up {v.name}
-                  </a>
-                )}
-                {v.baseURLFields === undefined ? null : <> Fill in {v.baseURLFields.map(f => `{${f}}`).join(', ')} in the base URL.</>}
-                {v.unverified === true ? <> The base URL was not verified against the vendor’s docs; check it.</> : null}
-              </p>
-            );
-          })()}
-        </div>
-
-        {form.providers.length === 0 ? null : (
-          <>
-            <h3 className="runin v2-added-head">Rows you added</h3>
-            <p className="muted">
-              Saved to your providers file (its path is under Runtime, below). A key pasted on a row goes to your Keychain, never into the vault.
-            </p>
-          </>
-        )}
-        {form.providers.map((row, index) => {
-          const rowVendor = vendorFor(prefixOf(row.id.trim()));
-          const enterprise = isEnterpriseVendor(rowVendor);
-          // A row nobody can fix is a row folded shut over its own error.
-          const rowHasError = Object.keys(errors).some(key => key.startsWith(`providers.${index}.`));
-          // The Id field leads the row when there is no vendor to name a
-          // model for: a blank row folded its only usable control away, and
-          // said "give it an id below" pointing at nothing.
-          const idField = (
-            <div className="field">
-              <label htmlFor={`v2-${row.key}-id`}>Id</label>
-              <input id={`v2-${row.key}-id`} value={row.id} placeholder="openai/gpt-5.6" onChange={e => patchRow(index, { id: e.target.value })} />
-              <FieldError message={errors[`providers.${index}.id`]} />
-            </div>
-          );
-          return (
-          <div className="v2-provider" key={row.key}>
-            {/* What this row IS, before what it is made of. The MODEL is
-                not set here any more — it belongs to the provider block
-                above, which is the one place a model gets chosen. What is
-                left is the connection: where to reach it and how to sign
-                in. */}
-            <p className="v2-provider-head">
-              <strong>{rowVendor?.label ?? rowVendor?.name ?? 'A model'}</strong>
-              <span className="muted">
-                {' — '}
-                {row.id.trim() === '' ? 'name it below' : <code>{row.id.trim()}</code>}
-              </span>
-            </p>
-            {rowVendor === undefined ? <div className="v2-provider-main">{idField}</div> : null}
-            <details className="v2-provider-advanced" open={rowHasError}>
-              <summary>the rest of this row</summary>
-            <div className="v2-provider-grid">
-              {rowVendor === undefined ? null : idField}
-              <div className="field">
-                <label htmlFor={`v2-${row.key}-baseurl`}>baseURL</label>
-                <input id={`v2-${row.key}-baseurl`} value={row.baseURL} placeholder={enterprise ? 'optional — a private endpoint' : 'https://…'} onChange={e => patchRow(index, { baseURL: e.target.value })} />
-                <FieldError message={errors[`providers.${index}.baseURL`]} />
-              </div>
-              {/* An enterprise vendor's credentials are fields, not one
-                  variable; its field set below names the environment. */}
-              {enterprise ? null : (
-                <div className="field">
-                  <label htmlFor={`v2-${row.key}-key`}>key variable (optional)</label>
-                  <input id={`v2-${row.key}-key`} value={row.apiKeyEnv} placeholder="only for headless use" onChange={e => patchRow(index, { apiKeyEnv: e.target.value })} />
-                  <FieldError message={errors[`providers.${index}.apiKeyEnv`]} />
-                </div>
-              )}
-              <TriField id={`v2-${row.key}-tools`} label="tools" value={row.tools} onChange={value => patchRow(index, { tools: value })} />
-              <TriField id={`v2-${row.key}-caching`} label="caching" value={row.caching} onChange={value => patchRow(index, { caching: value })} />
-              <TriField id={`v2-${row.key}-thinking`} label="thinking" value={row.thinking} onChange={value => patchRow(index, { thinking: value })} />
-              <div className="field">
-                <label htmlFor={`v2-${row.key}-context`}>contextTokens</label>
-                <input id={`v2-${row.key}-context`} type="number" min="1" step="1" value={row.contextTokens} onChange={e => patchRow(index, { contextTokens: e.target.value })} />
-                <FieldError message={errors[`providers.${index}.capabilities.contextTokens`]} />
-              </div>
-              <div className="field">
-                <label htmlFor={`v2-${row.key}-auth`}>auth</label>
-                <select id={`v2-${row.key}-auth`} value={row.auth} onChange={e => patchRow(index, { auth: e.target.value as ProviderRow['auth'] })}>
-                  <option value="">default</option>
-                  <option value="subscription">subscription</option>
-                  <option value="apikey">apikey</option>
-                  <option value="local">local</option>
-                </select>
-              </div>
-            </div>
-            </details>
-            {/* Where this row's text goes (providers spec §6): from the id's
-                prefix and, for an OpenAI-compatible server, its base URL. */}
-            {(() => {
-              const line = dataLineFor(row.id.trim(), row.baseURL.trim() === '' ? undefined : row.baseURL.trim());
-              return line === null ? null : (
-                <p className={line.locality === 'local' ? 'v2-provider-data v2-provider-data-local' : 'v2-provider-data'} role="note">
-                  {line.text}
-                  {line.termsUrl === null ? null : (
-                    <>
-                      {' · '}
-                      <a href={line.termsUrl} target="_blank" rel="noreferrer">
-                        their terms
-                      </a>
-                    </>
-                  )}
-                </p>
-              );
-            })()}
-            <button
-              type="button"
-              className="v2-link v2-remove"
-              onClick={() => {
-                patch({ providers: form.providers.filter((_, i) => i !== index) });
-                setErrors({});
-              }}
-            >
-              Remove provider {index + 1}
-            </button>
-          </div>
-          );
-        })}
+            setGeneral([]);
+            patch({ providers: [...form.providers, catalogRow(v)] });
+          }}
+          onAddBlank={() => {
+            setGeneral([]);
+            patch({ providers: [...form.providers, emptyRow()] });
+          }}
+        />
       </section>
 
       <section className="v2-group">

--- a/runtime/ui/src/v2/settings/YourModels.test.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.test.tsx
@@ -71,152 +71,65 @@ describe('the name a lawyer reads', () => {
   });
 });
 
-describe('one block per provider', () => {
-  const rows = [
-    provider({ id: 'claude-sub/claude-opus-5', auth: 'subscription' }),
-    provider({ id: 'claude-sub/claude-sonnet-5', auth: 'subscription' }),
-    provider({ id: 'ollama/gemma4:e4b', auth: 'local', locality: 'local' }),
-  ];
+describe('one block per provider entry', () => {
+  const claude = provider({ id: 'claude-sub/claude-opus-5', auth: 'subscription' });
+  const sonnet = provider({ id: 'claude-sub/claude-sonnet-5', auth: 'subscription' });
+  const ollama = provider({ id: 'ollama/gemma4:e4b', auth: 'local', locality: 'local' });
 
-  test('the models of one vendor fold into one block', () => {
-    // Two Claude models loaded is not two providers to read past. It is
-    // Claude, running one of them.
-    const groups = groupProviders(rows, 'claude-sub/claude-opus-5');
-    expect(groups.map(g => g.prefix)).toEqual(['claude-sub', 'ollama']);
-    expect(groups[0]!.name).toBe('Claude');
-    expect(groups[0]!.model).toBe('claude-opus-5');
+  test('a row and the provider it produces are ONE block', () => {
+    const groups = groupProviders([claude, ollama], '', [{ key: 'r1', id: 'ollama/gemma4:e4b' }]);
+    expect(groups).toHaveLength(2);
+    // The row's block is the editable one; the built-in Claude has none.
+    expect(groups.find(g => g.prefix === 'ollama')!.rowKey).toBe('r1');
+    expect(groups.find(g => g.prefix === 'claude-sub')!.rowKey).toBeUndefined();
   });
 
-  test('the block shows the model that actually answers, wherever it sits', () => {
-    // The default is the SECOND Claude loaded; the block must show that one,
-    // not the first it happened to meet.
-    const groups = groupProviders(rows, 'claude-sub/claude-sonnet-5');
-    expect(groups[0]!.model).toBe('claude-sonnet-5');
-    expect(groups[0]!.id).toBe('claude-sub/claude-sonnet-5');
+  test('two rows of one vendor are two blocks, each with its own identity', () => {
+    // Folding them into one made the second invisible: no fields, no
+    // Remove, and its validation errors had nowhere to render — Save
+    // refused with nothing marked.
+    const groups = groupProviders([], '', [
+      { key: 'r1', id: 'openai/gpt-5.6' },
+      { key: 'r2', id: 'openai/gpt-4o-mini' },
+    ]);
+    expect(groups).toHaveLength(2);
+    expect(groups.map(g => g.rowKey)).toEqual(['r1', 'r2']);
+    expect(new Set(groups.map(g => g.key)).size).toBe(2);
   });
 
-  test('with no default, the first loaded model stands for its provider', () => {
-    expect(groupProviders(rows, '').map(g => g.model)).toEqual(['claude-opus-5', 'gemma4:e4b']);
+  test("a block's key does not change when its id does", () => {
+    // The block is keyed on this. Keyed on the prefix, every keystroke in
+    // an Id field remounted the block and dropped focus — one character
+    // per click.
+    const before = groupProviders([], '', [{ key: 'r1', id: '' }])[0]!.key;
+    const after = groupProviders([], '', [{ key: 'r1', id: 'openai/gpt-5.6' }])[0]!.key;
+    expect(before).toBe(after);
   });
 
-  test('an unknown prefix still gets a block, under its own name', () => {
-    const groups = groupProviders([provider({ id: 'mystery/m', auth: 'apikey', keySet: true })], '');
-    expect(groups).toHaveLength(1);
-    expect(groups[0]!.name).toBe('mystery');
-  });
-});
-
-describe('choosing a model on a provider block', () => {
-  const rows = [provider({ id: 'xai/grok-4', auth: 'apikey', locality: 'cloud', keySet: true })];
-  const realFetch = globalThis.fetch;
-  let picks: Array<{ id: string; model: string }> = [];
-
-  function show(opts: { models: string[]; saves?: boolean } = { models: [] }): void {
-    picks = [];
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.startsWith('/providers/') && url.includes('/models')) {
-        return new Response(JSON.stringify({ models: opts.models.map(id => ({ id })), source: 'list' }), { headers: { 'content-type': 'application/json' } });
-      }
-      throw new Error(`unexpected fetch: ${url}`);
-    }) as unknown as typeof fetch;
-    render(
-      <YourModels
-        providers={rows}
-        defaultId="xai/grok-4"
-        builtinDefault={false}
-        busy={false}
-        baseURLOf={() => undefined}
-        fileIds={new Set(['xai/grok-4'])}
-        pendingIds={[]}
-        onMakeDefault={() => {}}
-        onPickModel={async (id, model) => {
-          picks.push({ id, model });
-          return opts.saves ?? true;
-        }}
-      />,
-    );
-  }
-
-  afterEach(() => {
-    globalThis.fetch = realFetch;
+  test('a loaded provider no row accounts for still gets a block', () => {
+    const groups = groupProviders([claude, sonnet], '', []);
+    expect(groups.map(g => g.model)).toEqual(['claude-opus-5', 'claude-sonnet-5']);
+    expect(groups.every(g => g.rowKey === undefined)).toBe(true);
   });
 
-  test('typing a model that PASSES THROUGH another one saves only what was chosen', async () => {
-    // xAI really sells both `grok-4` and `grok-4-fast`, and OpenAI both
-    // `gpt-5.6` and `gpt-5.6-mini`. Saving whenever the text spelled a
-    // listed model committed `grok-4` at the sixth keystroke and then reset
-    // the field to it, under the hand still typing `-fast`.
-    show({ models: ['grok-4', 'grok-4-fast'] });
-    await waitFor(() => expect(screen.getByText(/2 models listed/)).toBeTruthy());
-    const user = userEvent.setup({ document });
-    const box = screen.getByLabelText('xAI model');
-    await user.clear(box);
-    await user.type(box, 'grok-4-fast');
-    expect(picks).toEqual([]);
-    expect((box as HTMLInputElement).value).toBe('grok-4-fast');
-  });
-
-  test('a model the list does not carry is saved once, when the field is left', async () => {
-    show({ models: [] });
-    // Let the listing land first: it re-renders the field, and a keystroke
-    // racing that re-render is a test artefact, not a behaviour.
-    await waitFor(() => expect(screen.getByText(/0 models listed/)).toBeTruthy());
-    const user = userEvent.setup({ document });
-    const box = screen.getByLabelText('xAI model');
-    await user.clear(box);
-    await user.type(box, 'grok-5-unreleased');
-    expect(picks).toEqual([]);
-    // The first tab lands on the combo's own toggle, which is still inside
-    // the block — that is not leaving it, and must not save.
-    await user.tab();
-    expect(picks).toEqual([]);
-    await user.tab();
-    await waitFor(() => expect(picks).toEqual([{ id: 'xai/grok-4', model: 'grok-5-unreleased' }]));
-    // Once. `group.model` only catches up when the save returns, so the
-    // guard has to remember what it already sent.
-    await user.tab();
-    expect(picks).toHaveLength(1);
-  });
-
-  test('a save the page refused puts the field back', async () => {
-    // Another row on the page is incomplete, so nothing was written. The
-    // field must not go on showing a model the file does not have.
-    show({ models: [], saves: false });
-    await waitFor(() => expect(screen.getByText(/0 models listed/)).toBeTruthy());
-    const user = userEvent.setup({ document });
-    const box = screen.getByLabelText('xAI model');
-    await user.clear(box);
-    await user.type(box, 'grok-5-unreleased');
-    await user.tab();
-    await user.tab();
-    await waitFor(() => expect(picks).toHaveLength(1));
-    await waitFor(() => expect((box as HTMLInputElement).value).toBe('grok-4'));
-  });
-
-  test('leaving the field having changed nothing saves nothing', async () => {
-    show({ models: ['grok-4'] });
-    await waitFor(() => expect(screen.getByText(/1 model listed/)).toBeTruthy());
-    const user = userEvent.setup({ document });
-    await user.click(screen.getByLabelText('xAI model'));
-    await user.tab();
-    await user.tab();
-    expect(picks).toEqual([]);
+  test('the one that answers leads, then your own rows, then the built-ins', () => {
+    const groups = groupProviders([claude, ollama], 'ollama/gemma4:e4b', [{ key: 'r1', id: 'ollama/gemma4:e4b' }]);
+    expect(groups[0]!.id).toBe('ollama/gemma4:e4b');
   });
 });
 
 describe('which model a block stands for', () => {
-  test('your own row beats a built-in of the same vendor', () => {
-    // `loadRegistry` loads the built-ins FIRST. Without this rule, picking
-    // `qwen3:32b` on the Ollama block saved correctly and then re-rendered
-    // as the built-in `gemma4:e4b` — the pick looked refused.
+  test('your own row leads the built-in of the same vendor', () => {
+    // Both are genuinely loaded, so both are shown — but the one you can
+    // edit comes first. Picking `qwen3:32b` used to save correctly and then
+    // re-render as the built-in `gemma4:e4b`, so the pick looked refused.
     const loaded = [
       provider({ id: 'ollama/gemma4:e4b', auth: 'local', locality: 'local' }),
       provider({ id: 'ollama/qwen3:32b', auth: 'local', locality: 'local' }),
     ];
-    const groups = groupProviders(loaded, 'claude-sub/claude-opus-5', new Set(['ollama/qwen3:32b']));
-    expect(groups).toHaveLength(1);
-    expect(groups[0]!.model).toBe('qwen3:32b');
+    const groups = groupProviders(loaded, 'claude-sub/claude-opus-5', [{ key: 'r1', id: 'ollama/qwen3:32b' }]);
+    expect(groups.map(g => g.model)).toEqual(['qwen3:32b', 'gemma4:e4b']);
+    expect(groups[0]!.rowKey).toBe('r1');
   });
 
   test('the model that answers beats even your own row', () => {
@@ -224,7 +137,7 @@ describe('which model a block stands for', () => {
       provider({ id: 'ollama/gemma4:e4b', auth: 'local', locality: 'local' }),
       provider({ id: 'ollama/qwen3:32b', auth: 'local', locality: 'local' }),
     ];
-    const groups = groupProviders(loaded, 'ollama/gemma4:e4b', new Set(['ollama/qwen3:32b']));
+    const groups = groupProviders(loaded, 'ollama/gemma4:e4b', [{ key: 'r1', id: 'ollama/qwen3:32b' }]);
     expect(groups[0]!.model).toBe('gemma4:e4b');
   });
 
@@ -236,7 +149,7 @@ describe('which model a block stands for', () => {
       provider({ id: 'claude-sub/claude-opus-5', auth: 'subscription' }),
       provider({ id: 'anthropic/claude-opus-5', auth: 'apikey', locality: 'cloud', keySet: true }),
     ];
-    const names = groupProviders(loaded, '', new Set()).map(g => g.name);
+    const names = groupProviders(loaded, '').map(g => g.name);
     expect(new Set(names).size).toBe(2);
   });
 });
@@ -247,7 +160,7 @@ describe('a provider you have added but not saved', () => {
     // model picker and no key — and neither could be supplied in either
     // order: the row will not save without a model, and the vendor will not
     // list models without a key.
-    const groups = groupProviders([], '', new Set(), ['openai/']);
+    const groups = groupProviders([], '', [{ key: 'r1', id: 'openai/' }]);
     expect(groups).toHaveLength(1);
     expect(groups[0]!.prefix).toBe('openai');
     expect(groups[0]!.pending).toBe(true);
@@ -259,27 +172,31 @@ describe('a provider you have added but not saved', () => {
 
   test('a provider already loaded does not get a second block', () => {
     const loaded = [provider({ id: 'openai/gpt-5.6', auth: 'apikey', locality: 'cloud', keySet: true })];
-    const groups = groupProviders(loaded, '', new Set(['openai/gpt-5.6']), ['openai/']);
+    const groups = groupProviders(loaded, '', [{ key: 'r1', id: 'openai/gpt-5.6' }]);
     expect(groups).toHaveLength(1);
     expect(groups[0]!.model).toBe('gpt-5.6');
     expect(groups[0]!.pending).toBeUndefined();
   });
 
   test('a local provider says where it runs even before it is saved', () => {
-    expect(groupProviders([], '', new Set(), ['ollama/'])[0]!.reach.how).toBe('on this machine');
-    expect(groupProviders([], '', new Set(), ['openai/'])[0]!.reach.how).toBe('not set up yet');
+    expect(groupProviders([], '', [{ key: 'r1', id: 'ollama/' }])[0]!.reach.how).toBe('on this machine');
+    expect(groupProviders([], '', [{ key: 'r1', id: 'openai/' }])[0]!.reach.how).toBe('not set up yet');
   });
 
   test('a row with no id yet is still a block — that is where its Id field lives', () => {
     // Added and then invisible was the alternative: the row's only usable
     // control renders inside its block.
-    const [blank] = groupProviders([], '', new Set(), ['']);
+    const [blank] = groupProviders([], '', [{ key: 'r1', id: '' }]);
     expect(blank!.name).toBe('A model');
     expect(blank!.pending).toBe(true);
     expect(blank!.reach.blocked).toBe('give it an id below');
   });
 
-  test('the same pending vendor twice is still one block', () => {
-    expect(groupProviders([], '', new Set(), ['openai/', 'openai/'])).toHaveLength(1);
+  test('two rows of one vendor are two blocks — neither is hidden', () => {
+    const groups = groupProviders([], '', [
+      { key: 'r1', id: 'openai/' },
+      { key: 'r2', id: 'openai/' },
+    ]);
+    expect(groups.map(g => g.rowKey)).toEqual(['r1', 'r2']);
   });
 });

--- a/runtime/ui/src/v2/settings/YourModels.test.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.test.tsx
@@ -270,8 +270,13 @@ describe('a provider you have added but not saved', () => {
     expect(groupProviders([], '', new Set(), ['openai/'])[0]!.reach.how).toBe('not set up yet');
   });
 
-  test('an id that is only a slash is not a provider', () => {
-    expect(groupProviders([], '', new Set(), ['/x'])).toEqual([]);
+  test('a row with no id yet is still a block — that is where its Id field lives', () => {
+    // Added and then invisible was the alternative: the row's only usable
+    // control renders inside its block.
+    const [blank] = groupProviders([], '', new Set(), ['']);
+    expect(blank!.name).toBe('A model');
+    expect(blank!.pending).toBe(true);
+    expect(blank!.reach.blocked).toBe('give it an id below');
   });
 
   test('the same pending vendor twice is still one block', () => {

--- a/runtime/ui/src/v2/settings/YourModels.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.tsx
@@ -26,21 +26,9 @@ export interface YourModelsProps {
    * the practice saved. */
   builtinDefault: boolean;
   busy: boolean;
-  /** A saved row's base URL for this vendor, so a local runner's model list
-   * is asked for at the right address. */
-  baseURLOf(prefix: string): string | undefined;
-  /** An enterprise row's non-secret fields (a Bedrock region, an Azure
-   * resource). They name WHERE to ask, so without them that vendor's
-   * listing can only answer with an error. */
-  extraOf?(prefix: string): Record<string, string> | undefined;
-  /** The ids this practice's own file names, so a saved row is shown over a
-   * built-in of the same vendor. */
-  fileIds: ReadonlySet<string>;
-  /** Rows added but not saved yet. A provider you just picked gets its
-   * block AT ONCE — its key and its model are chosen on the block, and
-   * before this it had neither: the row could not be saved without a model,
-   * and the vendor would not list models without a key. */
-  pendingIds: readonly string[];
+  /** The practice's own rows, in file order. Each gets a block; a loaded
+   * provider no row accounts for gets one too. */
+  rows: readonly ProviderEntry[];
   /** The key control for a provider, supplied by the page (this component
    * knows nothing about the settings view). */
   renderKey?(group: ProviderGroup): JSX.Element | null;
@@ -122,8 +110,14 @@ export function reachOf(p: ProviderInfo): Reach {
   }
 }
 
-/** One provider, and every model of it the runtime has loaded. */
+/** One provider entry: a row of the practice's file, or a loaded built-in. */
 export interface ProviderGroup {
+  /** Stable across every edit to the row — what React keys the block on,
+   * and what the page looks the row up by. */
+  key: string;
+  /** The form row this block edits. Absent for a built-in, which the
+   * practice's file does not name. */
+  rowKey?: string;
   prefix: string;
   name: string;
   reach: Reach;
@@ -138,50 +132,70 @@ export interface ProviderGroup {
 }
 
 /**
- * The loaded ids, folded into one block per provider.
+ * One block per PROVIDER ENTRY: every row of the practice's own file, plus
+ * every loaded provider no row accounts for (the built-ins).
  *
- * A vendor can hold more than one loaded model — the built-in Ollama plus
- * the Ollama row you saved. The block shows the one in play, in this order:
+ * It used to fold by vendor prefix, and three things went wrong at once,
+ * all of them the same mistake — addressing a row by something that is not
+ * its identity:
  *
- *   1. the model that answers, if it is this vendor's;
- *   2. the model YOUR FILE names, over a built-in;
- *   3. whatever loaded first.
+ * - Two rows of one vendor collapsed into one block. The second became
+ *   invisible: no fields, no Remove, and its validation errors had nowhere
+ *   to render, so Save refused with nothing marked.
+ * - The block showed one row's model over another row's fields, because
+ *   the block picked its identity by rank and its details by "first row
+ *   with this prefix". Remove then deleted the provider you were not
+ *   looking at.
+ * - The block was KEYED on the prefix, which changes with every keystroke
+ *   in an Id field — so typing remounted the block and dropped focus after
+ *   each character.
  *
- * Rule 2 is not a nicety. `loadRegistry` puts the built-ins ahead of the
- * file, so without it, picking `qwen3:32b` on the Ollama block saved
- * correctly and then re-rendered as `gemma4:e4b` — the built-in, still
- * first, still not the default. The pick looked like it had been refused.
- * The others stay loaded and stay nameable by a task route; they are just
- * not a second block to read past.
+ * A row's `key` is stable for its lifetime. That is the identity.
  */
-export function groupProviders(
-  providers: ProviderInfo[],
-  defaultId: string,
-  fileIds: ReadonlySet<string> = new Set(),
-  pendingIds: readonly string[] = [],
-): ProviderGroup[] {
-  const groups = new Map<string, { group: ProviderGroup; rank: number }>();
-  for (const p of providers) {
-    const prefix = prefixOf(p.id);
-    const { vendor, model } = nameOf(p.id);
-    const rank = p.id === defaultId.trim() ? 0 : fileIds.has(p.id) ? 1 : 2;
-    const existing = groups.get(prefix);
-    if (existing !== undefined && existing.rank <= rank) continue;
-    groups.set(prefix, { rank, group: { prefix, name: vendor, reach: reachOf(p), model, id: p.id } });
-  }
-  // A provider added but not saved has no loaded model to speak for it. It
-  // still gets a block: the block is where its key and its model are set,
-  // and both have to happen before there is anything to save.
-  for (const id of pendingIds) {
-    const prefix = prefixOf(id);
-    if (groups.has(prefix)) continue;
+export interface ProviderEntry {
+  /** Stable for the row's life, across every edit to its id. */
+  key: string;
+  id: string;
+  baseURL?: string;
+  extra?: Record<string, string>;
+}
+
+export function groupProviders(providers: ProviderInfo[], defaultId: string, rows: readonly ProviderEntry[] = []): ProviderGroup[] {
+  const groups: ProviderGroup[] = [];
+  const claimed = new Set<string>();
+  for (const row of rows) {
+    const id = row.id.trim();
+    const live = providers.find(p => p.id === id);
+    if (live !== undefined) claimed.add(live.id);
     const { vendor, model } = nameOf(id);
-    // A row with no id at all still needs a block: it is where its own Id
-    // field lives, and without one the row was added and then invisible.
-    const name = prefix === '' ? 'A model' : vendor;
-    groups.set(prefix, { rank: 3, group: { prefix, name, reach: pendingReach(prefix), model, id, pending: true } });
+    groups.push({
+      key: `row:${row.key}`,
+      rowKey: row.key,
+      prefix: prefixOf(id),
+      // A row with no id yet is still a block: it is where its own Id field
+      // lives, and without one the row was added and then invisible.
+      name: id === '' ? 'A model' : vendor,
+      reach: live === undefined ? pendingReach(prefixOf(id)) : reachOf(live),
+      model,
+      id,
+      ...(live === undefined ? { pending: true } : {}),
+    });
   }
-  return [...groups.values()].map(entry => entry.group);
+  // The built-ins, and anything `serve --fake` added: loaded, real, and
+  // not the practice's to edit.
+  for (const p of providers) {
+    if (claimed.has(p.id)) continue;
+    const { vendor, model } = nameOf(p.id);
+    groups.push({ key: `id:${p.id}`, prefix: prefixOf(p.id), name: vendor, reach: reachOf(p), model, id: p.id });
+  }
+  // The one that answers leads; a row you saved before a built-in.
+  return groups.sort((a, b) => rank(a, defaultId) - rank(b, defaultId));
+}
+
+function rank(g: ProviderGroup, defaultId: string): number {
+  if (g.id !== '' && g.id === defaultId.trim()) return 0;
+  if (g.rowKey !== undefined) return 1;
+  return 2;
 }
 
 /** What an unsaved provider still needs, from the catalog alone. */
@@ -192,8 +206,9 @@ function pendingReach(prefix: string): Reach {
   return { how, usable: false, blocked: 'pick a model to finish' };
 }
 
-export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, extraOf, fileIds, pendingIds, renderKey, renderDetails, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
-  const groups = groupProviders(providers, defaultId, fileIds, pendingIds);
+export function YourModels({ providers, defaultId, builtinDefault, busy, rows, renderKey, renderDetails, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
+  const groups = groupProviders(providers, defaultId, rows);
+  const rowOf = (group: ProviderGroup): ProviderEntry | undefined => rows.find(r => r.key === group.rowKey);
   if (groups.length === 0) {
     return <p className="muted">No provider is set up. Add one below.</p>;
   }
@@ -201,13 +216,13 @@ export function YourModels({ providers, defaultId, builtinDefault, busy, baseURL
     <ul className="v2-yours" aria-label="Providers you can use">
       {groups.map(group => (
         <ProviderBlock
-          key={group.prefix}
+          key={group.key}
           group={group}
           isDefault={group.id === defaultId.trim()}
           builtinDefault={builtinDefault}
           busy={busy}
-          baseURL={baseURLOf(group.prefix)}
-          extra={extraOf?.(group.prefix)}
+          baseURL={rowOf(group)?.baseURL}
+          extra={rowOf(group)?.extra}
           {...(renderKey === undefined ? {} : { renderKey })}
           {...(renderDetails === undefined ? {} : { renderDetails })}
           relistN={relist != null && relist.prefix === group.prefix ? relist.n : 0}
@@ -318,8 +333,8 @@ function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, extra,
         }}
       >
         <ModelCombo
-          id={`v2-model-${group.prefix}`}
-          label={`${group.name} model`}
+          id={`v2-model-${group.key.replace(/[^A-Za-z0-9_-]/g, '-')}`}
+          label={group.name === 'A model' ? 'Model' : `${group.name} model`}
           value={text}
           models={models}
           placeholder={loading ? 'listing…' : 'pick or type a model'}

--- a/runtime/ui/src/v2/settings/YourModels.tsx
+++ b/runtime/ui/src/v2/settings/YourModels.tsx
@@ -44,6 +44,10 @@ export interface YourModelsProps {
   /** The key control for a provider, supplied by the page (this component
    * knows nothing about the settings view). */
   renderKey?(group: ProviderGroup): JSX.Element | null;
+  /** This provider's own settings — its id, address, and what it can do —
+   * rendered inside its block rather than as a second list of every
+   * provider further down the page. */
+  renderDetails?(group: ProviderGroup): JSX.Element | null;
   /** A provider whose key just changed, and a counter so the same provider
    * twice still counts. Its model list is re-asked: the key is usually the
    * whole reason the vendor would not answer. */
@@ -170,21 +174,25 @@ export function groupProviders(
   // and both have to happen before there is anything to save.
   for (const id of pendingIds) {
     const prefix = prefixOf(id);
-    if (prefix === '' || groups.has(prefix)) continue;
+    if (groups.has(prefix)) continue;
     const { vendor, model } = nameOf(id);
-    groups.set(prefix, { rank: 3, group: { prefix, name: vendor, reach: pendingReach(prefix), model, id, pending: true } });
+    // A row with no id at all still needs a block: it is where its own Id
+    // field lives, and without one the row was added and then invisible.
+    const name = prefix === '' ? 'A model' : vendor;
+    groups.set(prefix, { rank: 3, group: { prefix, name, reach: pendingReach(prefix), model, id, pending: true } });
   }
   return [...groups.values()].map(entry => entry.group);
 }
 
 /** What an unsaved provider still needs, from the catalog alone. */
 function pendingReach(prefix: string): Reach {
+  if (prefix === '') return { how: 'not set up yet', usable: false, blocked: 'give it an id below' };
   const connection = vendorFor(prefix)?.connection;
   const how = connection === 'local' ? 'on this machine' : connection === 'subscription' ? 'your subscription' : 'not set up yet';
   return { how, usable: false, blocked: 'pick a model to finish' };
 }
 
-export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, extraOf, fileIds, pendingIds, renderKey, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
+export function YourModels({ providers, defaultId, builtinDefault, busy, baseURLOf, extraOf, fileIds, pendingIds, renderKey, renderDetails, relist, onMakeDefault, onPickModel }: YourModelsProps): JSX.Element {
   const groups = groupProviders(providers, defaultId, fileIds, pendingIds);
   if (groups.length === 0) {
     return <p className="muted">No provider is set up. Add one below.</p>;
@@ -201,6 +209,7 @@ export function YourModels({ providers, defaultId, builtinDefault, busy, baseURL
           baseURL={baseURLOf(group.prefix)}
           extra={extraOf?.(group.prefix)}
           {...(renderKey === undefined ? {} : { renderKey })}
+          {...(renderDetails === undefined ? {} : { renderDetails })}
           relistN={relist != null && relist.prefix === group.prefix ? relist.n : 0}
           onMakeDefault={onMakeDefault}
           onPickModel={onPickModel}
@@ -218,12 +227,13 @@ interface ProviderBlockProps {
   baseURL: string | undefined;
   extra: Record<string, string> | undefined;
   renderKey?(group: ProviderGroup): JSX.Element | null;
+  renderDetails?(group: ProviderGroup): JSX.Element | null;
   relistN: number;
   onMakeDefault(id: string): void;
   onPickModel(id: string, model: string): Promise<boolean>;
 }
 
-function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, extra, renderKey, relistN, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
+function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, extra, renderKey, renderDetails, relistN, onMakeDefault, onPickModel }: ProviderBlockProps): JSX.Element {
   // A prefix the catalog does not know (`serve --fake`, a hand-edited id)
   // has nowhere to ask, so do not ask.
   const known = vendorFor(group.prefix) !== undefined;
@@ -333,6 +343,7 @@ function ProviderBlock({ group, isDefault, builtinDefault, busy, baseURL, extra,
           block — and it has to come before the model, because most vendors
           will not list their models without it. */}
       {renderKey?.(group) ?? null}
+      {renderDetails?.(group) ?? null}
     </li>
   );
 }


### PR DESCRIPTION
> i think you're wrong that available models are not listed. look online to find them. also under add a provider, it's unclear what to do. please make the interface much more simple and coherent and consistent overall.

**Right on the first count.** OpenAI documents what the Codex CLI answers to — `gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`, `gpt-5.5` ([learn.chatgpt.com/docs/models](https://learn.chatgpt.com/docs/models)). Our catalog said *"ChatGPT does not publish a model list"*, which was us never having looked. Both subscriptions now carry their real ids, Claude's including Fable.

`VendorModel.contextTokens` becomes optional: the docs give no window, and the router compares that number against a task's context bar, so it is not something to guess at. And a new invariant test — **every vendor can say what models it has** — because a provider you cannot choose a model for is a provider you cannot finish setting up.

### Adding a provider is a click

It was a search box with a placeholder and a greyed-out **Add**: you had to know to type something, know a list would appear, pick from it, then press Add. Four unsignposted steps to do the page's main job.

Now the providers a practice starts with are named, each with a line saying what it is, and you click one. The full catalog is behind *Someone else*, with the blank-row escape hatch beside it.

```
ADD A PROVIDER
  [ Claude (API key) ]   [ OpenAI ]        [ Google Gemini ]
    Anthropic, with        OpenAI, with      Google, with
    an API key             an API key        an API key

  Someone else — thirty more vendors, a model server on this
  machine, or any endpoint that speaks the OpenAI API.
```

Providers you already have drop out of the list, so every choice on it is actionable.

### A provider appears once

Every provider used to be written twice — a block at the top you could use, and a row further down you had to understand. That duplication was most of what made the page incoherent. The row's id, base URL, capability flags and auth now fold away inside that provider's own block, and the second list is gone.

A row with no id yet gets a block too — that is where its Id field lives. Without one it was added and then invisible.

### Checks

632 UI tests, 1294 runtime tests, both typechecks clean. Read live against the real vault: Claude and ChatGPT both report **4 models known**, Ollama **3 models listed** from the local daemon.