### PR TITLE
Say what is running, and --watch so it stays current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ A simpler Settings page, and the model lists we never asked for
 - **Adding a provider is clicking the one you want.** It was a search box with a placeholder and a greyed-out button — you had to know to type something, that a list would appear, to pick from it, and then to press Add. Four unsignposted steps to do the thing the page most wants you to do. The common providers are now named and clicked; the whole catalog is still there, behind *Someone else*.
 - **A provider appears once.** Every provider used to be written twice — a block at the top you could use, and a row further down you had to understand. Its id, address and capability flags now fold away inside its own block, and the second list is gone. One block per provider **entry**: two rows of the same vendor are two blocks, each editable and removable, rather than one silently hiding the other.
 
+Knowing what you are actually running
+
+- **Settings › Runtime now says what the server process is running**: the version, the commit it read, and how long it has been up. A serve reads its code once, at startup, and then keeps answering from it while the checkout moves on — but it serves the UI from disk, which a rebuild replaces underneath. So the page in front of you can be hours newer than the runtime behind it, and nothing said so. A process up for more than an hour says plainly that a restart would pick up changes made since. A compiled binary never says it, because it cannot drift.
+- **`serve --watch`** restarts the runtime when its own source changes, so the mismatch cannot open up in the first place. It needs a source checkout; a binary is told why it cannot.
+
 Adding a provider actually works now
 
 - A provider you add gets its **block straight away**, with its key and its model picker on it. Before this it appeared only as a stub down in "Rows you added", and the two things it needed were impossible to do in either order: the row would not save without a model, and the vendor would not list its models without a key.

--- a/runtime/src/cli.ts
+++ b/runtime/src/cli.ts
@@ -58,6 +58,7 @@ const { values, positionals } = parseArgs({
     'fake-script': { type: 'string' }, // `serve`: a JSON array of FakeScript steps for --fake
     open: { type: 'boolean' },        // `serve`: open the printed token URL in the browser
     'new-token': { type: 'boolean' }, // `serve`: mint a fresh bearer (signs every browser out)
+    watch: { type: 'boolean' },       // `serve`: restart when the runtime's own source changes
     dist: { type: 'string' },         // `serve`: the built UI to serve (default runtime/ui/dist)
     // `init` — the first-run answers as flags (spec 2026-09-01 §4); a
     // missing one is asked on stdin unless `--yes`.
@@ -103,7 +104,7 @@ const SELF = isCompiled() ? 'counsel-os' : 'bun runtime/src/cli.ts';
 
 function usage(): never {
   console.error('usage: bun runtime/src/cli.ts step --vault <dir> --provider <id> [--task <name>] [--schema <json>] [--session <id>] [--codex-home <dir>] [--cwd <dir>] [--step-timeout <ms>] "<prompt>"');
-  console.error('       bun runtime/src/cli.ts serve [--port <n>] [--vault <dir>] [--step-timeout <ms>] [--dist <dir>] [--open] [--new-token] [--fake [--fake-script <file.json>]]');
+  console.error('       bun runtime/src/cli.ts serve [--port <n>] [--vault <dir>] [--step-timeout <ms>] [--dist <dir>] [--open] [--new-token] [--watch] [--fake [--fake-script <file.json>]]');
   console.error('         --dist <dir> is the built UI; everything in it is served WITHOUT a token, so it must not overlap the vault');
   console.error('       bun runtime/src/cli.ts init [--vault <dir>] [--name <n> --org <o> --role in-house|outside|solo --jurisdiction <j> --practice "<one line>"] [--default-provider <id>] [--no-git] [--yes]');
   console.error('         creates a Counsel OS vault (default ~/Documents/Counsel OS) and seeds it; asks for anything missing unless --yes');
@@ -268,6 +269,34 @@ function fakeScript(file: string | undefined): FakeScript[] {
 // keeps the process alive, and the signal handlers startServer installs are
 // what remove ~/.counsel-os/runtime.json on the way out.
 if (cmd === 'serve') {
+  /**
+   * `--watch`: restart when the runtime's own source changes.
+   *
+   * A serve reads its code ONCE, at startup, and then keeps answering from
+   * it — while serving the UI from disk, which a rebuild updates underneath.
+   * A server left up overnight therefore hands you a new page driven by an
+   * old runtime, with nothing on screen to say so. (There is something on
+   * screen now: Settings › Runtime reports what the process is running and
+   * how long it has been running it.)
+   *
+   * Bun already has a watcher, and it is a flag to `bun` rather than
+   * anything a running script can switch on for itself — so re-exec once,
+   * under it, and let it own the restarts.
+   */
+  if (values.watch) {
+    if (isCompiled()) {
+      console.error('--watch needs a source checkout: a compiled binary runs what it was built with and cannot reload.');
+      process.exit(2);
+    }
+    // `Bun.argv` is [bun, entry, ...args]; keep the entry and drop the flag
+    // so the child does not re-exec forever.
+    const passthrough = Bun.argv.slice(1).filter(a => a !== '--watch');
+    const child = Bun.spawn(['bun', '--watch', ...passthrough], { stdio: ['inherit', 'inherit', 'inherit'] });
+    // Ctrl-C reaches the child through the terminal's process group; this
+    // waits on it so the parent does not exit out from under it.
+    process.exit(await child.exited);
+  }
+
   // A script with no `--fake` is a mistake worth naming: the file would be
   // read, ignored, and the real providers used.
   if (values['fake-script'] !== undefined && !values.fake) {

--- a/runtime/src/core/build-info.test.ts
+++ b/runtime/src/core/build-info.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from 'bun:test';
+import { buildInfo, resetBuildInfoForTests } from './build-info';
+
+describe('what the process is running', () => {
+  test('reports the release, and the commit it read from the checkout', () => {
+    resetBuildInfoForTests();
+    const info = buildInfo();
+    expect(info.version).toMatch(/^\d+\.\d+\.\d+$/);
+    // Tests run from a checkout, so both of these hold. A worktree keeps
+    // its own HEAD and shares its refs, which is the case that used to come
+    // back empty.
+    expect(info.source).toBe('source');
+    expect(info.commit).toMatch(/^[0-9a-f]{7}$/);
+  });
+
+  test('the start time is frozen at load, not read per call', () => {
+    // It answers "how old is this process", so it must not creep forward.
+    resetBuildInfoForTests();
+    const first = buildInfo().startedAt;
+    expect(new Date(first).getTime()).toBeLessThanOrEqual(Date.now());
+    resetBuildInfoForTests();
+    expect(buildInfo().startedAt).toBe(first);
+  });
+
+  test('the version matches the file the release script bumps', async () => {
+    // Four manifests are kept in step by `scripts/release.sh`; this is the
+    // one a running server reports, so it has to be that same number.
+    const onDisk = (await Bun.file(`${import.meta.dir}/../../../VERSION`).text()).trim();
+    resetBuildInfoForTests();
+    expect(buildInfo().version).toBe(onDisk);
+  });
+});

--- a/runtime/src/core/build-info.ts
+++ b/runtime/src/core/build-info.ts
@@ -1,0 +1,115 @@
+/**
+ * What this PROCESS is running — not what is on disk.
+ *
+ * The distinction is the whole point. `serve` loads its code once, at
+ * startup, so a server left running while the source moves under it goes on
+ * answering with the catalog it was born with. That is exactly what
+ * happened: a serve from the previous afternoon reported "ChatGPT does not
+ * publish a model list" hours after that had been fixed, while handing the
+ * browser a freshly built UI — new page, old runtime, and nothing on screen
+ * to say so.
+ *
+ * A version number alone would not have caught it: both were 0.14.0. So
+ * this reports when the process STARTED and, from a source checkout, the
+ * commit it read — the two facts that actually differ.
+ */
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { isCompiled } from './embedded';
+
+export interface BuildInfo {
+  /** The release this build belongs to. */
+  version: string;
+  /** ISO 8601. How old the running process is, which is how stale its code
+   * may be. */
+  startedAt: string;
+  /** `binary` runs what it was compiled with and cannot drift; `source`
+   * reads the checkout at startup and can. */
+  source: 'binary' | 'source';
+  /** The commit this process READ, from a source checkout. Absent for a
+   * binary, and absent when the checkout is not a git repository. */
+  commit?: string;
+}
+
+/**
+ * The real git directory. In a WORKTREE, `.git` is a file holding
+ * `gitdir: <path>` — the common case while this is being developed, and the
+ * one where a stale process is most likely.
+ */
+function resolveGitDir(root: string): string | null {
+  const dotGit = join(root, '.git');
+  if (!existsSync(dotGit)) return null;
+  if (statSync(dotGit).isDirectory()) return dotGit;
+  const pointer = readFileSync(dotGit, 'utf8').trim();
+  if (!pointer.startsWith('gitdir:')) return null;
+  const target = pointer.slice('gitdir:'.length).trim();
+  return isAbsolute(target) ? target : join(root, target);
+}
+
+/** Frozen at module load, which is the moment the code was read. */
+const STARTED_AT = new Date().toISOString();
+
+/** The repo root, for a checkout. `import.meta.dir` is `runtime/src/core`. */
+function repoRoot(): string {
+  return join(import.meta.dir, '..', '..', '..');
+}
+
+function readVersion(): string {
+  // Bundled into the binary by the compile step; read from the checkout
+  // otherwise. `release.sh` keeps this in step with the other manifests.
+  try {
+    const file = join(repoRoot(), 'VERSION');
+    if (existsSync(file)) return readFileSync(file, 'utf8').trim();
+  } catch {
+    // A version we cannot read is not a reason to fail to start.
+  }
+  return 'unknown';
+}
+
+function readCommit(): string | undefined {
+  // Read from `.git` rather than shelling out: `git rev-parse` would report
+  // the checkout's head NOW, which is the thing this is meant to detect
+  // drifting away from.
+  try {
+    const gitDir = resolveGitDir(repoRoot());
+    if (gitDir === null) return undefined;
+    const head = readFileSync(join(gitDir, 'HEAD'), 'utf8').trim();
+    const ref = head.startsWith('ref: ') ? head.slice(5).trim() : null;
+    // Detached: HEAD is the commit itself.
+    if (ref === null) return head.slice(0, 7);
+    // A worktree keeps its own HEAD but shares the refs. Try its own
+    // directory, then the shared one, then the packed file — which is where
+    // the loose ref goes once `git gc` has run.
+    const commonFile = join(gitDir, 'commondir');
+    const common = existsSync(commonFile) ? join(gitDir, readFileSync(commonFile, 'utf8').trim()) : gitDir;
+    for (const dir of [gitDir, common]) {
+      const refFile = join(dir, ref);
+      if (existsSync(refFile)) return readFileSync(refFile, 'utf8').trim().slice(0, 7);
+    }
+    const packed = readFileSync(join(common, 'packed-refs'), 'utf8');
+    const line = packed.split('\n').find(l => l.endsWith(` ${ref}`));
+    return line?.slice(0, 7);
+  } catch {
+    return undefined;
+  }
+}
+
+let cached: BuildInfo | null = null;
+
+export function buildInfo(): BuildInfo {
+  if (cached !== null) return cached;
+  const compiled = isCompiled();
+  const commit = compiled ? undefined : readCommit();
+  cached = {
+    version: readVersion(),
+    startedAt: STARTED_AT,
+    source: compiled ? 'binary' : 'source',
+    ...(commit === undefined ? {} : { commit }),
+  };
+  return cached;
+}
+
+/** Tests pin the values; a real process reads them once. */
+export function resetBuildInfoForTests(): void {
+  cached = null;
+}

--- a/runtime/src/server/routes.test.ts
+++ b/runtime/src/server/routes.test.ts
@@ -166,6 +166,21 @@ describe('GET /health', () => {
     expect(body.providers[0]!.auth).toBe('local');
     expect(body.providers[0]!.capabilities.tools).toBe(true);
   });
+
+  test('says what the running process is, so a stale one can be spotted', async () => {
+    // A serve reads its code once and then keeps answering from it while
+    // the checkout moves on — and serves the UI from disk, which a rebuild
+    // updates underneath. The page needs a way to tell.
+    const res = await call(appWithFake(), 'GET', '/health');
+    const body = (await res.json()) as { runtime?: { version: string; startedAt: string; source: string; commit?: string } };
+    expect(body.runtime).toBeDefined();
+    expect(body.runtime!.version).toMatch(/^\d+\.\d+\.\d+$/);
+    expect(body.runtime!.source).toBe('source');
+    expect(new Date(body.runtime!.startedAt).getTime()).toBeLessThanOrEqual(Date.now());
+    // Never the value of anything secret, and never the checkout's CURRENT
+    // head — the commit this process READ.
+    expect(body.runtime!.commit).toMatch(/^[0-9a-f]{7}$/);
+  });
 });
 
 describe('threads', () => {

--- a/runtime/src/server/routes.ts
+++ b/runtime/src/server/routes.ts
@@ -12,6 +12,7 @@ import { BASE_URL_RULE, isAllowedBaseURL, readRegistry, RegistryFile } from '../
 import { DiscoveryCache, discoverModels } from '../providers/discovery';
 import { prefixOf, vendorFor } from '../providers/vendors';
 import { readKey } from '../providers/secrets';
+import { buildInfo } from '../core/build-info';
 import { isEnterprise, resolveEnterprise } from '../providers/enterprise';
 import type { ThreadEvent, ThreadHeader } from '../threads/store';
 import { vaultDocket } from '../vault/docket';
@@ -503,6 +504,11 @@ export function createApp(deps: ServerDeps): App {
       // Whether this vault keeps the local record of decisions and marks
       // (routing-and-evals spec §7).
       outcomes: readVaultConfig(deps.vaultRoot).outcomes !== false,
+      // What this PROCESS is running. `serve` reads its code once, at
+      // startup, so a server left up while the checkout moves goes on
+      // answering with the catalog it was born with — and hands the browser
+      // a freshly built UI at the same time. The page says so now.
+      runtime: buildInfo(),
     });
   };
 

--- a/runtime/ui/src/api/types.ts
+++ b/runtime/ui/src/api/types.ts
@@ -209,6 +209,18 @@ export interface Health {
   /** Whether the vault keeps its local record of decisions and marks
    * (routing-and-evals spec §7). Absent on an older runtime. */
   outcomes?: boolean;
+  /** What the running process is, as opposed to what is on disk. Absent on
+   * an older runtime — which is itself the case this exists to reveal. */
+  runtime?: RuntimeBuild;
+}
+
+export interface RuntimeBuild {
+  version: string;
+  /** ISO 8601, frozen when the process read its code. */
+  startedAt: string;
+  source: 'binary' | 'source';
+  /** The commit the process read, from a source checkout. */
+  commit?: string;
 }
 
 /** The body of `POST /threads/:id/steps`. */

--- a/runtime/ui/src/settings/Health.test.tsx
+++ b/runtime/ui/src/settings/Health.test.tsx
@@ -66,3 +66,52 @@ describe('the Decisions and marks switch (routing-and-evals spec §7)', () => {
     expect(screen.getByText(/kept locally · on/)).toBeTruthy();
   });
 });
+
+describe('what the running process is', () => {
+  const withBuild = (over: Partial<NonNullable<HealthData['runtime']>>): HealthData => ({
+    ...health,
+    runtime: { version: '0.14.0', startedAt: new Date().toISOString(), source: 'source', ...over },
+  });
+
+  test('names the version and the commit the process read', () => {
+    install(() => json({ outcomes: true }));
+    render(<Health health={withBuild({ commit: 'abc1234' })} effective={effective} file="/f.yaml" />);
+    const running = screen.getByText('Running').closest('.fact')!;
+    expect(running.textContent).toContain('0.14.0');
+    expect(running.textContent).toContain('abc1234');
+    expect(running.textContent).toMatch(/started .* ago|started just now/);
+  });
+
+  test('a process older than an hour says to restart it', () => {
+    // The actual failure: a serve left up overnight kept answering from the
+    // catalog it was born with, while handing the browser a UI rebuilt that
+    // morning. Nothing on screen said so.
+    install(() => json({ outcomes: true }));
+    const yesterday = new Date(Date.now() - 19 * 3_600_000).toISOString();
+    render(<Health health={withBuild({ startedAt: yesterday })} effective={effective} file="/f.yaml" />);
+    const running = screen.getByText('Running').closest('.fact')!;
+    expect(running.textContent).toContain('19 hours ago');
+    expect(running.textContent).toContain('restart to pick up changes made since');
+  });
+
+  test('a fresh process does not nag', () => {
+    install(() => json({ outcomes: true }));
+    render(<Health health={withBuild({})} effective={effective} file="/f.yaml" />);
+    expect(screen.getByText('Running').closest('.fact')!.textContent).not.toContain('restart to pick up');
+  });
+
+  test('a compiled binary is never called stale — it cannot drift', () => {
+    install(() => json({ outcomes: true }));
+    const old = new Date(Date.now() - 40 * 3_600_000).toISOString();
+    render(<Health health={withBuild({ source: 'binary', startedAt: old })} effective={effective} file="/f.yaml" />);
+    const running = screen.getByText('Running').closest('.fact')!;
+    expect(running.textContent).toContain('2 days ago');
+    expect(running.textContent).not.toContain('restart to pick up');
+  });
+
+  test('a runtime too old to say so says that', () => {
+    install(() => json({ outcomes: true }));
+    render(<Health health={health} effective={effective} file="/f.yaml" />);
+    expect(screen.getByText(/an older runtime — restart it to see which/)).toBeTruthy();
+  });
+});

--- a/runtime/ui/src/settings/Health.tsx
+++ b/runtime/ui/src/settings/Health.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { ApiError, setVaultOutcomes, signOut } from '../api/client';
 import { dataLineOf } from '../v2/vendors';
-import type { Health as HealthData, SettingsView } from '../api/types';
+import type { Health as HealthData, RuntimeBuild, SettingsView } from '../api/types';
 
 export interface HealthProps {
   /** `GET /health` — where the vault and the tenant come from. `null` while
@@ -70,6 +70,13 @@ export function Health({ health, effective, file, secrets }: HealthProps): JSX.E
       <h2>Runtime</h2>
       <p className="muted">What is actually running right now — the file above plus the built-ins. Read-only; when a setting does not seem to take, compare it against this.</p>
       <dl className="facts">
+        <div className="fact">
+          <dt>
+            Running
+            <span className="leader" aria-hidden="true" />
+          </dt>
+          <dd>{health === null ? '…' : <RunningBuild build={health.runtime} />}</dd>
+        </div>
         <div className="fact">
           <dt>
             Vault
@@ -181,4 +188,45 @@ export function Health({ health, effective, file, secrets }: HealthProps): JSX.E
       )}
     </section>
   );
+}
+
+/**
+ * What the server process is running, and how long it has been running it.
+ *
+ * The age is the point. `serve` reads its code once, at startup, and then
+ * keeps answering from it while the checkout moves on — but it serves the
+ * UI from disk, so the page in front of you can be hours newer than the
+ * runtime behind it. That mismatch cost a morning: the page said "ChatGPT
+ * does not publish a model list" long after it did.
+ */
+function RunningBuild({ build }: { build: RuntimeBuild | undefined }): JSX.Element {
+  // Absent is itself the answer: a runtime too old to say.
+  if (build === undefined) return <span className="muted">an older runtime — restart it to see which</span>;
+  const started = new Date(build.startedAt);
+  const hours = (Date.now() - started.getTime()) / 3_600_000;
+  return (
+    <>
+      <code>{build.version}</code>
+      {build.commit === undefined ? null : (
+        <>
+          {' · '}
+          <code>{build.commit}</code>
+        </>
+      )}
+      {' · '}
+      {ageOf(hours)}
+      {/* Only from a checkout: a binary runs what it was compiled with and
+          cannot drift from it. */}
+      {build.source === 'source' && hours >= 1 ? (
+        <span className="v2-stale"> · restart to pick up changes made since</span>
+      ) : null}
+    </>
+  );
+}
+
+function ageOf(hours: number): string {
+  if (hours < 1 / 60) return 'started just now';
+  if (hours < 1) return `started ${Math.round(hours * 60)} minutes ago`;
+  if (hours < 24) return `started ${Math.round(hours)} hour${Math.round(hours) === 1 ? '' : 's'} ago`;
+  return `started ${Math.round(hours / 24)} day${Math.round(hours / 24) === 1 ? '' : 's'} ago`;
 }

--- a/runtime/ui/src/styles.css
+++ b/runtime/ui/src/styles.css
@@ -1188,3 +1188,6 @@ button:focus-visible, a:focus-visible, input:focus-visible, textarea:focus-visib
 .v2-provider-advanced > summary { cursor: pointer; color: var(--fg-faint); font-size: 12.5px; margin: 4px 0 6px; }
 .v2-yours-row .v2-provider { margin: 0; }
 .v2-yours-row .v2-provider-head { display: none; }
+
+/* The runtime has been up long enough to have drifted from the code on disk. */
+.v2-stale { color: var(--warn); }


### PR DESCRIPTION
A serve started the previous afternoon reported *"ChatGPT does not publish a model list"* hours after that was fixed — while showing the new provider UI at the same time.

Two correct behaviours meeting badly: `serve` reads its code **once**, at startup, while the UI it hands the browser comes from `runtime/ui/dist` **on disk**, which every rebuild replaces. The page in front of you can be hours newer than the runtime behind it, and nothing on screen said so.

A version number alone would not have caught it — both processes were `0.14.0`. So this reports the two facts that actually differ.

### Settings › Runtime › Running

```
Running ....... 0.14.0 · 8a961c4 · started 19 hours ago
                · restart to pick up changes made since
```

The commit is the one the process **read**, not the checkout's head now — the head is the thing it drifts away from, so reporting it would defeat the purpose. Past an hour, from a source checkout, it says so plainly. A compiled binary never does: it runs what it was built with and cannot drift.

A runtime too old to report any of this says *"an older runtime — restart it to see which"*, which is itself the answer.

### `serve --watch`

Re-execs once under Bun's own watcher, which owns the restarts from there. `--watch` is a flag to `bun`, not something a running script can switch on for itself, hence the single re-exec. Refused with a sentence on a compiled binary.

### Notes

`build-info.ts` reads the commit out of `.git` rather than shelling to `git rev-parse`. It handles a **worktree**, where `.git` is a file, `HEAD` is local and the refs are shared — the case this gets developed in, and the one where a stale process is likeliest. That path returned nothing on the first attempt and is now covered by a test.

### Checks

637 UI tests, 1296 runtime tests, both typechecks clean. Verified live: `--watch` restarts on a real edit to `runtime/src/providers/vendors.ts` (new `startedAt`, two startup lines), and `/health` reports version, commit and start time from both a worktree and the main checkout.